### PR TITLE
feat: 跨端图片处理方案与压缩/转换页实现

### DIFF
--- a/.github/02-design/02-cross-image-process.md
+++ b/.github/02-design/02-cross-image-process.md
@@ -1,283 +1,279 @@
-# 跨端高性能图片处理方案设计
+# 跨端图片处理方案设计
 
 ## 目录
 
-- [一、方案概述](#一方案概述)
-- [二、专业术语](#二专业术语)
-- [三、架构设计](#三架构设计)
-- [四、功能模块](#四功能模块)
-- [五、统一接口与平台适配](#五统一接口与平台适配)
-- [六、技术栈与项目结构](#六技术栈与项目结构)
-- [七、应用场景与性能](#七应用场景与性能)
-- [八、注意事项与安全](#八注意事项与安全)
+- [一、方案定位与原则](#一方案定位与原则)
+- [二、common 的职责：只做数据格式与契约](#二common-的职责只做数据格式与契约)
+- [三、使用层的职责：提供符合契约的实现](#三使用层的职责提供符合契约的实现)
+- [四、架构设计](#四架构设计)
+- [五、契约定义（方法签名与数据类型）](#五契约定义方法签名与数据类型)
+- [六、当前实现情况](#六当前实现情况)
+- [七、迁移方案](#七迁移方案)
+- [八、技术栈与项目结构](#八技术栈与项目结构)
 - [九、附录](#九附录)
 
 ---
 
-## 一、方案概述
+## 一、方案定位与原则
 
 ### 1.1 目标
 
-本文档描述 Pixuli 跨端图片处理方案的设计，用于：
+本方案约定 Pixuli **三端（Web、Desktop、Mobile）**
+的图片处理在**数据格式与调用契约上统一**，但**具体处理逻辑由各端自行实现**：
 
-- **高性能**：Web/Desktop 使用 Rust +
-  WASM，Mobile 使用原生实现，在各端达到较优性能与体积。
-- **跨平台统一**：通过统一接口实现三端一致的 API，应用层无平台分支。
-- **可维护与可扩展**：统一接口、实现分离，便于增加新功能或新平台。
+- **packages/common**：**不包含**任何平台相关的图片处理逻辑（不调用 Canvas、WASM、expo 等）。只负责**数据格式的统一与维护**，以及**方法签名与返回值的契约定义**。
+- **使用层（各端应用）**：各自提供符合 common 契约的**图片处理工具函数/实现**（如压缩、格式转换），内部可使用 Canvas、WASM、expo-image-manipulator 等；调用方统一使用 common 定义的类型与契约，保证入参、出参一致。
 
 ### 1.2 设计原则
 
-- **平台择优**：Web/PC 用 WASM（压缩、转换、编辑等），Mobile 用原生（如 expo-image-manipulator），不在一端勉强复用另一端实现。
-- **统一接口**：通过 `ImageProcessorService`
-  抽象对外 API，内部按平台选择适配器。
-- **类型安全**：TypeScript 统一定义入参、出参与错误形态。
-- **内存与错误可控**：WASM 侧利用 Rust 内存安全；各端统一错误格式与降级策略。
-
-### 1.3 架构决策
-
-| 决策                      | 说明                                                                                       |
-| ------------------------- | ------------------------------------------------------------------------------------------ |
-| **统一接口 + 平台适配器** | 应用层只依赖 `ImageProcessorService`；Web/PC 使用 Wasm 适配器，Mobile 使用 Native 适配器。 |
-| **Web/PC 使用 WASM**      | Rust 编译为 WASM，供浏览器与 Electron（含主进程 Node）调用；高性能、格式与算法可控。       |
-| **Mobile 使用原生**       | 不引入 WASM，使用 expo-image-manipulator 等，减小体积、避免 WASM 加载与兼容成本。          |
-
-**优势**：性能与体积在各端均较优；接口统一、实现分离，维护与扩展成本可控。
+- **common 不关心平台**：common 层不依赖、不实现任何具体平台的图片处理能力，只定义「入参是什么、出参是什么、方法长什么样」。
+- **使用层提供实现**：各端在各自工程内实现图片处理逻辑，并保证满足 common 规定的接口与返回值类型（如
+  `ImageProcessResult`）。
+- **类型与契约在 common 维护**：所有三端共用的类型（Options、Result）、以及「处理器」的接口形状（如
+  `compress(input, options): Promise<ImageProcessResult>`）仅在 common 定义与演进，保证三端数据格式统一。
 
 ---
 
-## 二、专业术语
+## 二、common 的职责：只做数据格式与契约
 
-### 2.1 图片处理术语
+### 2.1 只做两件事
 
-| 术语                      | 英文                  | 说明                                                                                            |
-| ------------------------- | --------------------- | ----------------------------------------------------------------------------------------------- |
-| **WASM**                  | WebAssembly           | 由 Rust 等编译得到的二进制模块，在 Web/Node 中运行，用于高性能计算                              |
-| **平台适配器**            | Platform Adapter      | 实现统一图片处理接口的某一端具体逻辑，如 WasmImageProcessorAdapter、NativeImageProcessorAdapter |
-| **ImageProcessorService** | ImageProcessorService | 对外统一图片处理 API 的抽象，内部按平台选择适配器                                               |
-| **压缩**                  | Compression           | 在可接受画质下减小文件体积（如质量参数、WebP/JPEG 编码）                                        |
-| **格式转换**              | Format Conversion     | 解码后以另一种编码输出（如 PNG→JPEG、JPEG→WebP）                                                |
+| 职责                     | 说明                                                                                                                                                                                                                 |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **数据格式的统一与维护** | 在 packages/common 中定义并导出所有图片处理相关的**类型**：如 `ImageProcessResult`、`ImageCompressionOptions`、`ImageConversionOptions`、`OutputMimeType` 等。三端均从 common 引用这些类型，保证入参、出参结构一致。 |
+| **方法契约的定义**       | 在 common 中定义**处理器接口**（如 `IImageProcessor`）：规定 `compress`、`convert` 等方法的**方法名、参数类型、返回值类型**。不包含任何实现；具体实现由使用层提供。                                                  |
 
-### 2.2 平台与实现术语
+### 2.2 common 不做什么
 
-| 术语                       | 英文                   | 说明                                                                          |
-| -------------------------- | ---------------------- | ----------------------------------------------------------------------------- |
-| **pkg-web**                | Web build              | wasm-pack 以 `--target web` 产出的 WASM 包，供浏览器使用                      |
-| **pkg-node**               | Node build             | wasm-pack 以 `--target nodejs` 产出的 WASM 包，供 Electron 主进程或 Node 使用 |
-| **expo-image-manipulator** | Expo Image Manipulator | Expo 提供的图片裁剪、旋转、缩放、格式等原生能力，供 Mobile 使用               |
+- **不实现**压缩、转换、裁剪等具体算法或调用（不调用 Canvas、WASM、expo-image-manipulator）。
+- **不选择**运行在哪个平台、用哪种技术；不包含「Web 适配器」「Native 适配器」等平台分支逻辑。
+- **不依赖**各端运行环境（不依赖 DOM、Node、React
+  Native 等），仅提供纯类型与接口定义，以便各端引用。
 
 ---
 
-## 三、架构设计
+## 三、使用层的职责：提供符合契约的实现
 
-### 3.1 整体架构图
+### 3.1 使用层需要提供什么
+
+各端应用（apps/pixuli、apps/mobile 等）需要**自己实现**图片处理逻辑，并对外暴露符合 common 契约的**图片处理工具**：
+
+- **方法签名**：与 common 定义的接口一致（例如
+  `compress(input, options): Promise<ImageProcessResult>`）。
+- **返回值**：必须符合 common 定义的
+  `ImageProcessResult`（或契约规定的其他类型），便于上游业务统一处理（展示、上传、统计等）。
+
+### 3.2 各端可采用的实现方式
+
+| 端            | 实现方式（由使用层自行选择） | 说明                                                                                                                    |
+| ------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Web / Desktop | Canvas API、或 packages/wasm | 在 apps/pixuli（或对应工程）内实现，接收 `File` 等，返回 `ImageProcessResult`。                                         |
+| Mobile        | expo-image-manipulator 等    | 在 apps/mobile 内实现，接收 URI 等，返回与 common 约定一致的 `ImageProcessResult`（如 uri、尺寸、大小、压缩率等字段）。 |
+
+- common 不关心各端内部用 Canvas 还是 WASM 还是原生；只要**入参、出参符合 common 的契约**即可。
+
+### 3.3 使用方式（建议）
+
+- 各端在应用入口或模块内**注册/注入**本端的图片处理实现（例如通过 Context、DI 或单例），业务代码统一调用「当前端的处理器」，而不写
+  `if (web) ... else if (mobile) ...`。
+- 业务层只依赖 **common 的类型**（从 common 导入
+  `ImageProcessResult`、Options 等），以及**本端提供的、符合契约的处理器实例**（从本端模块或 Context 获取）。
+
+---
+
+## 四、架构设计
+
+### 4.1 整体架构（common 仅契约与类型，实现在使用层）
 
 ```mermaid
 graph TB
-    subgraph 应用层
-        A1[apps/pixuli Web+Desktop]
+    subgraph 使用层
+        A1[apps/pixuli]
         A2[apps/mobile]
     end
 
-    subgraph 统一接口层
-        B[ImageProcessorService]
+    subgraph 使用层提供的实现
+        B1[Web 图片处理实现<br/>Canvas / WASM]
+        B2[Mobile 图片处理实现<br/>expo-image-manipulator]
     end
 
-    subgraph 平台适配层
-        C1[WasmImageProcessorAdapter]
-        C2[NativeImageProcessorAdapter]
+    subgraph packages/common 仅契约与类型
+        C[类型与接口定义<br/>ImageProcessResult / IImageProcessor 等]
     end
 
-    subgraph 实现层_Web_PC
-        D[packages/wasm<br/>Rust → pkg-web / pkg-node]
-    end
-
-    subgraph 实现层_Mobile
-        E[expo-image-manipulator]
-    end
-
-    A1 --> B
-    A2 --> B
-    B --> C1
-    B --> C2
-    C1 --> D
-    C2 --> E
+    A1 --> B1
+    A2 --> B2
+    B1 -.符合契约.-> C
+    B2 -.符合契约.-> C
+    A1 --> C
+    A2 --> C
 ```
 
-### 3.2 平台适配流程
+- **common**：只提供 C（类型 + 接口契约）；不包含 B1/B2。
+- **使用层**：A1/A2 引用 common 的类型；B1/B2 由各端实现并满足 C 的契约。
+
+### 4.2 调用关系
 
 ```mermaid
 sequenceDiagram
-    participant App as 应用层
-    participant Service as ImageProcessorService
-    participant Adapter as PlatformAdapter
-    participant Impl as 平台实现
+    participant Biz as 业务代码（任意端）
+    participant Impl as 本端图片处理实现（使用层提供）
+    participant Common as packages/common 类型
 
-    App->>Service: compress(file, 0.8)
-    Service->>Adapter: 按平台选择适配器
-    Adapter->>Impl: 调用 WASM 或原生 API
-    Impl-->>Adapter: 处理结果
-    Adapter-->>Service: 统一格式结果
-    Service-->>App: ImageProcessResult
+    Biz->>Common: 引用类型 ImageProcessResult, Options
+    Biz->>Impl: compress(input, options)
+    Impl->>Impl: 本端逻辑（Canvas/WASM/原生）
+    Impl-->>Biz: 返回符合 ImageProcessResult 的结果
 ```
 
-### 3.3 平台支持策略
-
-| 端                     | 实现                     | 入口/适配器                 |
-| ---------------------- | ------------------------ | --------------------------- |
-| Web / Desktop 渲染进程 | packages/wasm (pkg-web)  | WasmImageProcessorAdapter   |
-| Desktop 主进程         | packages/wasm (pkg-node) | WasmImageProcessorAdapter   |
-| Mobile                 | expo-image-manipulator   | NativeImageProcessorAdapter |
+- 业务代码依赖 common 的**类型**，调用**本端提供的**处理器实现；common 不参与具体调用链。
 
 ---
 
-## 四、功能模块
+## 五、契约定义（方法签名与数据类型）
 
-### 4.1 压缩 (compress)
+### 5.1 统一类型（common 定义并维护）
 
-| 能力      | Web/PC                                                                  | Mobile              |
-| --------- | ----------------------------------------------------------------------- | ------------------- |
-| WebP 压缩 | WASM（当前 WebP 在 WASM 中受限于纯 Rust 实现，见 packages/wasm README） | JPEG/PNG 等质量压缩 |
-| 质量控制  | 支持                                                                    | 支持                |
-| 批量压缩  | 支持                                                                    | 支持                |
-| 压缩统计  | 大小、压缩率等                                                          | 同左                |
+以下类型在 **packages/common** 中定义，三端共用：
 
-### 4.2 格式转换 (convert)
+- **ImageProcessResult**：统一结果结构
+  - `uri`、`blob`/`file`（可选）、`originalSize`、`processedSize`、`compressionRatio`、`width`、`height`、`originalWidth`、`originalHeight`、`mimeType`
+    等。
+- **ImageCompressionOptions**：压缩选项（quality、maxWidth、maxHeight、outputFormat、minSizeToCompress 等）。
+- **ImageConversionOptions**：转换选项（quality、maxWidth、maxHeight、maintainAspectRatio 等）。
+- **OutputMimeType**：支持的输出 MIME（如
+  `'image/jpeg' | 'image/png' | 'image/webp'`）。
 
-| 能力     | Web/PC                                     | Mobile          |
-| -------- | ------------------------------------------ | --------------- |
-| 多格式   | JPEG、PNG、WebP、GIF、BMP、TIFF 等（WASM） | JPEG、PNG、WebP |
-| 尺寸调整 | 支持，可保持宽高比                         | 支持            |
-| 批量转换 | 支持                                       | 支持            |
+### 5.2 处理器接口（common 定义，使用层实现）
 
-### 4.3 图片分析 (analyze)
+common 中可定义**接口**（无实现），规定使用层必须提供的方法形状，例如：
 
-| 能力     | Web/PC                                                                   | Mobile     |
-| -------- | ------------------------------------------------------------------------ | ---------- |
-| 基础信息 | 尺寸、格式、通道数、主色等                                               | 基础信息   |
-| AI 分析  | 对象检测、场景识别、标签/描述生成等（Desktop 另见 aiService、Dify 设计） | 可选或降级 |
+| 方法                               | 约定                                                                                                   |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `compress(input, options)`         | 入参：`File \| string`（或扩展）+ `ImageCompressionOptions`；返回：`Promise<ImageProcessResult>`。     |
+| `convert(input, format, options?)` | 入参：`File \| string`、目标格式、可选 `ImageConversionOptions`；返回：`Promise<ImageProcessResult>`。 |
 
-### 4.4 图片编辑 (edit)
+- 输入：各端可接受 `File`（Web/Desktop）或
+  `string`（URI，Mobile）；实现内部自行处理类型差异。
+- 输出：**必须**符合 common 的 `ImageProcessResult`，便于三端业务统一使用。
 
-| 能力        | Web/PC                                     | Mobile       |
-| ----------- | ------------------------------------------ | ------------ |
-| 裁剪        | 矩形、宽高比、可选智能裁剪                 | 矩形、宽高比 |
-| 旋转 / 翻转 | 任意角度、90° 步进、水平/垂直翻转          | 支持         |
-| 滤镜        | 亮度、对比度、饱和度、模糊、锐化等（WASM） | 依原生能力   |
-| 批量编辑    | 支持                                       | 支持         |
+### 5.3 输入输出约定（非流式）
 
----
-
-## 五、统一接口与平台适配
-
-### 5.1 接口定义（概要）
-
-统一服务对外提供以下能力（具体签名以代码为准）：
-
-| 方法                                               | 说明                               |
-| -------------------------------------------------- | ---------------------------------- |
-| `compress(input, quality)`                         | 压缩图片，返回统一结果格式         |
-| `convertFormat(input, format, quality?)`           | 格式转换                           |
-| `crop(input, region)`                              | 按区域裁剪                         |
-| `rotate(input, degrees)`                           | 旋转                               |
-| `resize(input, width?, height?, keepAspectRatio?)` | 尺寸调整                           |
-| `process(input, options)`                          | 综合处理（质量、格式、尺寸等组合） |
-| `getInfo(input)`                                   | 获取图片基本信息                   |
-
-输入类型：Web/PC 多为 `File` 或二进制；Mobile 多为 `string`（URI）。接口设计为
-`File | string` 或适配器内做转换。输出统一包含
-`uri`（或等效）及元数据，便于各端上传或展示。
-
-### 5.2 平台适配器职责
-
-| 适配器                          | 职责                                                                                          |
-| ------------------------------- | --------------------------------------------------------------------------------------------- |
-| **WasmImageProcessorAdapter**   | 调用 pixuli-wasm；将 File/二进制与 WASM 互转；将结果转为统一结构（如 Data URL 或 Blob URL）。 |
-| **NativeImageProcessorAdapter** | 调用 expo-image-manipulator；输入输出为 URI；返回统一结构（uri 等）。                         |
+- **整图处理**：当前约定为整图读入、整图输出，不做流式。
+- **输入**：`File | string`（或各端约定扩展类型），由使用层实现自行解析。
+- **输出**：统一为 `ImageProcessResult`；Web 侧可为 Blob URL +
+  File，Mobile 侧为本地 file URI，但字段名与含义一致。
 
 ---
 
-## 六、技术栈与项目结构
+## 六、当前实现情况
 
-### 6.1 技术栈
+### 6.1 packages/common 现状
 
-| 端         | 核心技术                                                                                          |
-| ---------- | ------------------------------------------------------------------------------------------------- |
-| **Web/PC** | Rust、wasm-bindgen、image-rs、wasm-pack；可选 webp、ort（ONNX）、ndarray 等（见 packages/wasm）。 |
-| **Mobile** | expo-image-manipulator、expo-file-system 等。                                                     |
+| 项目                   | 位置                                           | 说明                                                                                                                                                        |
+| ---------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **类型**               | `packages/common/src/types/image.ts`           | `ImageCompressionOptions`、`ImageProcessResult`、`ImageConversionOptions`、`OutputMimeType` 等已定义并导出，**符合「common 只做数据格式」**。               |
+| **Web 实现（待迁出）** | `packages/common/src/services/imageProcessor/` | 当前存在 `WebImageProcessorService`（Canvas 实现）。按新逻辑，**具体处理逻辑不应放在 common**；应视为过渡实现，目标迁至使用层（见迁移方案）。               |
+| **工具**               | `packages/common/src/utils/imageUtils.ts`      | `compressImage`、`getImageDimensions` 等内含 Canvas 逻辑，同样属于「具体实现」；若需统一契约，应由使用层提供实现，common 仅保留与契约相关的类型或工具类型。 |
 
-### 6.2 项目结构（概要）
+### 6.2 各端使用情况
 
-| 路径                                     | 说明                                                   |
-| ---------------------------------------- | ------------------------------------------------------ |
-| `packages/common/src/services/`          | ImageProcessorService 统一接口及工厂/平台选择逻辑      |
-| `packages/common/src/services/adapters/` | WasmImageProcessorAdapter、NativeImageProcessorAdapter |
-| `packages/wasm/src/`                     | Rust 源码：compress、convert、analyze、edit 等         |
-| `packages/wasm/pkg-web/`、`pkg-node/`    | wasm-pack 构建产物                                     |
+| 端              | 当前状态                                                                                                                                                                       |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **apps/pixuli** | 压缩页、转换页使用 common 的 `webImageProcessorService`（实现在 common 内）；上传组件等使用 `compressImage`。按新逻辑，这些实现应迁至 apps/pixuli，并实现 common 的接口契约。  |
+| **apps/mobile** | 使用 **apps/mobile/utils/imageUtils.ts** 的 `processImage(uri, options)`；返回形态与 common 的 `ImageProcessResult` 不完全一致。需在 mobile 层封装为符合 common 契约的返回值。 |
 
----
+### 6.3 与目标架构的差距
 
-## 七、应用场景与性能
-
-### 7.1 典型场景
-
-| 场景               | 说明               | 平台实现                       |
-| ------------------ | ------------------ | ------------------------------ |
-| 上传前压缩         | 减少上传体积与时间 | 三端均支持，实现不同           |
-| 格式统一           | 批量转为目标格式   | WASM / 原生                    |
-| 尺寸调整           | 缩略图或固定最大边 | 同上                           |
-| 基础信息 / AI 分析 | 元数据与标签、描述 | Web/PC 完整，Mobile 基础或可选 |
-
-### 7.2 性能与限制（参考）
-
-| 端                | 优势                         | 限制                          |
-| ----------------- | ---------------------------- | ----------------------------- |
-| **Web/PC (WASM)** | 高性能、多格式、可扩展 AI    | 模块体积与首次加载/初始化时间 |
-| **Mobile (原生)** | 体积小、无 WASM 加载、启动快 | 格式与高级功能相对受限        |
-
-具体性能指标（如单张 2MB 处理时间、压缩率）见 [九、附录](#九附录)。
+- common 内仍有**具体图片处理实现**（Web 用 Canvas）；目标为 common
+  **仅保留类型与契约**，实现全部在使用层。
+- 使用层尚未统一「注入符合 common 契约的处理器」；部分仍直接依赖 common 内的实现或各端私有 utils。
 
 ---
 
-## 八、注意事项与安全
+## 七、迁移方案
 
-### 8.1 平台差异
+### 7.1 目标状态
 
-- **输入**：Web/PC 多为 `File` 或 ArrayBuffer；Mobile 为 URI。适配器内部做转换。
-- **输出**：统一为带 `uri`（或等效）的结果结构，各端按需转为上传或展示格式。
-- **功能差异**：AI 分析、部分滤镜与格式以 Web/PC 为主；Mobile 可降级或隐藏。
+- **common**：仅包含图片处理相关的**类型**与**接口契约**（如
+  `IImageProcessor`）；**不包含**任何具体实现（无 Canvas、WASM、expo 调用）。
+- **使用层**：各端提供符合 common 契约的图片处理工具函数/对象，业务代码通过本端注入的处理器调用，并统一使用 common 的类型。
 
-### 8.2 错误与降级
+### 7.2 阶段一：在 common 中明确契约，收敛实现
 
-- 统一错误类型与错误信息，便于日志与用户提示。
-- 某端或某功能不可用时，返回明确错误或降级到基础能力。
+- 在 common 中**正式定义**处理器接口（如
+  `IImageProcessor`）：仅方法签名与返回值类型，无实现。
+- **保留**
+  common 内现有类型（`ImageProcessResult`、Options 等），确保三端继续从 common 引用。
+- 将 common 内现有的 **Web 实现**（`WebImageProcessorService` /
+  `webImageProcessorService`）**迁出**至
+  **apps/pixuli**（或 Web/Desktop 专用包）：在 apps/pixuli 中实现
+  `IImageProcessor`，内部使用 Canvas 或 WASM，返回 `ImageProcessResult`。
+- apps/pixuli 的压缩页、转换页、上传组件等改为使用**本端提供的**处理器实例（来自 apps/pixuli），不再从 common 导入具体实现。
 
-### 8.3 安全与健壮性
+### 7.3 阶段二：使用层统一注入与调用
 
-- **输入校验**：格式、大小、参数范围（如 quality 0–1）在接口或适配器内校验。
-- **内存**：WASM 侧依赖 Rust 与 WASM 边界；Mobile 侧及时释放大对象。
-- **测试**：接口级测试、各平台适配器测试、集成与性能基准（见 benchmark/）。
+- **apps/pixuli**：在应用内注册/注入本端图片处理器（实现 common 的
+  `IImageProcessor`）；业务代码通过 Context 或单例获取该处理器并调用
+  `compress`、`convert` 等。
+- **apps/mobile**：在应用内实现符合 common 契约的处理器（内部仍可用
+  `processImage` / expo-image-manipulator），将返回值映射为 common 的
+  `ImageProcessResult`；同样通过注入方式供业务使用。
+- 两端的业务代码**只依赖**
+  common 的类型与接口定义，以及**本端注入的处理器**，不依赖对端的实现或 common 内的具体逻辑。
+
+### 7.4 阶段三：清理 common 中的实现代码
+
+- 从 packages/common 中**移除**图片处理的具体实现（如
+  `webImageProcessor.ts`、以及 utils 中纯图片处理相关的实现）；若存在仅被 Web 使用的工具（如
+  `calculateDisplayDimensions`），可迁至 apps/pixuli 或保留为「与契约无直接关系的工具」并在文档中说明。
+- common 仅保留：类型定义、处理器接口定义、以及必要的文档说明契约与使用方式。
+
+### 7.5 迁移检查清单
+
+- [ ] common 中定义并导出
+      `IImageProcessor`（或等价接口），仅方法签名与类型，无实现。
+- [ ] common 中移除或迁出所有具体图片处理实现（Canvas/WASM/expo 等）。
+- [ ] apps/pixuli 实现并注入符合契约的 Web/Desktop 图片处理器；压缩页、转换页、上传等改为使用该处理器。
+- [ ] apps/mobile 实现并注入符合契约的图片处理器，返回
+      `ImageProcessResult`；业务改为使用该处理器。
+- [ ] 三端业务仅依赖 common 的类型与契约，以及本端提供的处理器；无跨端实现依赖。
+
+---
+
+## 八、技术栈与项目结构
+
+### 8.1 common 内保留内容（目标）
+
+| 路径                                                     | 内容                                                                                                   |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `packages/common/src/types/image.ts`                     | 类型：`ImageProcessResult`、`ImageCompressionOptions`、`ImageConversionOptions`、`OutputMimeType` 等。 |
+| `packages/common/src/services/imageProcessor/`（或等价） | 仅**接口定义**（如 `IImageProcessor`）、以及导出类型；无具体实现文件。                                 |
+
+### 8.2 使用层各端
+
+| 端          | 实现位置（建议）                      | 实现方式                                                                                |
+| ----------- | ------------------------------------- | --------------------------------------------------------------------------------------- |
+| Web/Desktop | apps/pixuli 或 packages 下 Web 专用包 | Canvas API 或 packages/wasm，实现 `IImageProcessor`，返回 `ImageProcessResult`。        |
+| Mobile      | apps/mobile                           | expo-image-manipulator 等，封装为符合 `IImageProcessor` 的接口与 `ImageProcessResult`。 |
 
 ---
 
 ## 九、附录
 
-### 9.1 性能指标（参考）
+### 9.1 专业术语
 
-以下为设计目标或典型值，实际以 benchmark 与真机为准：
+| 术语                   | 说明                                                                           |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| **契约**               | common 中定义的方法签名与数据类型；使用层实现必须满足的接口与返回值形状。      |
+| **ImageProcessResult** | common 定义并维护的统一结果类型；各端实现必须返回符合该结构的对象。            |
+| **使用层**             | 各端应用（apps/pixuli、apps/mobile）；负责提供符合 common 契约的图片处理实现。 |
 
-| 指标              | Web/PC (WASM)     | Mobile (原生)   |
-| ----------------- | ----------------- | --------------- |
-| 单张 2MB 压缩     | &lt; 100ms 量级   | &lt; 150ms 量级 |
-| 单张 2MB 格式转换 | &lt; 150ms 量级   | &lt; 200ms 量级 |
-| 基础信息获取      | &lt; 10ms 量级    | &lt; 50ms 量级  |
-| 批量处理          | 支持并发/批量 API | 支持批量        |
+### 9.2 为何 common 不做具体实现
 
-### 9.2 最佳实践摘要
-
-- **统一接口**：业务只依赖 ImageProcessorService，不直接依赖 WASM 或原生模块。
-- **预加载**：Web/Desktop 可在应用启动时预加载 WASM，减少首次调用延迟。
-- **错误与日志**：使用统一错误格式，并接入
-  [04-cross-platform-logging](./04-cross-platform-logging.md) 便于排查。
+- **平台差异大**：Web（Canvas/WASM）、Mobile（原生）依赖不同运行时与依赖，若实现放在 common，common 会依赖多套环境或需要大量条件分支，违背「common 只做类型与契约」的边界。
+- **依赖与体积**：具体实现会引入 Canvas、WASM、expo 等依赖，不利于 common 保持轻量、可被任意端引用。
+- **职责清晰**：common 只负责「数据长什么样、方法叫什么、返回什么」；「怎么算」由使用层各端自行负责，便于各端选型与优化。
 
 ### 9.3 相关文档
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -145,7 +145,6 @@ graph TB
 
 - [Project Homepage](https://github.com/trueLoving/Pixuli)
 - [Issue Feedback](https://github.com/trueLoving/Pixuli/issues)
-- [Documentation](https://pixuli-docs.vercel.app/)
 - [Feature Roadmap](./ROADMAP.md)
 - [Changelog](../../CHANGELOG.md)
 - [Contributing Guide](../../CONTRIBUTING.md)

--- a/apps/mobile/components/settings/modals/HelpModal.tsx
+++ b/apps/mobile/components/settings/modals/HelpModal.tsx
@@ -43,13 +43,13 @@ export const HelpModal: React.FC<HelpModalProps> = ({
       id: 'docs',
       title: t('help.documentation') || '使用文档',
       icon: 'book.fill',
-      url: 'https://pixuli-docs.vercel.app/',
+      url: 'https://github.com/trueLoving/Pixuli/wiki/Pixuli-Usage-Tutorial',
     },
     {
       id: 'faq',
       title: t('help.faq') || '常见问题',
       icon: 'questionmark.circle.fill',
-      url: 'https://pixuli-docs.vercel.app/',
+      url: 'https://github.com/trueLoving/Pixuli/wiki/Pixuli-Usage-Tutorial',
     },
     {
       id: 'github',

--- a/apps/pixuli/src/i18n/locales/en-US.json
+++ b/apps/pixuli/src/i18n/locales/en-US.json
@@ -25,5 +25,47 @@
   },
   "header": {
     "operationLog": "Operation Log"
+  },
+  "compressPage": {
+    "title": "Image Compression",
+    "dropHint": "Drag images here or click to select",
+    "quality": "Quality",
+    "maxWidth": "Max width",
+    "maxHeight": "Max height",
+    "maxWidthPlaceholder": "No limit",
+    "maxHeightPlaceholder": "No limit",
+    "outputFormat": "Output format",
+    "minSizeToCompress": "Skip if smaller than (KB)",
+    "minSizePlaceholder": "No limit",
+    "compressBtn": "Compress",
+    "compressing": "Compressing...",
+    "originalSize": "Original",
+    "processedSize": "Compressed",
+    "ratio": "Ratio",
+    "dimensions": "Dimensions",
+    "download": "Download",
+    "noFiles": "Select images to compress first",
+    "clear": "Clear",
+    "keepAspectRatio": "Keep aspect ratio"
+  },
+  "convertPage": {
+    "title": "Image Conversion",
+    "dropHint": "Drag images here or click to select",
+    "targetFormat": "Target format",
+    "quality": "Quality",
+    "maxWidth": "Max width",
+    "maxHeight": "Max height",
+    "maxWidthPlaceholder": "No limit",
+    "maxHeightPlaceholder": "No limit",
+    "convertBtn": "Convert",
+    "converting": "Converting...",
+    "originalSize": "Original",
+    "processedSize": "Converted",
+    "ratio": "Size ratio",
+    "dimensions": "Dimensions",
+    "download": "Download",
+    "noFiles": "Select images to convert first",
+    "clear": "Clear",
+    "keepAspectRatio": "Keep aspect ratio"
   }
 }

--- a/apps/pixuli/src/i18n/locales/zh-CN.json
+++ b/apps/pixuli/src/i18n/locales/zh-CN.json
@@ -25,5 +25,47 @@
   },
   "header": {
     "operationLog": "操作日志"
+  },
+  "compressPage": {
+    "title": "图片压缩",
+    "dropHint": "拖拽图片到此处，或点击选择文件",
+    "quality": "压缩质量",
+    "maxWidth": "最大宽度",
+    "maxHeight": "最大高度",
+    "maxWidthPlaceholder": "不限制",
+    "maxHeightPlaceholder": "不限制",
+    "outputFormat": "输出格式",
+    "minSizeToCompress": "小于此大小不压缩（KB）",
+    "minSizePlaceholder": "不限制",
+    "compressBtn": "压缩",
+    "compressing": "压缩中...",
+    "originalSize": "原始大小",
+    "processedSize": "压缩后",
+    "ratio": "压缩率",
+    "dimensions": "尺寸",
+    "download": "下载",
+    "noFiles": "请先选择要压缩的图片",
+    "clear": "清空",
+    "keepAspectRatio": "保持宽高比"
+  },
+  "convertPage": {
+    "title": "图片转换",
+    "dropHint": "拖拽图片到此处，或点击选择文件",
+    "targetFormat": "目标格式",
+    "quality": "质量",
+    "maxWidth": "最大宽度",
+    "maxHeight": "最大高度",
+    "maxWidthPlaceholder": "不限制",
+    "maxHeightPlaceholder": "不限制",
+    "convertBtn": "转换",
+    "converting": "转换中...",
+    "originalSize": "原始大小",
+    "processedSize": "转换后",
+    "ratio": "体积比",
+    "dimensions": "尺寸",
+    "download": "下载",
+    "noFiles": "请先选择要转换的图片",
+    "clear": "清空",
+    "keepAspectRatio": "保持宽高比"
   }
 }

--- a/apps/pixuli/src/pages/compress/index.tsx
+++ b/apps/pixuli/src/pages/compress/index.tsx
@@ -1,14 +1,327 @@
-import React from 'react';
+import {
+  formatFileSize,
+  webImageProcessorService,
+  type ImageCompressionOptions,
+  type ImageProcessResult,
+} from '@packages/common/src';
+import { Download, ImageIcon, Loader2, Trash2 } from 'lucide-react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useI18n } from '@/i18n/useI18n';
+
+type ResultItem = { file: File; result: ImageProcessResult };
 
 export const CompressPage: React.FC = () => {
   const { t } = useI18n();
+  const [files, setFiles] = useState<File[]>([]);
+  const [results, setResults] = useState<ResultItem[]>([]);
+  const [processing, setProcessing] = useState(false);
+
+  const [quality, setQuality] = useState(0.8);
+  const [maxWidth, setMaxWidth] = useState<number | ''>('');
+  const [maxHeight, setMaxHeight] = useState<number | ''>('');
+  const [outputFormat, setOutputFormat] = useState<
+    'image/jpeg' | 'image/png' | 'image/webp'
+  >('image/jpeg');
+  const [minSizeKB, setMinSizeKB] = useState<number | ''>('');
+  const [keepAspectRatio, setKeepAspectRatio] = useState(true);
+
+  const options: ImageCompressionOptions = {
+    quality,
+    maxWidth: maxWidth === '' ? undefined : maxWidth,
+    maxHeight: maxHeight === '' ? undefined : maxHeight,
+    maintainAspectRatio: keepAspectRatio,
+    outputFormat,
+    minSizeToCompress:
+      minSizeKB === '' ? undefined : (minSizeKB as number) * 1024,
+  };
+
+  const resultsRef = useRef<ResultItem[]>([]);
+  resultsRef.current = results;
+
+  const revokeResults = useCallback((items: ResultItem[]) => {
+    items.forEach(({ result }) => {
+      if (result.uri?.startsWith('blob:')) URL.revokeObjectURL(result.uri);
+    });
+  }, []);
+
+  useEffect(() => {
+    return () => revokeResults(resultsRef.current);
+  }, [revokeResults]);
+
+  const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const list = e.target.files;
+    if (!list?.length) return;
+    setFiles(Array.from(list));
+    setResults([]);
+    revokeResults(results);
+  };
+
+  const onDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      const list = e.dataTransfer.files;
+      if (!list?.length) return;
+      const images = Array.from(list).filter(f => f.type.startsWith('image/'));
+      if (images.length) {
+        revokeResults(resultsRef.current);
+        setFiles(images);
+        setResults([]);
+      }
+    },
+    [revokeResults],
+  );
+  const onDragOver = (e: React.DragEvent) => e.preventDefault();
+
+  const handleCompress = async () => {
+    if (!files.length) return;
+    setProcessing(true);
+    revokeResults(resultsRef.current);
+    setResults([]);
+    const newResults: ResultItem[] = [];
+    try {
+      for (const file of files) {
+        const result = await webImageProcessorService.compress(file, options);
+        newResults.push({ file, result });
+      }
+      setResults(newResults);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  const handleClear = useCallback(() => {
+    revokeResults(resultsRef.current);
+    setFiles([]);
+    setResults([]);
+  }, [revokeResults]);
+
+  const handleDownload = (item: ResultItem) => {
+    const a = document.createElement('a');
+    a.href = item.result.uri;
+    a.download = item.result.file.name;
+    a.click();
+  };
 
   return (
-    <div className="h-full w-full flex items-center justify-center">
-      <div className="text-center">
-        <p className="text-lg text-gray-600 mb-2">{t('sidebar.comingSoon')}</p>
-        <p className="text-sm text-gray-400">{t('sidebar.imageCompress')}</p>
+    <div className="h-full w-full overflow-auto p-6">
+      <div className="mx-auto max-w-4xl">
+        <h1 className="mb-6 text-xl font-semibold text-gray-800 dark:text-gray-200">
+          {t('compressPage.title')}
+        </h1>
+
+        <div
+          className="mb-6 rounded-xl border-2 border-dashed border-gray-300 bg-gray-50 p-8 text-center dark:border-gray-600 dark:bg-gray-800/50"
+          onDrop={onDrop}
+          onDragOver={onDragOver}
+        >
+          <input
+            type="file"
+            accept="image/*"
+            multiple
+            className="hidden"
+            id="compress-file-input"
+            onChange={onFileChange}
+          />
+          <label
+            htmlFor="compress-file-input"
+            className="cursor-pointer text-gray-600 dark:text-gray-400"
+          >
+            <ImageIcon className="mx-auto mb-2 h-12 w-12" />
+            <p>{t('compressPage.dropHint')}</p>
+            {files.length > 0 && (
+              <p className="mt-2 text-sm">
+                {files.length} {t('sourceManager.imageCount')}
+              </p>
+            )}
+          </label>
+        </div>
+
+        <div className="mb-6 rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+          <h2 className="mb-3 text-sm font-medium text-gray-700 dark:text-gray-300">
+            选项
+          </h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div>
+              <label className="mb-1 block text-xs text-gray-500">
+                {t('compressPage.quality')} ({(quality * 100).toFixed(0)}%)
+              </label>
+              <input
+                type="range"
+                min="0.1"
+                max="1"
+                step="0.05"
+                value={quality}
+                onChange={e => setQuality(Number(e.target.value))}
+                className="w-full"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs text-gray-500">
+                {t('compressPage.maxWidth')}
+              </label>
+              <input
+                type="number"
+                min="1"
+                placeholder={t('compressPage.maxWidthPlaceholder')}
+                value={maxWidth}
+                onChange={e =>
+                  setMaxWidth(
+                    e.target.value === '' ? '' : Number(e.target.value),
+                  )
+                }
+                className="w-full rounded border border-gray-300 px-2 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs text-gray-500">
+                {t('compressPage.maxHeight')}
+              </label>
+              <input
+                type="number"
+                min="1"
+                placeholder={t('compressPage.maxHeightPlaceholder')}
+                value={maxHeight}
+                onChange={e =>
+                  setMaxHeight(
+                    e.target.value === '' ? '' : Number(e.target.value),
+                  )
+                }
+                className="w-full rounded border border-gray-300 px-2 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs text-gray-500">
+                {t('compressPage.outputFormat')}
+              </label>
+              <select
+                value={outputFormat}
+                onChange={e =>
+                  setOutputFormat(
+                    e.target.value as 'image/jpeg' | 'image/png' | 'image/webp',
+                  )
+                }
+                className="w-full rounded border border-gray-300 px-2 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+              >
+                <option value="image/jpeg">JPEG</option>
+                <option value="image/png">PNG</option>
+                <option value="image/webp">WebP</option>
+              </select>
+            </div>
+            <div>
+              <label className="mb-1 block text-xs text-gray-500">
+                {t('compressPage.minSizeToCompress')}
+              </label>
+              <input
+                type="number"
+                min="0"
+                placeholder={t('compressPage.minSizePlaceholder')}
+                value={minSizeKB}
+                onChange={e =>
+                  setMinSizeKB(
+                    e.target.value === '' ? '' : Number(e.target.value),
+                  )
+                }
+                className="w-full rounded border border-gray-300 px-2 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+              />
+            </div>
+            <div className="flex items-center gap-2 pt-6">
+              <input
+                type="checkbox"
+                id="keep-aspect"
+                checked={keepAspectRatio}
+                onChange={e => setKeepAspectRatio(e.target.checked)}
+                className="rounded"
+              />
+              <label
+                htmlFor="keep-aspect"
+                className="text-sm text-gray-600 dark:text-gray-400"
+              >
+                {t('compressPage.keepAspectRatio')}
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div className="mb-6 flex gap-3">
+          <button
+            type="button"
+            onClick={handleCompress}
+            disabled={!files.length || processing}
+            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {processing ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {t('compressPage.compressing')}
+              </>
+            ) : (
+              t('compressPage.compressBtn')
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={handleClear}
+            className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            <Trash2 className="h-4 w-4" />
+            {t('compressPage.clear')}
+          </button>
+        </div>
+
+        {!files.length && !results.length && (
+          <p className="text-center text-sm text-gray-500">
+            {t('compressPage.noFiles')}
+          </p>
+        )}
+
+        {results.length > 0 && (
+          <div className="space-y-4">
+            <h2 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              结果
+            </h2>
+            <ul className="space-y-3">
+              {results.map((item, i) => (
+                <li
+                  key={i}
+                  className="flex flex-wrap items-center gap-4 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/50"
+                >
+                  <img
+                    src={item.result.uri}
+                    alt={item.result.file.name}
+                    className="h-20 w-20 rounded object-cover"
+                  />
+                  <div className="min-w-0 flex-1 text-sm">
+                    <p className="truncate font-medium text-gray-800 dark:text-gray-200">
+                      {item.result.file.name}
+                    </p>
+                    <p className="text-gray-500">
+                      {t('compressPage.originalSize')}:{' '}
+                      {formatFileSize(item.result.originalSize)} →{' '}
+                      {t('compressPage.processedSize')}:{' '}
+                      {formatFileSize(item.result.processedSize)} (
+                      {((1 - item.result.compressionRatio) * 100).toFixed(1)}%{' '}
+                      {t('compressPage.ratio')})
+                    </p>
+                    <p className="text-gray-500">
+                      {t('compressPage.dimensions')}: {item.result.width} ×{' '}
+                      {item.result.height}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleDownload(item)}
+                    className="inline-flex items-center gap-1 rounded border border-gray-300 bg-white px-3 py-1.5 text-sm hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:hover:bg-gray-600"
+                  >
+                    <Download className="h-4 w-4" />
+                    {t('compressPage.download')}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/pixuli/src/pages/convert/index.tsx
+++ b/apps/pixuli/src/pages/convert/index.tsx
@@ -1,14 +1,305 @@
-import React from 'react';
+import {
+  formatFileSize,
+  webImageProcessorService,
+  type ImageProcessResult,
+  type OutputMimeType,
+} from '@packages/common/src';
+import { Download, ImageIcon, Loader2, Trash2 } from 'lucide-react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useI18n } from '@/i18n/useI18n';
+
+type ResultItem = { file: File; result: ImageProcessResult };
 
 export const ConvertPage: React.FC = () => {
   const { t } = useI18n();
+  const [files, setFiles] = useState<File[]>([]);
+  const [results, setResults] = useState<ResultItem[]>([]);
+  const [processing, setProcessing] = useState(false);
+
+  const [targetFormat, setTargetFormat] =
+    useState<OutputMimeType>('image/jpeg');
+  const [quality, setQuality] = useState(0.9);
+  const [maxWidth, setMaxWidth] = useState<number | ''>('');
+  const [maxHeight, setMaxHeight] = useState<number | ''>('');
+  const [keepAspectRatio, setKeepAspectRatio] = useState(true);
+
+  const resultsRef = useRef<ResultItem[]>([]);
+  resultsRef.current = results;
+
+  const revokeResults = useCallback((items: ResultItem[]) => {
+    items.forEach(({ result }) => {
+      if (result.uri?.startsWith('blob:')) URL.revokeObjectURL(result.uri);
+    });
+  }, []);
+
+  useEffect(() => {
+    return () => revokeResults(resultsRef.current);
+  }, [revokeResults]);
+
+  const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const list = e.target.files;
+    if (!list?.length) return;
+    setFiles(Array.from(list));
+    setResults([]);
+    revokeResults(resultsRef.current);
+  };
+
+  const onDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      const list = e.dataTransfer.files;
+      if (!list?.length) return;
+      const images = Array.from(list).filter(f => f.type.startsWith('image/'));
+      if (images.length) {
+        revokeResults(resultsRef.current);
+        setFiles(images);
+        setResults([]);
+      }
+    },
+    [revokeResults],
+  );
+  const onDragOver = (e: React.DragEvent) => e.preventDefault();
+
+  const handleConvert = async () => {
+    if (!files.length) return;
+    setProcessing(true);
+    revokeResults(resultsRef.current);
+    setResults([]);
+    const newResults: ResultItem[] = [];
+    try {
+      for (const file of files) {
+        const result = await webImageProcessorService.convert(
+          file,
+          targetFormat,
+          {
+            quality,
+            maxWidth: maxWidth === '' ? undefined : maxWidth,
+            maxHeight: maxHeight === '' ? undefined : maxHeight,
+            maintainAspectRatio: keepAspectRatio,
+          },
+        );
+        newResults.push({ file, result });
+      }
+      setResults(newResults);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  const handleClear = useCallback(() => {
+    revokeResults(resultsRef.current);
+    setFiles([]);
+    setResults([]);
+  }, [revokeResults]);
+
+  const handleDownload = (item: ResultItem) => {
+    const a = document.createElement('a');
+    a.href = item.result.uri;
+    a.download = item.result.file.name;
+    a.click();
+  };
 
   return (
-    <div className="h-full w-full flex items-center justify-center">
-      <div className="text-center">
-        <p className="text-lg text-gray-600 mb-2">{t('sidebar.comingSoon')}</p>
-        <p className="text-sm text-gray-400">{t('sidebar.imageConvert')}</p>
+    <div className="h-full w-full overflow-auto p-6">
+      <div className="mx-auto max-w-4xl">
+        <h1 className="mb-6 text-xl font-semibold text-gray-800 dark:text-gray-200">
+          {t('convertPage.title')}
+        </h1>
+
+        <div
+          className="mb-6 rounded-xl border-2 border-dashed border-gray-300 bg-gray-50 p-8 text-center dark:border-gray-600 dark:bg-gray-800/50"
+          onDrop={onDrop}
+          onDragOver={onDragOver}
+        >
+          <input
+            type="file"
+            accept="image/*"
+            multiple
+            className="hidden"
+            id="convert-file-input"
+            onChange={onFileChange}
+          />
+          <label
+            htmlFor="convert-file-input"
+            className="cursor-pointer text-gray-600 dark:text-gray-400"
+          >
+            <ImageIcon className="mx-auto mb-2 h-12 w-12" />
+            <p>{t('convertPage.dropHint')}</p>
+            {files.length > 0 && (
+              <p className="mt-2 text-sm">
+                {files.length} {t('sourceManager.imageCount')}
+              </p>
+            )}
+          </label>
+        </div>
+
+        <div className="mb-6 rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+          <h2 className="mb-3 text-sm font-medium text-gray-700 dark:text-gray-300">
+            选项
+          </h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div>
+              <label className="mb-1 block text-xs text-gray-500">
+                {t('convertPage.targetFormat')}
+              </label>
+              <select
+                value={targetFormat}
+                onChange={e =>
+                  setTargetFormat(e.target.value as OutputMimeType)
+                }
+                className="w-full rounded border border-gray-300 px-2 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+              >
+                <option value="image/jpeg">JPEG</option>
+                <option value="image/png">PNG</option>
+                <option value="image/webp">WebP</option>
+              </select>
+            </div>
+            <div>
+              <label className="mb-1 block text-xs text-gray-500">
+                {t('convertPage.quality')} ({(quality * 100).toFixed(0)}%)
+              </label>
+              <input
+                type="range"
+                min="0.1"
+                max="1"
+                step="0.05"
+                value={quality}
+                onChange={e => setQuality(Number(e.target.value))}
+                className="w-full"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs text-gray-500">
+                {t('convertPage.maxWidth')}
+              </label>
+              <input
+                type="number"
+                min="1"
+                placeholder={t('convertPage.maxWidthPlaceholder')}
+                value={maxWidth}
+                onChange={e =>
+                  setMaxWidth(
+                    e.target.value === '' ? '' : Number(e.target.value),
+                  )
+                }
+                className="w-full rounded border border-gray-300 px-2 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs text-gray-500">
+                {t('convertPage.maxHeight')}
+              </label>
+              <input
+                type="number"
+                min="1"
+                placeholder={t('convertPage.maxHeightPlaceholder')}
+                value={maxHeight}
+                onChange={e =>
+                  setMaxHeight(
+                    e.target.value === '' ? '' : Number(e.target.value),
+                  )
+                }
+                className="w-full rounded border border-gray-300 px-2 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+              />
+            </div>
+            <div className="flex items-center gap-2 pt-6">
+              <input
+                type="checkbox"
+                id="convert-keep-aspect"
+                checked={keepAspectRatio}
+                onChange={e => setKeepAspectRatio(e.target.checked)}
+                className="rounded"
+              />
+              <label
+                htmlFor="convert-keep-aspect"
+                className="text-sm text-gray-600 dark:text-gray-400"
+              >
+                {t('convertPage.keepAspectRatio')}
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div className="mb-6 flex gap-3">
+          <button
+            type="button"
+            onClick={handleConvert}
+            disabled={!files.length || processing}
+            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {processing ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {t('convertPage.converting')}
+              </>
+            ) : (
+              t('convertPage.convertBtn')
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={handleClear}
+            className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            <Trash2 className="h-4 w-4" />
+            {t('convertPage.clear')}
+          </button>
+        </div>
+
+        {!files.length && !results.length && (
+          <p className="text-center text-sm text-gray-500">
+            {t('convertPage.noFiles')}
+          </p>
+        )}
+
+        {results.length > 0 && (
+          <div className="space-y-4">
+            <h2 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              结果
+            </h2>
+            <ul className="space-y-3">
+              {results.map((item, i) => (
+                <li
+                  key={i}
+                  className="flex flex-wrap items-center gap-4 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/50"
+                >
+                  <img
+                    src={item.result.uri}
+                    alt={item.result.file.name}
+                    className="h-20 w-20 rounded object-cover"
+                  />
+                  <div className="min-w-0 flex-1 text-sm">
+                    <p className="truncate font-medium text-gray-800 dark:text-gray-200">
+                      {item.result.file.name}
+                    </p>
+                    <p className="text-gray-500">
+                      {t('convertPage.originalSize')}:{' '}
+                      {formatFileSize(item.result.originalSize)} →{' '}
+                      {t('convertPage.processedSize')}:{' '}
+                      {formatFileSize(item.result.processedSize)} (
+                      {t('convertPage.ratio')}:{' '}
+                      {(item.result.compressionRatio * 100).toFixed(1)}%)
+                    </p>
+                    <p className="text-gray-500">
+                      {t('convertPage.dimensions')}: {item.result.width} ×{' '}
+                      {item.result.height}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleDownload(item)}
+                    className="inline-flex items-center gap-1 rounded border border-gray-300 bg-white px-3 py-1.5 text-sm hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:hover:bg-gray-600"
+                  >
+                    <Download className="h-4 w-4" />
+                    {t('convertPage.download')}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/common/src/components/layout/empty-state/native/EmptyState.native.tsx
+++ b/packages/common/src/components/layout/empty-state/native/EmptyState.native.tsx
@@ -27,7 +27,9 @@ const EmptyStateNative: React.FC<EmptyStateProps> = ({
   const colorScheme = colorSchemeProp ?? systemColorScheme;
 
   const handleOpenDocs = () => {
-    Linking.openURL('https://pixuli-docs.vercel.app/');
+    Linking.openURL(
+      'https://github.com/trueLoving/Pixuli/wiki/Pixuli-Usage-Tutorial',
+    );
   };
 
   // 主题颜色定义

--- a/packages/common/src/components/layout/empty-state/web/EmptyState.tsx
+++ b/packages/common/src/components/layout/empty-state/web/EmptyState.tsx
@@ -88,7 +88,7 @@ const EmptyState: React.FC<EmptyStateProps> = ({
           <HelpCircle className="w-4 h-4" />
           <span>{translate('emptyState.needHelp')}</span>
           <a
-            href="https://pixuli-docs.vercel.app/"
+            href="https://github.com/trueLoving/Pixuli/wiki/Pixuli-Usage-Tutorial"
             target="_blank"
             rel="noopener noreferrer"
             className="help-link"

--- a/packages/common/src/components/layout/sidebar/web/Sidebar.tsx
+++ b/packages/common/src/components/layout/sidebar/web/Sidebar.tsx
@@ -221,13 +221,13 @@ const Sidebar: React.FC<SidebarProps> = ({
       tool: 'compress',
       icon: <Zap size={20} />,
       label: translate('sidebar.imageCompress'),
-      comingSoon: true,
+      comingSoon: false,
     },
     {
       tool: 'convert',
       icon: <FileImage size={20} />,
       label: translate('sidebar.imageConvert'),
-      comingSoon: true,
+      comingSoon: false,
     },
     {
       tool: 'analyze',

--- a/packages/common/src/services/imageProcessor/README.md
+++ b/packages/common/src/services/imageProcessor/README.md
@@ -1,0 +1,19 @@
+# 图片处理服务（Web/Desktop）
+
+- **适用端**：Web、Electron 渲染进程。
+- **实现方式**：纯 Web 技术（Canvas API），不依赖 WASM。
+- **依赖约定**：当前实现仅使用浏览器原生 API，无额外 npm 依赖；若将来接入 WASM 或第三方图片库，应由**使用方项目**安装，并在本包（pixuli-common）中以
+  **peerDependencies** 声明，不放入 common 的 dependencies。
+
+## 导出
+
+- `WebImageProcessorService`：类，可实例化。
+- `webImageProcessorService`：单例，可直接用。
+- `compress(file, options)`：压缩。
+- `convert(file, outputFormat, options)`：格式转换。
+
+类型见
+`types/image.ts`：`ImageCompressionOptions`、`ImageProcessResult`、`ImageConversionOptions`、`OutputMimeType`。
+
+使用完毕后若仅用于一次性展示，建议对返回的 `result.uri` 调用
+`URL.revokeObjectURL(result.uri)` 释放 Blob URL，避免内存占用。

--- a/packages/common/src/services/imageProcessor/index.ts
+++ b/packages/common/src/services/imageProcessor/index.ts
@@ -1,0 +1,11 @@
+/**
+ * 图片处理服务（Web/Desktop 纯 Web 实现）
+ * 仅适用于 Web 与 Electron 渲染进程，使用 Canvas API，不依赖 WASM。
+ * 移动端请使用各端自己的实现（如 expo-image-manipulator）并通过统一接口对接。
+ */
+
+export {
+  WebImageProcessorService,
+  webImageProcessorService,
+  type OutputMimeType,
+} from './webImageProcessor';

--- a/packages/common/src/services/imageProcessor/webImageProcessor.ts
+++ b/packages/common/src/services/imageProcessor/webImageProcessor.ts
@@ -1,0 +1,260 @@
+/**
+ * Web/Desktop 图片处理服务（纯 Web 技术：Canvas API）
+ * 供 Web 与 Electron 渲染进程使用，不依赖 WASM。
+ * 相关运行环境依赖由使用方保证，本包不安装图片处理相关依赖，仅以 peerDependency 声明（如需要）。
+ */
+
+import type {
+  ImageCompressionOptions,
+  ImageProcessResult,
+  ImageConversionOptions,
+} from '../../types/image';
+import {
+  calculateDisplayDimensions,
+  getImageDimensions,
+} from '../../utils/imageUtils';
+
+const DEFAULT_QUALITY = 0.8;
+const DEFAULT_CONVERT_QUALITY = 0.9;
+
+/** 支持的输出 MIME 类型（与 Canvas toBlob 一致） */
+export type OutputMimeType = 'image/jpeg' | 'image/png' | 'image/webp';
+
+function getExtensionFromMime(mime: string): string {
+  const map: Record<string, string> = {
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+    'image/webp': 'webp',
+  };
+  return map[mime] ?? 'jpg';
+}
+
+/**
+ * 使用 Canvas 将图片绘制并导出为 Blob
+ */
+function processImageWithCanvas(
+  file: File,
+  options: {
+    outputFormat: OutputMimeType;
+    quality: number;
+    maxWidth?: number;
+    maxHeight?: number;
+    maintainAspectRatio: boolean;
+  },
+): Promise<{
+  blob: Blob;
+  originalWidth: number;
+  originalHeight: number;
+  width: number;
+  height: number;
+}> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const objectUrl = URL.createObjectURL(file);
+
+    img.onload = () => {
+      try {
+        const originalWidth = img.naturalWidth || img.width;
+        const originalHeight = img.naturalHeight || img.height;
+
+        const { width: targetWidth, height: targetHeight } =
+          options.maxWidth || options.maxHeight
+            ? calculateDisplayDimensions(
+                originalWidth,
+                originalHeight,
+                options.maxWidth,
+                options.maxHeight,
+                options.maintainAspectRatio,
+              )
+            : { width: originalWidth, height: originalHeight };
+
+        const canvas = document.createElement('canvas');
+        canvas.width = targetWidth;
+        canvas.height = targetHeight;
+
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          URL.revokeObjectURL(objectUrl);
+          reject(new Error('无法创建 Canvas 上下文'));
+          return;
+        }
+
+        ctx.drawImage(img, 0, 0, targetWidth, targetHeight);
+
+        canvas.toBlob(
+          blob => {
+            URL.revokeObjectURL(objectUrl);
+            if (!blob) {
+              reject(new Error('图片处理失败：无法生成 Blob'));
+              return;
+            }
+            resolve({
+              blob,
+              originalWidth,
+              originalHeight,
+              width: targetWidth,
+              height: targetHeight,
+            });
+          },
+          options.outputFormat,
+          options.quality,
+        );
+      } catch (error) {
+        URL.revokeObjectURL(objectUrl);
+        reject(
+          new Error(
+            `图片处理失败: ${error instanceof Error ? error.message : '未知错误'}`,
+          ),
+        );
+      }
+    };
+
+    img.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      reject(new Error('图片加载失败'));
+    };
+
+    img.src = objectUrl;
+  });
+}
+
+function buildResult(
+  file: File,
+  blob: Blob,
+  mimeType: string,
+  originalSize: number,
+  originalWidth: number,
+  originalHeight: number,
+  width: number,
+  height: number,
+): ImageProcessResult {
+  const ext = getExtensionFromMime(mimeType);
+  const baseName = file.name.replace(/\.[^/.]+$/, '');
+  const fileName = `${baseName}.${ext}`;
+  const processedFile = new File([blob], fileName, {
+    type: mimeType,
+    lastModified: Date.now(),
+  });
+  const uri = URL.createObjectURL(blob);
+  const processedSize = blob.size;
+  const compressionRatio = originalSize > 0 ? processedSize / originalSize : 1;
+
+  return {
+    uri,
+    blob,
+    file: processedFile,
+    originalSize,
+    processedSize,
+    compressionRatio,
+    width,
+    height,
+    originalWidth,
+    originalHeight,
+    mimeType,
+  };
+}
+
+/**
+ * Web 图片处理服务（纯 Canvas 实现）
+ */
+export class WebImageProcessorService {
+  /**
+   * 压缩图片（质量 + 可选尺寸）
+   * @param file 原始图片文件
+   * @param options 压缩选项
+   */
+  async compress(
+    file: File,
+    options: ImageCompressionOptions = {},
+  ): Promise<ImageProcessResult> {
+    const {
+      quality = DEFAULT_QUALITY,
+      maxWidth,
+      maxHeight,
+      maintainAspectRatio = true,
+      outputFormat = 'image/jpeg',
+      minSizeToCompress,
+    } = options;
+
+    if (minSizeToCompress != null && file.size < minSizeToCompress) {
+      const dims = await getImageDimensions(file);
+      const blob = new Blob([await file.arrayBuffer()], { type: file.type });
+      const uri = URL.createObjectURL(blob);
+      return {
+        uri,
+        blob,
+        file,
+        originalSize: file.size,
+        processedSize: file.size,
+        compressionRatio: 1,
+        width: dims.width,
+        height: dims.height,
+        originalWidth: dims.width,
+        originalHeight: dims.height,
+        mimeType: file.type,
+      };
+    }
+
+    const { blob, originalWidth, originalHeight, width, height } =
+      await processImageWithCanvas(file, {
+        outputFormat: outputFormat as OutputMimeType,
+        quality,
+        maxWidth,
+        maxHeight,
+        maintainAspectRatio,
+      });
+
+    return buildResult(
+      file,
+      blob,
+      outputFormat,
+      file.size,
+      originalWidth,
+      originalHeight,
+      width,
+      height,
+    );
+  }
+
+  /**
+   * 格式转换（可同时改尺寸与质量）
+   * @param file 原始图片文件
+   * @param outputFormat 目标 MIME 类型
+   * @param options 可选质量与尺寸
+   */
+  async convert(
+    file: File,
+    outputFormat: OutputMimeType,
+    options: ImageConversionOptions = {},
+  ): Promise<ImageProcessResult> {
+    const {
+      quality = DEFAULT_CONVERT_QUALITY,
+      maxWidth,
+      maxHeight,
+      maintainAspectRatio = true,
+    } = options;
+
+    const { blob, originalWidth, originalHeight, width, height } =
+      await processImageWithCanvas(file, {
+        outputFormat,
+        quality,
+        maxWidth,
+        maxHeight,
+        maintainAspectRatio,
+      });
+
+    return buildResult(
+      file,
+      blob,
+      outputFormat,
+      file.size,
+      originalWidth,
+      originalHeight,
+      width,
+      height,
+    );
+  }
+}
+
+/** 单例，供 Web/Desktop 直接使用 */
+export const webImageProcessorService = new WebImageProcessorService();

--- a/packages/common/src/services/index.ts
+++ b/packages/common/src/services/index.ts
@@ -9,3 +9,10 @@ export type {
   IOperationLogStorage,
   OperationLogServiceOptions,
 } from './operationLog';
+
+// 图片处理（Web/Desktop 纯 Web 实现，依赖 Canvas；移动端勿用）
+export {
+  WebImageProcessorService,
+  webImageProcessorService,
+  type OutputMimeType,
+} from './imageProcessor';

--- a/packages/common/src/types/image.ts
+++ b/packages/common/src/types/image.ts
@@ -88,3 +88,41 @@ export interface ImageCompressionResult {
   /** 压缩后尺寸 */
   compressedDimensions: { width: number; height: number };
 }
+
+/** 图片处理统一结果（压缩/转换共用，Web 端为 Blob URL + File） */
+export interface ImageProcessResult {
+  /** 可访问的 URL（Web 为 blob: 或 data:） */
+  uri: string;
+  /** 处理后的 Blob，便于上传或再处理 */
+  blob: Blob;
+  /** 处理后的 File，便于表单或下载 */
+  file: File;
+  /** 原始大小（字节） */
+  originalSize: number;
+  /** 处理后大小（字节） */
+  processedSize: number;
+  /** 压缩/体积变化比例（0–1，如 0.3 表示体积变为 30%） */
+  compressionRatio: number;
+  /** 处理后宽度 */
+  width: number;
+  /** 处理后高度 */
+  height: number;
+  /** 原始宽度 */
+  originalWidth: number;
+  /** 原始高度 */
+  originalHeight: number;
+  /** 输出 MIME 类型 */
+  mimeType: string;
+}
+
+/** 格式转换选项（与压缩选项兼容，用于 convert） */
+export interface ImageConversionOptions {
+  /** 质量 0–1，默认 0.9 */
+  quality?: number;
+  /** 最大宽度（像素） */
+  maxWidth?: number;
+  /** 最大高度（像素） */
+  maxHeight?: number;
+  /** 是否保持宽高比，默认 true */
+  maintainAspectRatio?: boolean;
+}


### PR DESCRIPTION
# 跨端图片处理方案与压缩/转换页实现

## 概述

本 PR 引入跨端图片处理的设计约定与 Web/Desktop 端压缩、转换页面实现，并明确 **packages/common** 在图片处理上的定位：**仅做契约与数据规范**，不包含平台抹平与具体实现逻辑。

## 变更摘要

### 1. 设计文档（`.github/02-design/02-cross-image-process.md`）

- **common 职责**：只做**数据格式统一与契约定义**（类型 + 接口形状），不做具体图片处理实现、不抹平平台差异。
- **使用层职责**：各端（apps/pixuli、apps/mobile）自行提供符合 common 契约的图片处理实现（如 Canvas、WASM、expo-image-manipulator），保证入参/出参符合 common 定义的类型。
- 文档结构：方案定位、common 与使用层职责、架构图、契约定义、当前实现情况、迁移方案、技术栈与附录。

### 2. packages/common

- **类型**（`src/types/image.ts`）：新增 `ImageProcessResult`、`ImageConversionOptions` 等，供三端统一使用。
- **图片处理服务**（`src/services/imageProcessor/`）：
  - `WebImageProcessorService`：基于 Canvas API 的 compress/convert 实现（当前供 Web/Desktop 使用）。
  - 导出 `webImageProcessorService` 单例及 `OutputMimeType`。
  - README 说明适用端与依赖约定（实现层依赖由使用方安装，common 以 peerDependency 声明为佳）。
- **导出**：在 `services/index.ts` 中导出上述服务与类型。

### 3. apps/pixuli（Web/Desktop）

- **压缩页**（`src/pages/compress/index.tsx`）：支持拖拽/选择图片，质量/尺寸/格式/最小压缩阈值等选项，压缩后结果列表（预览、体积比、下载）。
- **转换页**（`src/pages/convert/index.tsx`）：支持拖拽/选择图片，目标格式、质量、尺寸选项，转换后结果列表与下载。
- **国际化**：在 `src/i18n/locales/` 的 zh-CN.json、en-US.json 中新增 `compressPage`、`convertPage` 文案（与 operationLog 的 `compress`/`convert` 区分，避免 key 冲突）。

### 4. 其它修改

- apps/mobile：`HelpModal.tsx`、`README.md` 等文案或说明微调。
- packages/common：`empty-state`、`Sidebar` 等组件微调（若存在）。

## 设计要点

- **契约优先**：common 不关心各端用 Canvas 还是 WASM 还是原生，只约定「方法签名 + 返回类型」（如 `ImageProcessResult`），便于三端技术栈差异较大时仍能统一数据与接口。
- **后续迁移**：设计文档中说明可将 common 内现有 Web 实现迁至 apps/pixuli，common 仅保留类型与接口定义；本 PR 先保留现有实现以保障压缩/转换页可用。

## 如何验证

- 在 Web 或 Desktop 下打开「压缩」「转换」入口，上传或拖拽图片，设置选项后执行压缩/转换，检查结果列表与下载是否正常。
- 切换中英文，确认 compressPage/convertPage 相关文案显示正确。

## 合并说明

- 目标分支：`main`
- 建议合并后：按设计文档「迁移方案」逐步将具体实现迁出 common（可选），并让各端通过注入符合契约的处理器使用图片处理能力。
