### PR TITLE
refactor(m2): REF-206/207 apps 切换至 @pixuli/core + @pixuli/ui

### DIFF
--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -463,8 +463,8 @@ workspace 移除 wasm/benchmark；更新 README 去掉 Rust。
 | REF-203 | [M2] 迁移 L1/L2 组件至 ui（不含已删展示组件）                  | refactor, m2, area:ui, priority:P0                | P0     | #61, #48     | [#62](https://github.com/trueLoving/Pixuli/issues/62) | ✅   |
 | REF-204 | [M2] webImageProcessor 与 toast 迁入 ui                        | refactor, m2, area:ui, priority:P1                | P1     | #61          | [#69](https://github.com/trueLoving/Pixuli/issues/69) | ✅   |
 | REF-205 | [M2] index.native 停止导出 webImageProcessor                   | refactor, m2, area:core, priority:P0              | P0     | #60          | [#63](https://github.com/trueLoving/Pixuli/issues/63) | ✅   |
-| REF-206 | [M2] apps/pixuli 切换为 @pixuli/core + @pixuli/ui              | refactor, m2, area:web, area:desktop, priority:P0 | P0     | #62          | [#64](https://github.com/trueLoving/Pixuli/issues/64) | ⬜   |
-| REF-207 | [M2] apps/mobile 切换 import（core + ui/native）               | refactor, m2, area:mobile, priority:P0            | P0     | #60, #61     | [#65](https://github.com/trueLoving/Pixuli/issues/65) | ⬜   |
+| REF-206 | [M2] apps/pixuli 切换为 @pixuli/core + @pixuli/ui              | refactor, m2, area:web, area:desktop, priority:P0 | P0     | #62          | [#64](https://github.com/trueLoving/Pixuli/issues/64) | ✅   |
+| REF-207 | [M2] apps/mobile 切换 import（core + ui/native）               | refactor, m2, area:mobile, priority:P0            | P0     | #60, #61     | [#65](https://github.com/trueLoving/Pixuli/issues/65) | ✅   |
 | REF-208 | [M2] 保留 pixuli-common 兼容 re-export（deprecated）           | refactor, m2, priority:P1                         | P1     | #64, #65     | [#66](https://github.com/trueLoving/Pixuli/issues/66) | ⬜   |
 | REF-209 | [M2] ESLint 边界：禁止 core→ui、provider→ui                    | refactor, m2, priority:P2                         | P2     | #60          | [#67](https://github.com/trueLoving/Pixuli/issues/67) | ⬜   |
 | REF-210 | [M2] M2 回归与删除空壳 packages/common                         | refactor, m2, priority:P0                         | P0     | #64–#67, #69 | [#68](https://github.com/trueLoving/Pixuli/issues/68) | ⬜   |

--- a/apps/mobile/app/(tabs)/filter.tsx
+++ b/apps/mobile/app/(tabs)/filter.tsx
@@ -6,7 +6,7 @@ import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { useI18n } from '@/i18n/useI18n';
 import { useImageStore } from '@/stores/imageStore';
-import { ImageItem } from '@packages/common/src/index.native';
+import type { ImageItem } from '@pixuli/core/types';
 import { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -12,7 +12,8 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 import { useI18n } from '@/i18n/useI18n';
 import { useImageStore } from '@/stores/imageStore';
 import { useSourceStore } from '@/stores/sourceStore';
-import { EmptyState, ImageItem } from '@packages/common/src/index.native';
+import type { ImageItem } from '@pixuli/core/types';
+import { EmptyState } from '@pixuli/ui/native';
 import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
 import {

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -12,7 +12,7 @@ import {
   useThemeMode,
 } from '@/hooks/useColorScheme';
 import { useI18n, useInitLanguage } from '@/i18n/useI18n';
-import { VersionInfoModal } from '@packages/common/src/index.native';
+import { VersionInfoModal } from '@pixuli/ui/native';
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
 import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';

--- a/apps/mobile/components/image/ImageBrowser.tsx
+++ b/apps/mobile/components/image/ImageBrowser.tsx
@@ -1,7 +1,7 @@
 import { useI18n } from '@/i18n/useI18n';
 import { formatImageFileSize } from '@/utils/imageUtils';
 import { showError, showSuccess } from '@/utils/toast';
-import { ImageItem } from '@packages/common/src/index.native';
+import type { ImageItem } from '@pixuli/core/types';
 import * as Clipboard from 'expo-clipboard';
 import { Image } from 'expo-image';
 import * as Sharing from 'expo-sharing';

--- a/apps/mobile/components/image/ImageGrid.tsx
+++ b/apps/mobile/components/image/ImageGrid.tsx
@@ -1,4 +1,4 @@
-import { ImageItem } from '@packages/common/src/index.native';
+import type { ImageItem } from '@pixuli/core/types';
 import { Image } from 'expo-image';
 import {
   FlatList,

--- a/apps/mobile/components/image/modals/ImageEditModal.tsx
+++ b/apps/mobile/components/image/modals/ImageEditModal.tsx
@@ -1,5 +1,5 @@
 import { useI18n } from '@/i18n/useI18n';
-import { ImageEditData, ImageItem } from '@packages/common/src/index.native';
+import type { ImageEditData, ImageItem } from '@pixuli/core/types';
 import { useEffect, useState } from 'react';
 import {
   ActivityIndicator,

--- a/apps/mobile/components/settings/modals/StorageConfigModal.tsx
+++ b/apps/mobile/components/settings/modals/StorageConfigModal.tsx
@@ -4,7 +4,7 @@ import { useI18n } from '@/i18n/useI18n';
 import { useImageStore } from '@/stores/imageStore';
 import { useSourceStore } from '@/stores/sourceStore';
 import { showError, showSuccess } from '@/utils/toast';
-import { GitHubConfig, GiteeConfig } from '@packages/common/src/index.native';
+import type { GitHubConfig, GiteeConfig } from '@pixuli/core/types';
 import * as DocumentPicker from 'expo-document-picker';
 import { useEffect, useRef, useState } from 'react';
 import {

--- a/apps/mobile/config/gitee.ts
+++ b/apps/mobile/config/gitee.ts
@@ -1,4 +1,4 @@
-import { GiteeConfig } from '@packages/common/src/index.native';
+import type { GiteeConfig } from '@pixuli/core/types';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const GITEE_CONFIG_KEY = 'pixuli-gitee-config';

--- a/apps/mobile/config/github.ts
+++ b/apps/mobile/config/github.ts
@@ -1,4 +1,4 @@
-import { GitHubConfig } from '@packages/common/src/index.native';
+import type { GitHubConfig } from '@pixuli/core/types';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const GITHUB_CONFIG_KEY = 'pixuli-github-config';

--- a/apps/mobile/i18n/index.ts
+++ b/apps/mobile/i18n/index.ts
@@ -2,7 +2,7 @@ import * as Localization from 'expo-localization';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 // 直接从 locales 导入，避免导入 toast 相关的内容
-import { deepMerge, enUS, zhCN } from '@packages/common/src/index.native';
+import { deepMerge, enUS, zhCN } from '@pixuli/ui/locales';
 // 导入移动端语言包
 import { mobileLocales } from './locales';
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -39,6 +39,8 @@
     "expo-system-ui": "~6.0.9",
     "i18next": "^25.6.0",
     "octokit": "3.1.2",
+    "@pixuli/core": "workspace:*",
+    "@pixuli/ui": "workspace:*",
     "pixuli-common": "workspace:*",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/mobile/services/logService.ts
+++ b/apps/mobile/services/logService.ts
@@ -6,7 +6,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   OperationLogService,
   type IOperationLogStorage,
-} from '@packages/common/src/index.native';
+} from '@pixuli/core/operation-log';
 
 const STORAGE_KEY = 'pixuli-operation-logs';
 

--- a/apps/mobile/stores/imageStore.ts
+++ b/apps/mobile/stores/imageStore.ts
@@ -1,14 +1,16 @@
-import {
+import type {
   BatchUploadProgress,
   GitHubConfig,
-  GitHubStorageService,
   GiteeConfig,
-  GiteeStorageService,
   ImageEditData,
   ImageItem,
   MultiImageUploadData,
   UploadProgress,
-} from '@packages/common/src/index.native';
+} from '@pixuli/core/types';
+import {
+  GitHubStorageService,
+  GiteeStorageService,
+} from 'pixuli-common/services/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { create } from 'zustand';
 import {

--- a/apps/mobile/types/log.ts
+++ b/apps/mobile/types/log.ts
@@ -8,5 +8,5 @@ export type {
   LogStatistics,
   OperationLogAddOptions,
   OperationLogClearOptions,
-} from '@packages/common/src/index.native';
-export { LogActionType, LogStatus } from '@packages/common/src/index.native';
+} from '@pixuli/core/types';
+export { LogActionType, LogStatus } from '@pixuli/core/types';

--- a/apps/mobile/utils/metadataCache.ts
+++ b/apps/mobile/utils/metadataCache.ts
@@ -1,5 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { ImageItem } from '@packages/common/src/index.native';
+import type { ImageItem } from '@pixuli/core/types';
 
 const METADATA_CACHE_KEY_PREFIX = 'pixuli-metadata-cache';
 const METADATA_CACHE_VERSION = '1.0';

--- a/apps/pixuli/package.json
+++ b/apps/pixuli/package.json
@@ -26,6 +26,8 @@
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.556.0",
     "octokit": "3.1.2",
+    "@pixuli/core": "workspace:*",
+    "@pixuli/ui": "workspace:*",
     "pixuli-common": "workspace:*",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/pixuli/src/App.tsx
+++ b/apps/pixuli/src/App.tsx
@@ -1,4 +1,4 @@
-import { useDemoMode } from '@packages/common/src';
+import { useDemoMode } from '@pixuli/ui';
 import { useCallback, useMemo } from 'react';
 import './App.css';
 import { SearchProvider } from './contexts/SearchContext';

--- a/apps/pixuli/src/config/gitee.ts
+++ b/apps/pixuli/src/config/gitee.ts
@@ -1,4 +1,4 @@
-import { GiteeConfig } from '@packages/common/src';
+import type { GiteeConfig } from '@pixuli/core/types';
 
 const GITEE_CONFIG_KEY = 'pixuli-gitee-config';
 

--- a/apps/pixuli/src/config/github.ts
+++ b/apps/pixuli/src/config/github.ts
@@ -1,4 +1,4 @@
-import { GitHubConfig } from '@packages/common/src';
+import type { GitHubConfig } from '@pixuli/core/types';
 
 const GITHUB_CONFIG_KEY = 'pixuli-github-config';
 

--- a/apps/pixuli/src/contexts/SearchContext.tsx
+++ b/apps/pixuli/src/contexts/SearchContext.tsx
@@ -11,7 +11,8 @@ import React, {
   useEffect,
   useCallback,
 } from 'react';
-import { FilterOptions, createDefaultFilters } from '@packages/common/src';
+import type { FilterOptions } from '@pixuli/ui';
+import { createDefaultFilters } from '@pixuli/core/utils';
 import {
   getSearchHistory,
   addSearchHistory,

--- a/apps/pixuli/src/features/image-content/ImageContent.tsx
+++ b/apps/pixuli/src/features/image-content/ImageContent.tsx
@@ -1,9 +1,5 @@
-import {
-  EmptyState,
-  formatFileSize,
-  getImageDimensionsFromUrl,
-  ImageBrowser,
-} from '@packages/common/src';
+import { EmptyState, ImageBrowser } from '@pixuli/ui';
+import { formatFileSize, getImageDimensionsFromUrl } from '@pixuli/core/utils';
 import { RefreshCw } from 'lucide-react';
 import React from 'react';
 import { useImageStore } from '../../stores/imageStore';

--- a/apps/pixuli/src/features/operation-log/OperationLogModal.tsx
+++ b/apps/pixuli/src/features/operation-log/OperationLogModal.tsx
@@ -1,6 +1,6 @@
 import { LogActionType, LogStatus, LogFilter } from '@/types/log';
 import { useLogStore } from '@/stores/logStore';
-import { showError, showSuccess } from '@packages/common/src';
+import { showError, showSuccess } from '@pixuli/ui/feedback/toast';
 import {
   Calendar,
   Download,

--- a/apps/pixuli/src/hooks/useAppInitialization.ts
+++ b/apps/pixuli/src/hooks/useAppInitialization.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { getDemoGitHubConfig, getDemoGiteeConfig } from '@packages/common/src';
+import { getDemoGitHubConfig, getDemoGiteeConfig } from '@pixuli/ui';
 import { useImageStore } from '../stores/imageStore';
 import { useSourceStore } from '../stores/sourceStore';
 

--- a/apps/pixuli/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/pixuli/src/hooks/useKeyboardShortcuts.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { keyboardManager } from '@packages/common/src';
+import { keyboardManager } from '@pixuli/ui';
 import { createKeyboardShortcuts } from '../utils/keyboardShortcuts';
 
 /**

--- a/apps/pixuli/src/hooks/useUIState.ts
+++ b/apps/pixuli/src/hooks/useUIState.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import type { SidebarView, SidebarUtilityTool } from '@packages/common/src';
+import type { SidebarView, SidebarUtilityTool } from '@pixuli/ui';
 import { useImageStore } from '../stores/imageStore';
 
 /**

--- a/apps/pixuli/src/i18n/index.ts
+++ b/apps/pixuli/src/i18n/index.ts
@@ -2,7 +2,7 @@ import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 // 导入packages/ui的语言包
-import { deepMerge, enUS, zhCN } from '@packages/common/src';
+import { deepMerge, enUS, zhCN } from '@pixuli/ui/locales';
 // 导入桌面端功能模块语言包
 import { operationLogLocales } from '../features';
 import { desktopLocales } from './locales';

--- a/apps/pixuli/src/i18n/useI18n.ts
+++ b/apps/pixuli/src/i18n/useI18n.ts
@@ -1,4 +1,4 @@
-import { updateAllToasts } from '@packages/common/src';
+import { updateAllToasts } from '@pixuli/ui/feedback/toast';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/apps/pixuli/src/layouts/AppMain.tsx
+++ b/apps/pixuli/src/layouts/AppMain.tsx
@@ -11,9 +11,8 @@ import {
   Search,
   UploadButton,
   useDemoMode,
-  type ImageUploadData,
-  type MultiImageUploadData,
-} from '@packages/common/src';
+} from '@pixuli/ui';
+import type { ImageUploadData, MultiImageUploadData } from '@pixuli/core/types';
 import { ScrollText } from 'lucide-react';
 import React from 'react';
 import { useLocation } from 'react-router-dom';

--- a/apps/pixuli/src/layouts/MainLayout.tsx
+++ b/apps/pixuli/src/layouts/MainLayout.tsx
@@ -11,10 +11,9 @@ import {
   Toaster,
   useDemoMode,
   VersionInfoModal,
-  type ImageUploadData,
-  type MultiImageUploadData,
-  type VersionInfo,
-} from '@packages/common/src';
+} from '@pixuli/ui';
+import type { VersionInfo } from '@pixuli/ui';
+import type { ImageUploadData, MultiImageUploadData } from '@pixuli/core/types';
 import React from 'react';
 import {
   OfflineIndicator,

--- a/apps/pixuli/src/layouts/Sidebar.tsx
+++ b/apps/pixuli/src/layouts/Sidebar.tsx
@@ -3,10 +3,7 @@
  * 处理侧边栏的显示和交互逻辑
  */
 
-import {
-  Sidebar as CommonSidebar,
-  type SidebarMenuItem,
-} from '@packages/common/src';
+import { Sidebar as CommonSidebar, type SidebarMenuItem } from '@pixuli/ui';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '../router/routes';

--- a/apps/pixuli/src/pages/compress/index.tsx
+++ b/apps/pixuli/src/pages/compress/index.tsx
@@ -1,9 +1,9 @@
-import {
-  formatFileSize,
-  webImageProcessorService,
-  type ImageCompressionOptions,
-  type ImageProcessResult,
-} from '@packages/common/src';
+import type {
+  ImageCompressionOptions,
+  ImageProcessResult,
+} from '@pixuli/core/types';
+import { formatFileSize } from '@pixuli/core/utils';
+import { webImageProcessorService } from '@pixuli/ui/services/imageProcessor';
 import { Download, ImageIcon, Loader2, Trash2 } from 'lucide-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useI18n } from '@/i18n/useI18n';

--- a/apps/pixuli/src/pages/convert/index.tsx
+++ b/apps/pixuli/src/pages/convert/index.tsx
@@ -1,9 +1,9 @@
+import type { ImageProcessResult } from '@pixuli/core/types';
+import { formatFileSize } from '@pixuli/core/utils';
 import {
-  formatFileSize,
   webImageProcessorService,
-  type ImageProcessResult,
   type OutputMimeType,
-} from '@packages/common/src';
+} from '@pixuli/ui/services/imageProcessor';
 import { Download, ImageIcon, Loader2, Trash2 } from 'lucide-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useI18n } from '@/i18n/useI18n';

--- a/apps/pixuli/src/pages/photos/index.tsx
+++ b/apps/pixuli/src/pages/photos/index.tsx
@@ -4,7 +4,7 @@ import { useImageOperations } from '@/hooks/useImageOperations';
 import { useI18n } from '@/i18n/useI18n';
 import { useImageStore } from '@/stores/imageStore';
 import { useSourceStore } from '@/stores/sourceStore';
-import { createDefaultFilters, filterImages } from '@packages/common/src';
+import { createDefaultFilters, filterImages } from '@pixuli/core/utils';
 import React, { useEffect, useMemo, useRef } from 'react';
 
 interface PhotosPageProps {

--- a/apps/pixuli/src/services/logService.ts
+++ b/apps/pixuli/src/services/logService.ts
@@ -5,7 +5,7 @@
 import {
   OperationLogService,
   type IOperationLogStorage,
-} from '@packages/common/src';
+} from '@pixuli/core/operation-log';
 
 const STORAGE_KEY = 'pixuli-operation-logs';
 

--- a/apps/pixuli/src/stores/imageStore.ts
+++ b/apps/pixuli/src/stores/imageStore.ts
@@ -11,10 +11,10 @@ import {
 import {
   GiteeStorageService,
   GitHubStorageService,
-} from '@packages/common/src';
+} from 'pixuli-common/services';
 import { LogActionType, LogStatus } from '@/types/log';
 import { useLogStore } from '@/stores/logStore';
-import {
+import type {
   BatchUploadProgress,
   GiteeConfig,
   GitHubConfig,
@@ -23,7 +23,7 @@ import {
   ImageUploadData,
   MultiImageUploadData,
   UploadProgress,
-} from '@packages/common/src';
+} from '@pixuli/core/types';
 import { create } from 'zustand';
 
 interface ImageState {

--- a/apps/pixuli/src/types/log.ts
+++ b/apps/pixuli/src/types/log.ts
@@ -8,5 +8,5 @@ export type {
   LogStatistics,
   OperationLogAddOptions,
   OperationLogClearOptions,
-} from '@packages/common/src';
-export { LogActionType, LogStatus } from '@packages/common/src';
+} from '@pixuli/core/types';
+export { LogActionType, LogStatus } from '@pixuli/core/types';

--- a/apps/pixuli/src/utils/keyboardShortcuts.ts
+++ b/apps/pixuli/src/utils/keyboardShortcuts.ts
@@ -1,4 +1,4 @@
-import { COMMON_SHORTCUTS, SHORTCUT_CATEGORIES } from '@packages/common/src';
+import { COMMON_SHORTCUTS, SHORTCUT_CATEGORIES } from '@pixuli/ui';
 
 // 键盘快捷键配置
 export const createKeyboardShortcuts = (t: (key: string) => string) => [

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -2,9 +2,15 @@
   "name": "pixuli-common",
   "version": "1.0.0",
   "description": "Pixuli common",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./native": "./src/index.native.ts",
+    "./services": "./src/services/index.ts",
+    "./services/native": "./src/services/index.native.ts"
+  },
   "files": ["dist", "README.md", "src", "docs"],
   "publishConfig": {
     "access": "public"

--- a/packages/core/src/types/image-browser.ts
+++ b/packages/core/src/types/image-browser.ts
@@ -1,0 +1,14 @@
+/**
+ * 图片浏览/筛选相关共享类型（Web / Mobile）
+ */
+
+export interface FilterOptions {
+  searchTerm: string;
+  selectedTypes: string[];
+  selectedTags: string[];
+}
+
+export type SortField = 'createdAt' | 'name' | 'size';
+export type SortOrder = 'asc' | 'desc';
+
+export type ViewMode = 'grid' | 'list';

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './image';
+export * from './image-browser';
 export * from './github';
 export * from './gitee';
 export * from './log';

--- a/packages/core/src/utils/__tests__/filterUtils.test.ts
+++ b/packages/core/src/utils/__tests__/filterUtils.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { filterImages, createDefaultFilters } from '../filterUtils';
 import type { ImageItem } from '../../types/image';
-import type { FilterOptions } from '../../components/image/image-browser/common/types';
+import type { FilterOptions } from '../../types/image-browser';
 
 const mockImages: ImageItem[] = [
   {

--- a/packages/core/src/utils/filterUtils.ts
+++ b/packages/core/src/utils/filterUtils.ts
@@ -1,5 +1,5 @@
 import type { ImageItem } from '../types/image';
-import type { FilterOptions } from '../components/image/image-browser/common/types';
+import type { FilterOptions } from '../types/image-browser';
 
 /**
  * 根据筛选条件过滤图片数组

--- a/packages/core/src/utils/sortUtils.ts
+++ b/packages/core/src/utils/sortUtils.ts
@@ -1,8 +1,5 @@
 import type { ImageItem } from '../types/image';
-import type {
-  SortField,
-  SortOrder,
-} from '../components/image/image-browser/common/types';
+import type { SortField, SortOrder } from '../types/image-browser';
 
 /**
  * 对图片数组进行排序

--- a/packages/ui/src/image/image-browser/common/types.ts
+++ b/packages/ui/src/image/image-browser/common/types.ts
@@ -1,14 +1,9 @@
 /**
- * ImageBrowser 组件共享类型定义
+ * ImageBrowser 组件共享类型（定义在 @pixuli/core，此处 re-export）
  */
-
-export interface FilterOptions {
-  searchTerm: string;
-  selectedTypes: string[];
-  selectedTags: string[];
-}
-
-export type SortField = 'createdAt' | 'name' | 'size';
-export type SortOrder = 'asc' | 'desc';
-
-export type ViewMode = 'grid' | 'list';
+export type {
+  FilterOptions,
+  SortField,
+  SortOrder,
+  ViewMode,
+} from '@pixuli/core/types';

--- a/packages/ui/src/web/index.ts
+++ b/packages/ui/src/web/index.ts
@@ -44,7 +44,6 @@ export {
   keyboardManager,
   COMMON_SHORTCUTS,
   SHORTCUT_CATEGORIES,
-  createKeyboardShortcuts,
 } from '../utils/keyboardShortcuts';
 export type {
   KeyboardShortcut,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,12 @@ importers:
       '@expo/vector-icons':
         specifier: ^15.0.3
         version: 15.0.3(expo-font@14.0.11(expo@54.0.32)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.82.0(@babel/core@7.28.5))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.82.0(@babel/core@7.28.5))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@pixuli/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@pixuli/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@react-native-async-storage/async-storage':
         specifier: ^2.1.0
         version: 2.2.0(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.82.0(@babel/core@7.28.5))(@types/react@19.1.17)(react@19.1.0))
@@ -186,6 +192,12 @@ importers:
 
   apps/pixuli:
     dependencies:
+      '@pixuli/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@pixuli/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       i18next:
         specifier: ^25.6.0
         version: 25.6.0(typescript@5.9.3)


### PR DESCRIPTION
## Summary

### REF-206（apps/pixuli）
- 新增依赖 `@pixuli/core`、`@pixuli/ui`
- 移除全部 `@packages/common/src` 引用：类型/筛选/日志 → core；组件/toast/快捷键/locales/图片处理 → ui
- GitHub/Gitee 存储服务暂经 `pixuli-common/services`

### REF-207（apps/mobile）
- 新增依赖 `@pixuli/core`、`@pixuli/ui`
- 类型与操作日志 → `@pixuli/core`；`EmptyState` / `VersionInfoModal` → `@pixuli/ui/native`；locales → `@pixuli/ui/locales`
- 存储服务 → `pixuli-common/services/native`（不含 webImageProcessor）

### 配套
- `pixuli-common` 补充 `exports` 子路径（`./services`、`./services/native` 等）
- `@pixuli/core` 新增 `types/image-browser.ts`，修复 `filterUtils` / `sortUtils` 类型引用

Closes #64
Closes #65

## Test plan

- [x] `pnpm test`（504 tests）
- [x] `pnpm run build:web`
- [x] `pnpm --filter pixuli-app exec tsc --noEmit`
- [x] `pnpm --filter pixuli-mobile exec tsc --noEmit`


Made with [Cursor](https://cursor.com)