### PR TITLE
refactor(m2): REF-208/209 common deprecated 兼容层与 ESLint 包边界

### DIFF
--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -465,8 +465,8 @@ workspace 移除 wasm/benchmark；更新 README 去掉 Rust。
 | REF-205 | [M2] index.native 停止导出 webImageProcessor                   | refactor, m2, area:core, priority:P0              | P0     | #60          | [#63](https://github.com/trueLoving/Pixuli/issues/63) | ✅   |
 | REF-206 | [M2] apps/pixuli 切换为 @pixuli/core + @pixuli/ui              | refactor, m2, area:web, area:desktop, priority:P0 | P0     | #62          | [#64](https://github.com/trueLoving/Pixuli/issues/64) | ✅   |
 | REF-207 | [M2] apps/mobile 切换 import（core + ui/native）               | refactor, m2, area:mobile, priority:P0            | P0     | #60, #61     | [#65](https://github.com/trueLoving/Pixuli/issues/65) | ✅   |
-| REF-208 | [M2] 保留 pixuli-common 兼容 re-export（deprecated）           | refactor, m2, priority:P1                         | P1     | #64, #65     | [#66](https://github.com/trueLoving/Pixuli/issues/66) | ⬜   |
-| REF-209 | [M2] ESLint 边界：禁止 core→ui、provider→ui                    | refactor, m2, priority:P2                         | P2     | #60          | [#67](https://github.com/trueLoving/Pixuli/issues/67) | ⬜   |
+| REF-208 | [M2] 保留 pixuli-common 兼容 re-export（deprecated）           | refactor, m2, priority:P1                         | P1     | #64, #65     | [#66](https://github.com/trueLoving/Pixuli/issues/66) | ✅   |
+| REF-209 | [M2] ESLint 边界：禁止 core→ui、provider→ui                    | refactor, m2, priority:P2                         | P2     | #60          | [#67](https://github.com/trueLoving/Pixuli/issues/67) | ✅   |
 | REF-210 | [M2] M2 回归与删除空壳 packages/common                         | refactor, m2, priority:P0                         | P0     | #64–#67, #69 | [#68](https://github.com/trueLoving/Pixuli/issues/68) | ⬜   |
 
 <details>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,117 @@
+import importPlugin from 'eslint-plugin-import';
+import tseslint from 'typescript-eslint';
+
+/** REF-209：core / provider 包不得依赖 UI 层 */
+const noUiDependencyRules = {
+  'no-restricted-imports': [
+    'error',
+    {
+      patterns: [
+        {
+          group: ['@pixuli/ui', '@pixuli/ui/*'],
+          message:
+            '不得依赖 @pixuli/ui：业务内核与 provider 包应保持无 UI 依赖（REF-209）',
+        },
+      ],
+    },
+  ],
+  'import/no-restricted-paths': [
+    'error',
+    {
+      zones: [
+        {
+          target: './packages/core',
+          from: './packages/ui',
+          message:
+            '不得从 packages/ui 引用：@pixuli/core 与 @pixuli/ui 分层（REF-209）',
+        },
+        {
+          target: './packages/core',
+          from: './packages/ui/**',
+          message:
+            '不得从 packages/ui 引用：@pixuli/core 与 @pixuli/ui 分层（REF-209）',
+        },
+      ],
+    },
+  ],
+};
+
+const providerNoUiRules = {
+  'no-restricted-imports': [
+    'error',
+    {
+      patterns: [
+        {
+          group: ['@pixuli/ui', '@pixuli/ui/*'],
+          message:
+            '不得依赖 @pixuli/ui：provider 包应保持无 UI 依赖（REF-209）',
+        },
+      ],
+    },
+  ],
+  'import/no-restricted-paths': [
+    'error',
+    {
+      zones: [
+        {
+          target: './packages/provider-github',
+          from: './packages/ui',
+          message:
+            '不得从 packages/ui 引用：provider 与 ui 分层（REF-209）',
+        },
+        {
+          target: './packages/provider-github',
+          from: './packages/ui/**',
+          message:
+            '不得从 packages/ui 引用：provider 与 ui 分层（REF-209）',
+        },
+        {
+          target: './packages/provider-gitee',
+          from: './packages/ui',
+          message:
+            '不得从 packages/ui 引用：provider 与 ui 分层（REF-209）',
+        },
+        {
+          target: './packages/provider-gitee',
+          from: './packages/ui/**',
+          message:
+            '不得从 packages/ui 引用：provider 与 ui 分层（REF-209）',
+        },
+      ],
+    },
+  ],
+};
+
+const tsLanguageOptions = {
+  parser: tseslint.parser,
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+};
+
+export default tseslint.config(
+  {
+    ignores: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/dist-electron/**',
+      '**/build/**',
+      '**/.expo/**',
+      'archive/**',
+      '**/coverage/**',
+    ],
+  },
+  {
+    files: ['packages/core/**/*.{ts,tsx}'],
+    languageOptions: tsLanguageOptions,
+    plugins: { import: importPlugin },
+    rules: noUiDependencyRules,
+  },
+  {
+    files: ['packages/provider-*/**/*.{ts,tsx}'],
+    languageOptions: tsLanguageOptions,
+    plugins: { import: importPlugin },
+    rules: providerNoUiRules,
+  },
+);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "dev:desktop": "pnpm run --filter pixuli-app dev:desktop",
     "build:desktop": "pnpm run --filter pixuli-app build:desktop",
     "test": "vitest run",
-    "ci": "pnpm test && pnpm run build:web && pnpm --filter pixuli-app exec tsc && pnpm --filter pixuli-app exec vite build --mode desktop && pnpm --filter pixuli-mobile exec tsc --noEmit",
+    "lint": "eslint packages/core",
+    "lint:boundaries": "eslint packages/core",
+    "ci": "pnpm lint:boundaries && pnpm test && pnpm run build:web && pnpm --filter pixuli-app exec tsc && pnpm --filter pixuli-app exec vite build --mode desktop && pnpm --filter pixuli-mobile exec tsc --noEmit",
     "prepare": "husky"
   },
   "keywords": [
@@ -34,7 +36,10 @@
     "husky": "^9.1.7",
     "jsdom": "^25.0.1",
     "lint-staged": "^16.2.5",
+    "eslint": "^9.25.0",
+    "eslint-plugin-import": "^2.31.0",
     "prettier": "^3.0.0",
+    "typescript-eslint": "^8.30.0",
     "vitest": "^2.1.8"
   },
   "lint-staged": {

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,283 +1,35 @@
-# Pixuli Common
+# pixuli-common（兼容层，已废弃）
 
-Pixuli Common is the shared library for the Pixuli project, providing common
-React components, Hooks, utility functions, and services across three platforms
-(Web, Desktop, Mobile).
+> **@deprecated** 本包仅用于 M2 迁移期的兼容 re-export。新代码请使用
+> [`@pixuli/core`](../core/README.md) 与 [`@pixuli/ui`](../ui/README.md)。
 
-## 📦 Installation
+## 迁移对照
 
-```bash
-# Use in monorepo
-pnpm add pixuli-common
+| 原 `pixuli-common` 用法                       | 请改用                                                                             |
+| --------------------------------------------- | ---------------------------------------------------------------------------------- |
+| 类型（`ImageItem`、`GitHubConfig` 等）        | `@pixuli/core/types`                                                               |
+| 工具（`filterImages`、`formatFileSize` 等）   | `@pixuli/core/utils`                                                               |
+| 操作日志                                      | `@pixuli/core/operation-log`                                                       |
+| Web UI 组件、toast、快捷键、locales           | `@pixuli/ui` 及子路径                                                              |
+| Native UI（`EmptyState`、`VersionInfoModal`） | `@pixuli/ui/native`                                                                |
+| Web 图片处理                                  | `@pixuli/ui/services/imageProcessor`                                               |
+| GitHub/Gitee 存储服务                         | `pixuli-common/services` 或 `pixuli-common/services/native`（M3 迁至 provider 包） |
 
-# Or import directly from source
-import { ImageBrowser } from 'pixuli-common/src'
-```
+## 入口
 
-## 🚀 Feature Modules
+| 路径                            | 说明                                                        |
+| ------------------------------- | ----------------------------------------------------------- |
+| `pixuli-common`                 | Web/Desktop barrel（deprecated）                            |
+| `pixuli-common/native`          | React Native barrel（deprecated，不含 `webImageProcessor`） |
+| `pixuli-common/services`        | 存储与日志服务（Web）                                       |
+| `pixuli-common/services/native` | 存储与日志服务（Mobile）                                    |
 
-### Components
-
-Components are organized by functionality for easy discovery and maintenance:
-
-#### 📷 Image Components (`components/image/`)
-
-- **ImageBrowser** - Main image browser component
-- **ImageGrid** - Image grid view
-- **ImageList** - Image list view
-- **ImageSorter** - Image sorter
-- **ImagePreviewModal** - Image preview modal
-- **ImageUrlModal** - Image URL modal
-- **ImageEditModal** - Image edit modal
-- **ImageUpload** - Image upload component
-- **ImageCropModal** - Image crop modal
-- **PhotoWall** - Photo wall component
-- **Gallery3D** - 3D gallery component
-- **Timeline** - Timeline component
-
-#### 🎨 Layout Components (`components/layout/`)
-
-- **Sidebar** - Sidebar component
-- **Header** - Header component
-- **EmptyState** - Empty state component
-
-#### ⚙️ Config Components (`components/config/`)
-
-- **GitHubConfigModal** - GitHub configuration modal
-- **GiteeConfigModal** - Gitee configuration modal
-
-#### 🎯 UI Components (`components/ui/`)
-
-- **Search** - Search component
-- **Toaster** - Toast notification component
-- **UploadButton** - Upload button component
-- **RefreshButton** - Refresh button component
-- **ActionButton** - Action button component
-- **KeyboardHelpModal** - Keyboard shortcuts help modal
-- **LanguageSwitcher** - Language switcher
-- **FullScreenLoading** - Full-screen loading component
-
-#### 🚀 Feature Components (`components/features/`)
-
-- **SlideShowPlayer** - Slideshow player
-- **SlideShowSettings** - Slideshow settings
-- **BrowseModeSwitcher** - Browse mode switcher
-- **VersionInfoModal** - Version info modal
-
-#### 🛠️ Development Tools (`components/dev/`)
-
-- **Demo** - Demo component
-- **DevTools** - Development tools component
-
-### Hooks
-
-- **useVirtualScroll** - Virtual scroll Hook
-- **useLazyLoad** - Lazy load Hook
-- **useInfiniteScroll** - Infinite scroll Hook
-- **useImageDimensions** - Image dimensions Hook
-- **useImageInfo** - Image info Hook
-- **useImageDimensionsFromUrl** - Get image dimensions from URL Hook
-- **useKeyboard** - Keyboard event Hook
-- **useKeyboardShortcut** - Keyboard shortcut Hook
-- **useKeyboardMultiple** - Multiple key listener Hook
-- **useEscapeKey** - Escape key Hook
-- **useEnterKey** - Enter key Hook
-- **useArrowKeys** - Arrow keys Hook
-- **useNumberKeys** - Number keys Hook
-- **useLetterKeys** - Letter keys Hook
-
-### Utility Functions
-
-- **toast** - Toast notification utility
-- **fileSizeUtils** - File size formatting utility
-- **filterUtils** - Filter utility functions
-- **imageUtils** - Image processing utilities (compression, conversion,
-  dimension retrieval, etc.)
-- **keyboardShortcuts** - Keyboard shortcut management system
-- **sortUtils** - Sorting utility functions
-- **dateUtils** - Date utility functions
-
-### Services
-
-- **GiteeStorageService** - Gitee storage service
-- **GitHubStorageService** - GitHub storage service
-
-### Type Definitions
-
-- **image.ts** - Image-related types
-- **github.ts** - GitHub-related types
-- **gitee.ts** - Gitee-related types
-
-### Internationalization (Locales)
-
-- Supports Chinese (zh-CN) and English (en-US)
-- Provides locale merging and default translation functionality
-
-## 📝 Usage Examples
-
-### Basic Component Usage
-
-```tsx
-import {
-  ImageBrowser,
-  ImageUpload,
-  Search,
-  Sidebar,
-  Header,
-} from 'pixuli-common';
-
-function App() {
-  return (
-    <>
-      <Header />
-      <Sidebar />
-      <Search searchQuery={query} onSearchChange={setQuery} variant="header" />
-      <ImageBrowser images={images} />
-      <ImageUpload onUpload={handleUpload} />
-    </>
-  );
-}
-```
-
-### Hooks Usage
-
-```tsx
-import { useImageDimensions, useKeyboard } from 'pixuli-common';
-
-function MyComponent() {
-  const { dimensions, loading } = useImageDimensions(file);
-  const { isPressed } = useKeyboard('Escape', () => {
-    // Handle Escape key
-  });
-
-  return <div>...</div>;
-}
-```
-
-### Utility Functions Usage
-
-```tsx
-import { formatFileSize, compressImage, keyboardManager } from 'pixuli-common';
-
-// Format file size
-const size = formatFileSize(1024 * 1024); // "1 MB"
-
-// Compress image
-const compressed = await compressImage(file, { quality: 0.8 });
-
-// Register keyboard shortcut
-keyboardManager.register({
-  key: 's',
-  ctrlKey: true,
-  description: 'Save',
-  action: () => save(),
-  category: 'General',
-});
-```
-
-## 🛠️ Development
-
-### Build
+## 开发
 
 ```bash
-pnpm build
+pnpm --filter pixuli-common test
 ```
 
-### Development Mode (Watch File Changes)
-
-```bash
-pnpm dev
-```
-
-### Testing
-
-```bash
-# Run tests
-pnpm test
-
-# Watch mode
-pnpm test:watch
-
-# UI mode
-pnpm test:ui
-
-# Coverage
-pnpm test:coverage
-```
-
-## 📊 Test Coverage
-
-The package includes comprehensive unit tests covering:
-
-- ✅ All Hooks (6)
-- ✅ All utility functions (7)
-- ✅ Component functionality tests (27 test files, 632 test cases)
-
-Tests use Vitest + React Testing Library with jsdom environment.
-
-## 📁 Directory Structure
-
-Components are organized by functionality with a clear structure:
-
-```
-components/
-├── layout/              # Layout components (3)
-│   ├── sidebar/
-│   ├── header/
-│   └── empty-state/
-├── image/               # Image-related components (6)
-│   ├── image-browser/
-│   ├── image-upload/
-│   ├── image-preview-modal/
-│   ├── photo-wall/
-│   ├── gallery-3d/
-│   └── timeline/
-├── config/              # Config-related components (2)
-│   ├── github-config/
-│   └── gitee-config/
-├── ui/                  # General UI components (8)
-│   ├── search/
-│   ├── toaster/
-│   ├── upload-button/
-│   ├── refresh-button/
-│   ├── action-button/
-│   ├── language-switcher/
-│   ├── keyboard-help/
-│   └── fullscreen-loading/
-├── features/            # Feature components (3)
-│   ├── slide-show/
-│   ├── browse-mode-switcher/
-│   └── version-info/
-└── dev/                 # Development tools (2)
-    ├── demo/
-    └── devtools/
-```
-
-Each component directory structure:
-
-```
-component-name/
-├── locales/             # Internationalization files (use plural form)
-│   ├── index.ts
-│   ├── zh-CN.json
-│   └── en-US.json
-├── common/              # Cross-platform shared code (optional)
-│   ├── types.ts
-│   ├── hooks.ts
-│   └── utils.ts
-├── web/                 # Web platform implementation
-│   ├── index.ts
-│   ├── ComponentName.tsx
-│   └── ComponentName.css
-└── native/              # React Native implementation (optional)
-    ├── index.ts
-    └── ComponentName.native.tsx
-```
-
-## 📄 License
+## License
 
 MIT
-
-## 👤 Author
-
-trueLoving

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pixuli-common",
   "version": "1.0.0",
-  "description": "Pixuli common",
+  "description": "Pixuli common — deprecated compatibility re-exports; use @pixuli/core and @pixuli/ui",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/common/src/index.native.ts
+++ b/packages/common/src/index.native.ts
@@ -1,10 +1,8 @@
 /**
  * @fileoverview React Native 平台专用导出文件
- * 此文件用于 React Native 移动应用的统一导出入口
- * Web/Desktop 应用请使用 index.ts
+ * @deprecated 请改用 `@pixuli/core`、`@pixuli/ui/native` 及 `pixuli-common/services/native`
  *
- * 注意：此文件仅导出 React Native 环境可用的组件和工具
- * Web 专用组件（如 Sidebar、Header 等）不会在此文件中导出
+ * Web/Desktop 应用请使用 `index.ts`（同样已 deprecated）。
  */
 
 // ==================== 类型导出（@pixuli/core） ====================

--- a/packages/common/src/locales/index.ts
+++ b/packages/common/src/locales/index.ts
@@ -1,1 +1,4 @@
+/**
+ * @deprecated 请改用 `@pixuli/ui/locales`
+ */
 export * from '@pixuli/ui/locales';

--- a/packages/common/src/services/index.native.ts
+++ b/packages/common/src/services/index.native.ts
@@ -1,7 +1,8 @@
 /**
- * React Native 可用的 services（不含 Web Canvas 图片处理）
+ * React Native 可用的 services（不含 Web Canvas 图片处理）。
+ *
+ * @deprecated 类型与操作日志请用 `@pixuli/core`；存储服务暂保留本路径，M3 迁至 provider 包。
  */
-
 export { GiteeStorageService } from './giteeStorageService';
 export { GitHubStorageService } from './githubStorageService';
 export {
@@ -10,6 +11,7 @@ export {
 } from '@pixuli/core/platform';
 export { logInterceptorService } from './logInterceptorService';
 export type { LogEntry, LogLevel } from './logInterceptorService';
+/** @deprecated 请改用 `@pixuli/core/operation-log` */
 export {
   OperationLogService,
   type IOperationLogStorage,

--- a/packages/common/src/services/index.ts
+++ b/packages/common/src/services/index.ts
@@ -1,3 +1,9 @@
+/**
+ * GitHub/Gitee 存储与日志拦截仍在本包实现（M3 将迁至 provider 包）。
+ * 其余能力请直接使用 `@pixuli/core` / `@pixuli/ui`。
+ *
+ * @deprecated 应用请改用 `@pixuli/core`、`@pixuli/ui` 及 `pixuli-common/services` 子路径；完整 barrel 入口 `pixuli-common` 将移除。
+ */
 export { GiteeStorageService } from './giteeStorageService';
 export { GitHubStorageService } from './githubStorageService';
 export {
@@ -6,6 +12,7 @@ export {
 } from '@pixuli/core/platform';
 export { logInterceptorService } from './logInterceptorService';
 export type { LogEntry, LogLevel } from './logInterceptorService';
+/** @deprecated 请改用 `@pixuli/core/operation-log` */
 export {
   OperationLogService,
   type IOperationLogStorage,
@@ -13,7 +20,7 @@ export {
 } from '@pixuli/core/operation-log';
 
 // 图片处理（Web/Desktop 纯 Web 实现，依赖 Canvas；移动端勿用）
-/** @deprecated 请改用 @pixuli/ui/services/imageProcessor */
+/** @deprecated 请改用 `@pixuli/ui/services/imageProcessor` */
 export {
   WebImageProcessorService,
   webImageProcessorService,

--- a/packages/common/src/utils/fileSizeUtils.ts
+++ b/packages/common/src/utils/fileSizeUtils.ts
@@ -1,1 +1,2 @@
+/** @deprecated 请改用 `@pixuli/core/utils` */
 export * from '@pixuli/core/utils';

--- a/packages/common/src/utils/filterUtils.ts
+++ b/packages/common/src/utils/filterUtils.ts
@@ -1,1 +1,2 @@
+/** @deprecated 请改用 `@pixuli/core/utils` */
 export * from '@pixuli/core/utils';

--- a/packages/common/src/utils/imageUtils.ts
+++ b/packages/common/src/utils/imageUtils.ts
@@ -1,1 +1,2 @@
+/** @deprecated 请改用 `@pixuli/core/utils` */
 export * from '@pixuli/core/utils';

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -1,3 +1,8 @@
+/**
+ * @deprecated 请改用 `@pixuli/core/utils`、`@pixuli/ui/feedback/toast`、`@pixuli/ui/utils/keyboardShortcuts`
+ */
 export * from '@pixuli/core/utils';
+/** @deprecated 请改用 `@pixuli/ui/feedback/toast` */
 export * from '@pixuli/ui/feedback/toast';
+/** @deprecated 请改用 `@pixuli/ui/utils/keyboardShortcuts` */
 export * from '@pixuli/ui/utils/keyboardShortcuts';

--- a/packages/common/src/utils/sortUtils.ts
+++ b/packages/common/src/utils/sortUtils.ts
@@ -1,1 +1,2 @@
+/** @deprecated 请改用 `@pixuli/core/utils` */
 export * from '@pixuli/core/utils';

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -16,7 +16,11 @@
 
 ## 依赖边界
 
-不得依赖：`react-dom`、`lucide-react`、`react-hot-toast` 等 UI 库。
+不得依赖：`react-dom`、`lucide-react`、`react-hot-toast`、`@pixuli/ui`
+等 UI 库。
 
-`pixuli-common` 在迁移期间从此包 re-export，应用侧请逐步改为直接引用
+根目录 `pnpm lint:boundaries` 通过 ESLint `import/no-restricted-paths` 与
+`no-restricted-imports` 强制执行（REF-209）。
+
+`pixuli-common` 在迁移期间从此包 re-export（已 `@deprecated`），应用请直接引用
 `@pixuli/core`。

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -3,14 +3,20 @@
 基于 React 的共享界面层：`exports["."]` 面向 Web/Desktop，`exports["./native"]`
 面向 React Native。
 
-## 当前内容（REF-202）
+## 子路径导出（节选）
 
-| 入口                | 内容                                              |
-| ------------------- | ------------------------------------------------- |
-| `@pixuli/ui`        | `useLazyLoad`、`useInfiniteScroll`、`useKeyboard` |
-| `@pixuli/ui/native` | `EmptyState`、`VersionInfoModal`、`Demo`（RN）    |
+| 入口                                 | 内容                                                                       |
+| ------------------------------------ | -------------------------------------------------------------------------- |
+| `@pixuli/ui`                         | Web：Image/Layout/Config、primitives、toast、keyboardShortcuts、locales 等 |
+| `@pixuli/ui/native`                  | `EmptyState`、`VersionInfoModal`、`Demo`（RN）                             |
+| `@pixuli/ui/locales`                 | 聚合语言包                                                                 |
+| `@pixuli/ui/services/imageProcessor` | Web Canvas 图片压缩/转换                                                   |
 
-Web 侧 L1/L2 组件仍在 `pixuli-common`，见 REF-203。
+## 依赖边界
+
+- 依赖 `@pixuli/core`（类型、工具）
+- **不得**被 `@pixuli/core` 或未来的 `provider-*` 包引用（见 REF-209
+  ESLint 规则）
 
 ## 依赖
 
@@ -19,5 +25,5 @@ Web 侧 L1/L2 组件仍在 `pixuli-common`，见 REF-203。
 - `react-dom`（Web，optional peer）
 - `react-native` 及相关 Expo 模块（Native，optional peer）
 
-`pixuli-common` 在迁移期间从此包 re-export，应用请逐步改为直接引用
-`@pixuli/ui`。
+`pixuli-common` 在迁移期间从此包 re-export（已 `@deprecated`），应用请使用
+`@pixuli/ui` 直接引用。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,12 @@ importers:
       '@vitest/ui':
         specifier: ^2.1.8
         version: 2.1.9(vitest@2.1.9)
+      eslint:
+        specifier: ^9.25.0
+        version: 9.38.0(jiti@2.6.1)
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -41,6 +47,9 @@ importers:
       prettier:
         specifier: ^3.0.0
         version: 3.6.2
+      typescript-eslint:
+        specifier: ^8.30.0
+        version: 8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@24.10.1)(@vitest/ui@2.1.9)(jsdom@25.0.1)(lightningcss@1.30.2)(terser@5.44.1)
@@ -1508,6 +1517,12 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
   '@eslint-community/regexpp@4.12.2':
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
@@ -2934,6 +2949,14 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/eslint-plugin@8.60.0':
+    resolution: {integrity: sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.60.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/parser@8.46.2':
     resolution: {integrity: sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2941,14 +2964,31 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/parser@8.60.0':
+    resolution: {integrity: sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/project-service@8.46.2':
     resolution: {integrity: sha512-PULOLZ9iqwI7hXcmL4fVfIsBi6AN9YxRc0frbvmg8f+4hQAjQ5GYNKK0DIArNo+rOKmR/iBYwkpBmnIwin4wBg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/project-service@8.60.0':
+    resolution: {integrity: sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.46.2':
     resolution: {integrity: sha512-LF4b/NmGvdWEHD2H4MsHD8ny6JpiVNDzrSZr3CsckEgCbAGZbYM4Cqxvi9L+WqDMT+51Ozy7lt2M+d0JLEuBqA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.60.0':
+    resolution: {integrity: sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.46.2':
@@ -2957,6 +2997,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/tsconfig-utils@8.60.0':
+    resolution: {integrity: sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/type-utils@8.46.2':
     resolution: {integrity: sha512-HbPM4LbaAAt/DjxXaG9yiS9brOOz6fabal4uvUmaUYe6l3K1phQDMQKBRUrr06BQkxkvIZVVHttqiybM9nJsLA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2964,8 +3010,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/type-utils@8.60.0':
+    resolution: {integrity: sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/types@8.46.2':
     resolution: {integrity: sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.60.0':
+    resolution: {integrity: sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.46.2':
@@ -2974,6 +3031,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/typescript-estree@8.60.0':
+    resolution: {integrity: sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/utils@8.46.2':
     resolution: {integrity: sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2981,8 +3044,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/utils@8.60.0':
+    resolution: {integrity: sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.46.2':
     resolution: {integrity: sha512-tUFMXI4gxzzMXt4xpGJEsBsTox0XbNQ1y94EwlD/CuZwFcQP79xfQqMhau9HsRc/J0cAPA/HZt1dZPtGn9V/7w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.60.0':
+    resolution: {integrity: sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -3483,6 +3557,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -3545,6 +3623,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -4361,6 +4443,10 @@ packages:
   eslint-visitor-keys@4.2.1:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   eslint@9.38.0:
     resolution: {integrity: sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==}
@@ -6015,6 +6101,10 @@ packages:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -7475,6 +7565,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -7546,6 +7642,13 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
+
+  typescript-eslint@8.60.0:
+    resolution: {integrity: sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -9245,6 +9348,11 @@ snapshots:
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.38.0(jiti@2.6.1))':
+    dependencies:
+      eslint: 9.38.0(jiti@2.6.1)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.38.0(jiti@2.6.1))':
     dependencies:
       eslint: 9.38.0(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
@@ -11265,12 +11373,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/type-utils': 8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.60.0
+      eslint: 9.38.0(jiti@2.6.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.46.2
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.46.2
+      debug: 4.4.3
+      eslint: 9.38.0(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.60.0
       debug: 4.4.3
       eslint: 9.38.0(jiti@2.6.1)
       typescript: 5.9.3
@@ -11286,12 +11422,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.60.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.60.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.46.2':
     dependencies:
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/visitor-keys': 8.46.2
 
+  '@typescript-eslint/scope-manager@8.60.0':
+    dependencies:
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/visitor-keys': 8.60.0
+
   '@typescript-eslint/tsconfig-utils@8.46.2(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/tsconfig-utils@8.60.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
@@ -11307,7 +11461,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.38.0(jiti@2.6.1)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.46.2': {}
+
+  '@typescript-eslint/types@8.60.0': {}
 
   '@typescript-eslint/typescript-estree@8.46.2(typescript@5.9.3)':
     dependencies:
@@ -11325,6 +11493,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.60.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/visitor-keys': 8.60.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.6.1))
@@ -11336,10 +11519,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.38.0(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      eslint: 9.38.0(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.46.2':
     dependencies:
       '@typescript-eslint/types': 8.46.2
       eslint-visitor-keys: 4.2.1
+
+  '@typescript-eslint/visitor-keys@8.60.0':
+    dependencies:
+      '@typescript-eslint/types': 8.60.0
+      eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -11987,6 +12186,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.8.20: {}
@@ -12058,6 +12259,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -12928,7 +13133,7 @@ snapshots:
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-expo: 1.0.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.38.0(jiti@2.6.1))
       globals: 16.4.0
@@ -12957,7 +13162,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -12972,6 +13177,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.38.0(jiti@2.6.1)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.38.0(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-expo@1.0.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/types': 8.46.2
@@ -12981,7 +13196,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -13005,6 +13220,35 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.38.0(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.38.0(jiti@2.6.1))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -13044,6 +13288,8 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@9.38.0(jiti@2.6.1):
     dependencies:
@@ -15189,6 +15435,10 @@ snapshots:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -16887,6 +17137,10 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   ts-interface-checker@0.1.13: {}
 
   ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3):
@@ -16978,6 +17232,17 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
+
+  typescript-eslint@8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.38.0(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.9.3: {}
 


### PR DESCRIPTION
## Summary

### REF-208
- 为 `pixuli-common` 各入口（`index`、`index.native`、`locales`、`utils`、`services`）补充 `@deprecated` 与迁移至 `@pixuli/core` / `@pixuli/ui` 的说明
- 更新 `packages/common/README.md` 为迁移对照表；遗留 utils shim 标注改用 `@pixuli/core/utils`

### REF-209
- 新增根目录 `eslint.config.mjs`：`packages/core` 与未来的 `packages/provider-*` 禁止依赖 `@pixuli/ui`（`no-restricted-imports` + `import/no-restricted-paths`）
- 新增 `pnpm lint` / `pnpm lint:boundaries`，并纳入 `ci` 脚本

Closes #66
Closes #67

## Test plan

- [x] `pnpm lint:boundaries`
- [x] `pnpm test`（504 tests）


Made with [Cursor](https://cursor.com)