### PR TITLE
feat(m3): REF-302 实现 @pixuli/provider-github

### DIFF
--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -504,7 +504,7 @@ native。
 | ID      | 建议标题                                        | Labels                                            | 优先级 | Depends on         | GitHub #                                                | 状态 |
 | ------- | ----------------------------------------------- | ------------------------------------------------- | ------ | ------------------ | ------------------------------------------------------- | ---- |
 | REF-301 | [M3] 在 core 定义 StorageProvider 与 Registry   | refactor, m3, area:core, area:plugin, priority:P0 | P0     | #60                | [#70](https://github.com/trueLoving/Pixuli/issues/70)   | ✅   |
-| REF-302 | [M3] 实现 @pixuli/provider-github               | refactor, m3, area:plugin, priority:P0            | P0     | #70                | [#71](https://github.com/trueLoving/Pixuli/issues/71)   | ⬜   |
+| REF-302 | [M3] 实现 @pixuli/provider-github               | refactor, m3, area:plugin, priority:P0            | P0     | #70                | [#71](https://github.com/trueLoving/Pixuli/issues/71)   | ✅   |
 | REF-303 | [M3] 实现 @pixuli/provider-gitee                | refactor, m3, area:plugin, priority:P0            | P0     | #70                | [#72](https://github.com/trueLoving/Pixuli/issues/72)   | ⬜   |
 | REF-304 | [M3] 重构 apps/pixuli imageStore 使用 Registry  | refactor, m3, area:web, area:desktop, priority:P0 | P0     | #71, #72, #64      | [#73](https://github.com/trueLoving/Pixuli/issues/73)   | ⬜   |
 | REF-305 | [M3] 重构 apps/mobile imageStore 使用 Registry  | refactor, m3, area:mobile, priority:P0            | P0     | #71, #72, #65      | [#74](https://github.com/trueLoving/Pixuli/issues/74)   | ⬜   |
@@ -645,7 +645,7 @@ flowchart LR
 | -------- | -------- | ------ | ------- |
 | M1       | 12       | 7      | 58%     |
 | M2       | 10       | 0      | 0%      |
-| M3       | 11       | 1      | 9%      |
+| M3       | 11       | 2      | 18%     |
 | M4       | 6        | 0      | 0%      |
 | M5       | 5        | 0      | 0%      |
 | **合计** | **44**   | **7**  | **16%** |

--- a/apps/mobile/components/image/ImageUploadButton.tsx
+++ b/apps/mobile/components/image/ImageUploadButton.tsx
@@ -167,7 +167,7 @@ export function ImageUploadButton({
       }
 
       await uploadImage({
-        uri: finalUri,
+        file: finalUri,
         name: finalName,
         description: data.description,
         tags: data.tags,

--- a/apps/mobile/stores/imageStore.ts
+++ b/apps/mobile/stores/imageStore.ts
@@ -4,6 +4,7 @@ import type {
   GiteeConfig,
   ImageEditData,
   ImageItem,
+  ImageUploadData,
   MultiImageUploadData,
   UploadProgress,
 } from '@pixuli/core/types';
@@ -67,12 +68,7 @@ interface ImageState {
   clearGiteeConfig: () => Promise<void>;
   initializeStorage: () => void;
   loadImages: () => Promise<void>;
-  uploadImage: (uploadData: {
-    uri: string;
-    name?: string;
-    description?: string;
-    tags?: string[];
-  }) => Promise<void>;
+  uploadImage: (uploadData: ImageUploadData) => Promise<void>;
   uploadMultipleImages: (
     uploadData: MultiImageUploadData & { uris: string[] },
   ) => Promise<void>;
@@ -549,12 +545,7 @@ export const useImageStore = create<ImageState>((set, get) => ({
     }
   },
 
-  uploadImage: async (uploadData: {
-    uri: string;
-    name?: string;
-    description?: string;
-    tags?: string[];
-  }) => {
+  uploadImage: async (uploadData: ImageUploadData) => {
     const { storageService } = get();
     if (!storageService) {
       set({ error: '存储服务未初始化', loading: false });
@@ -651,8 +642,8 @@ export const useImageStore = create<ImageState>((set, get) => ({
               : null,
           }));
 
-          const uploadData = {
-            uri,
+          const uploadData: ImageUploadData = {
+            file: uri,
             name: name ? `${name}-${i + 1}-${fileName}` : fileName,
             description,
             tags,

--- a/apps/pixuli/src/stores/imageStore.ts
+++ b/apps/pixuli/src/stores/imageStore.ts
@@ -24,6 +24,7 @@ import type {
   MultiImageUploadData,
   UploadProgress,
 } from '@pixuli/core/types';
+import { getUploadFileName } from '@pixuli/core/types';
 import { create } from 'zustand';
 
 interface ImageState {
@@ -256,7 +257,7 @@ export const useImageStore = create<ImageState>((set, get) => {
         });
         // 记录上传失败日志
         useLogStore.getState().addLog(LogActionType.UPLOAD, LogStatus.FAILED, {
-          imageName: uploadData.name || uploadData.file.name,
+          imageName: getUploadFileName(uploadData.file, uploadData.name),
           error: errorMsg,
           duration,
         });

--- a/docs/02-system-design/07-storage-plugin-system.md
+++ b/docs/02-system-design/07-storage-plugin-system.md
@@ -516,14 +516,14 @@ const githubManifest: StoragePluginManifest = {
 
 ### B. 相关源码索引（M2 基线）
 
-| 路径                                                   | 说明                         |
-| ------------------------------------------------------ | ---------------------------- |
-| `packages/core/src/plugins/types.ts`                   | 契约定义                     |
-| `packages/core/src/plugins/registry.ts`                | DefaultStoragePluginRegistry |
-| `packages/common/src/services/githubStorageService.ts` | 待迁至 provider-github       |
-| `packages/common/src/services/giteeStorageService.ts`  | 待迁至 provider-gitee        |
-| `apps/pixuli/src/stores/imageStore.ts`                 | 待 REF-304                   |
-| `apps/mobile/stores/imageStore.ts`                     | 待 REF-305                   |
+| 路径                                                   | 说明                                     |
+| ------------------------------------------------------ | ---------------------------------------- |
+| `packages/core/src/plugins/types.ts`                   | 契约定义                                 |
+| `packages/core/src/plugins/registry.ts`                | DefaultStoragePluginRegistry             |
+| `packages/common/src/services/githubStorageService.ts` | 已迁至 `packages/plugin-provider-github` |
+| `packages/common/src/services/giteeStorageService.ts`  | 待迁至 provider-gitee                    |
+| `apps/pixuli/src/stores/imageStore.ts`                 | 待 REF-304                               |
+| `apps/mobile/stores/imageStore.ts`                     | 待 REF-305                               |
 
 ### C. 文档维护
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,25 +54,25 @@ const providerNoUiRules = {
     {
       zones: [
         {
-          target: './packages/provider-github',
+          target: './packages/plugin-provider-github',
           from: './packages/ui',
           message:
             '不得从 packages/ui 引用：provider 与 ui 分层（REF-209）',
         },
         {
-          target: './packages/provider-github',
+          target: './packages/plugin-provider-github',
           from: './packages/ui/**',
           message:
             '不得从 packages/ui 引用：provider 与 ui 分层（REF-209）',
         },
         {
-          target: './packages/provider-gitee',
+          target: './packages/plugin-provider-gitee',
           from: './packages/ui',
           message:
             '不得从 packages/ui 引用：provider 与 ui 分层（REF-209）',
         },
         {
-          target: './packages/provider-gitee',
+          target: './packages/plugin-provider-gitee',
           from: './packages/ui/**',
           message:
             '不得从 packages/ui 引用：provider 与 ui 分层（REF-209）',
@@ -109,7 +109,7 @@ export default tseslint.config(
     rules: noUiDependencyRules,
   },
   {
-    files: ['packages/provider-*/**/*.{ts,tsx}'],
+    files: ['packages/plugin-provider-*/**/*.{ts,tsx}'],
     languageOptions: tsLanguageOptions,
     plugins: { import: importPlugin },
     rules: providerNoUiRules,

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -13,7 +13,8 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@pixuli/core": "workspace:*"
+    "@pixuli/core": "workspace:*",
+    "@pixuli/provider-github": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/common/src/services/index.native.ts
+++ b/packages/common/src/services/index.native.ts
@@ -2,6 +2,6 @@
  * React Native 存储与日志拦截（不含 Web Canvas 图片处理）。
  */
 export { GiteeStorageService } from './giteeStorageService';
-export { GitHubStorageService } from './githubStorageService';
+export { GitHubStorageService } from '@pixuli/provider-github';
 export { logInterceptorService } from './logInterceptorService';
 export type { LogEntry, LogLevel } from './logInterceptorService';

--- a/packages/common/src/services/index.ts
+++ b/packages/common/src/services/index.ts
@@ -3,6 +3,6 @@
  * 应用请仅使用本路径，勿再依赖 `pixuli-common` 根入口。
  */
 export { GiteeStorageService } from './giteeStorageService';
-export { GitHubStorageService } from './githubStorageService';
+export { GitHubStorageService } from '@pixuli/provider-github';
 export { logInterceptorService } from './logInterceptorService';
 export type { LogEntry, LogLevel } from './logInterceptorService';

--- a/packages/core/src/types/image.ts
+++ b/packages/core/src/types/image.ts
@@ -21,6 +21,16 @@ export interface ImageUploadData {
   tags?: string[];
 }
 
+/** Web/Desktop 上传表单：file 恒为 File */
+export type WebImageUploadData = Omit<ImageUploadData, 'file'> & { file: File };
+
+export function getUploadFileName(file: File | string, name?: string): string {
+  if (typeof file === 'string') {
+    return name || file.split('/').pop() || 'image.jpg';
+  }
+  return name || file.name;
+}
+
 export interface ImageCropOptions {
   aspectRatio?: number;
   minWidth?: number;

--- a/packages/plugin-provider-github/package.json
+++ b/packages/plugin-provider-github/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@pixuli/provider-github",
+  "version": "1.0.0",
+  "description": "Pixuli GitHub storage provider plugin",
+  "type": "module",
+  "license": "MIT",
+  "exports": {
+    ".": "./src/index.ts",
+    "./register": "./src/register.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pixuli/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "jsdom": "^25.0.1",
+    "typescript": "^5.0.0",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/plugin-provider-github/src/__tests__/githubStorageProvider.test.ts
+++ b/packages/plugin-provider-github/src/__tests__/githubStorageProvider.test.ts
@@ -131,8 +131,8 @@ describe('GitHubStorageService', () => {
     });
 
     it('应该上传图片文件（使用 URI）', async () => {
-      const uploadData = {
-        uri: 'file:///path/to/image.jpg',
+      const uploadData: ImageUploadData = {
+        file: 'file:///path/to/image.jpg',
         name: 'image.jpg',
         description: 'Test image',
       };

--- a/packages/plugin-provider-github/src/__tests__/register.test.ts
+++ b/packages/plugin-provider-github/src/__tests__/register.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { createStoragePluginRegistry } from '@pixuli/core/plugins';
+import { registerGitHubProvider, githubManifest } from '../register';
+import { GitHubStorageProvider } from '../githubStorageProvider';
+
+describe('registerGitHubProvider', () => {
+  it('registers github manifest and creates provider', () => {
+    const registry = createStoragePluginRegistry();
+    registerGitHubProvider(registry);
+
+    expect(registry.listManifests()).toEqual([githubManifest]);
+    const provider = registry.create('github', {
+      platform: 'web',
+      platformAdapter: {} as never,
+    });
+    expect(provider).toBeInstanceOf(GitHubStorageProvider);
+    expect(provider.manifest.id).toBe('github');
+  });
+
+  it('throws when registering github twice', () => {
+    const registry = createStoragePluginRegistry();
+    registerGitHubProvider(registry);
+    expect(() => registerGitHubProvider(registry)).toThrow(
+      'Storage plugin already registered: github',
+    );
+  });
+});

--- a/packages/plugin-provider-github/src/githubStorageProvider.ts
+++ b/packages/plugin-provider-github/src/githubStorageProvider.ts
@@ -1,34 +1,67 @@
 import type { ImageItem, ImageUploadData } from '@pixuli/core/types';
 import type { GitHubConfig } from '@pixuli/core/types';
-import {
-  DefaultPlatformAdapter,
-  type PlatformAdapter,
-} from '@pixuli/core/platform';
+import type {
+  ImageListOptions,
+  ImageMetadataLoadOptions,
+  ProviderContext,
+  StorageProviderConfig,
+  StorageProviderWithMetadata,
+} from '@pixuli/core/plugins';
+import { githubManifest } from './manifest';
 
-export class GitHubStorageService {
-  private config: GitHubConfig;
-  private baseUrl = 'https://api.github.com';
-  private platformAdapter: PlatformAdapter;
-  // @ts-ignore
-  private platform: 'web' | 'desktop' | 'mobile';
+function narrowGitHubConfig(
+  config: StorageProviderConfig | GitHubConfig,
+): GitHubConfig {
+  const { owner, repo, branch, token, path } = config;
 
-  constructor(
-    config: GitHubConfig,
-    options: {
-      platform: 'web' | 'desktop' | 'mobile';
-      platformAdapter?: PlatformAdapter;
-    } = {
-      platform: 'web',
-      platformAdapter: new DefaultPlatformAdapter(),
-    },
+  if (
+    typeof owner !== 'string' ||
+    typeof repo !== 'string' ||
+    typeof branch !== 'string' ||
+    typeof token !== 'string' ||
+    typeof path !== 'string'
   ) {
-    this.config = config;
-    this.platformAdapter =
-      options.platformAdapter || new DefaultPlatformAdapter();
-    this.platform = options.platform || 'web';
+    throw new Error('Invalid GitHub storage provider config');
+  }
+
+  return { owner, repo, branch, token, path };
+}
+
+export class GitHubStorageProvider implements StorageProviderWithMetadata {
+  readonly manifest = githubManifest;
+
+  private config!: GitHubConfig;
+  private readonly baseUrl = 'https://api.github.com';
+  private readonly platformAdapter: ProviderContext['platformAdapter'];
+  private readonly fetchFn: typeof fetch;
+  private readonly logger: Pick<Console, 'log' | 'warn' | 'error'>;
+
+  constructor(ctx: ProviderContext) {
+    this.platformAdapter = ctx.platformAdapter;
+    this.fetchFn =
+      ctx.fetch ??
+      ((input: RequestInfo | URL, init?: RequestInit) =>
+        globalThis.fetch(input, init));
+    this.logger = ctx.logger ?? console;
+  }
+
+  configure(config: StorageProviderConfig): void {
+    this.config = narrowGitHubConfig(config);
+  }
+
+  private assertConfigured(): void {
+    if (!this.config) {
+      throw new Error('GitHub storage provider is not configured');
+    }
+  }
+
+  getRawUrl(path: string): string {
+    this.assertConfigured();
+    return `https://raw.githubusercontent.com/${this.config.owner}/${this.config.repo}/refs/heads/${this.config.branch}/${this.config.path}/${path}`;
   }
 
   private async makeGitHubRequest(endpoint: string, options: RequestInit = {}) {
+    this.assertConfigured();
     const url = `${this.baseUrl}${endpoint}`;
     const headers = {
       Authorization: `token ${this.config.token}`,
@@ -37,7 +70,7 @@ export class GitHubStorageService {
       ...options.headers,
     };
 
-    const response = await fetch(url, {
+    const response = await this.fetchFn(url, {
       ...options,
       headers,
     });
@@ -63,7 +96,7 @@ export class GitHubStorageService {
     try {
       return await this.platformAdapter.getImageDimensions(file);
     } catch (error) {
-      console.warn(
+      this.logger.warn(
         'Failed to get image dimensions, using default values:',
         error,
       );
@@ -121,9 +154,9 @@ export class GitHubStorageService {
     metadata: ImageItem,
   ): Promise<void> {
     try {
-      await this.updateImageMetadata(fileName, metadata);
+      await this.persistImageMetadata(fileName, metadata);
     } catch (error) {
-      console.error('Failed to upload metadata:', error);
+      this.logger.error('Failed to upload metadata:', error);
       // 元数据上传失败不应该阻止整个上传流程，但记录错误
       throw new Error(`上传元数据失败: ${error}`);
     }
@@ -140,14 +173,10 @@ export class GitHubStorageService {
    * @param uploadData 上传数据
    * @returns Promise<ImageItem> 上传后的图片信息
    */
-  async uploadImage(
-    uploadData:
-      | ImageUploadData
-      | { uri: string; name?: string; description?: string; tags?: string[] },
-  ): Promise<ImageItem> {
+  async uploadImage(uploadData: ImageUploadData): Promise<ImageItem> {
+    this.assertConfigured();
     try {
-      // 兼容 web/desktop 的 File 和 mobile 的 URI
-      const file = 'file' in uploadData ? uploadData.file : uploadData.uri;
+      const file = uploadData.file;
       const name = uploadData.name;
       const description = uploadData.description;
       const tags = uploadData.tags;
@@ -199,26 +228,27 @@ export class GitHubStorageService {
       } catch (error) {
         // 元数据上传失败时，记录警告但不影响图片上传的成功
         // 因为图片文件已经成功上传，元数据可以在后续补充
-        console.warn(
+        this.logger.warn(
           'Image file uploaded successfully, but metadata upload failed:',
           error,
         );
-        console.warn(
+        this.logger.warn(
           'You can update metadata later or it will be fetched from the image URL',
         );
       }
 
       return imageItem;
     } catch (error) {
-      console.error('Upload image failed:', error);
+      this.logger.error('Upload image failed:', error);
       throw new Error(`上传图片失败: ${error}`);
     }
   }
 
   // 删除图片
-  async deleteImage(_imageId: string, fileName: string): Promise<void> {
+  async deleteImage(path: string): Promise<void> {
+    this.assertConfigured();
     try {
-      const filePath = `${this.config.path}/${fileName}`;
+      const filePath = `${this.config.path}/${path}`;
 
       // 首先获取文件的SHA
       const fileInfo = await this.makeGitHubRequest(
@@ -231,7 +261,7 @@ export class GitHubStorageService {
         {
           method: 'DELETE',
           body: JSON.stringify({
-            message: `Delete image: ${fileName}`,
+            message: `Delete image: ${path}`,
             sha: fileInfo.sha,
             branch: this.config.branch,
           }),
@@ -240,13 +270,13 @@ export class GitHubStorageService {
 
       // 删除对应的元数据文件
       try {
-        await this.deleteImageMetadata(fileName);
+        await this.deleteImageMetadata(path);
       } catch (error) {
-        console.warn('Failed to delete metadata file:', error);
+        this.logger.warn('Failed to delete metadata file:', error);
         // 不抛出错误，因为图片已经删除成功
       }
     } catch (error) {
-      console.error('Delete image failed:', error);
+      this.logger.error('Delete image failed:', error);
       throw new Error(`删除图片失败: ${error}`);
     }
   }
@@ -286,7 +316,9 @@ export class GitHubStorageService {
 
       // 确保获取到了 SHA
       if (!metadataFileInfo.sha) {
-        console.warn(`Metadata file exists but no SHA found for ${fileName}`);
+        this.logger.warn(
+          `Metadata file exists but no SHA found for ${fileName}`,
+        );
         return;
       }
 
@@ -304,13 +336,14 @@ export class GitHubStorageService {
       );
     } catch (error) {
       // 删除元数据失败不应该阻止图片删除，只记录警告
-      console.warn(`Failed to delete metadata for ${fileName}:`, error);
+      this.logger.warn(`Failed to delete metadata for ${fileName}:`, error);
       throw new Error(`Failed to delete metadata for ${fileName}: ${error}`);
     }
   }
 
   // 获取图片列表
-  async getImageList(): Promise<ImageItem[]> {
+  async listImages(_options?: ImageListOptions): Promise<ImageItem[]> {
+    this.assertConfigured();
     try {
       const response = await this.makeGitHubRequest(
         `/repos/${this.config.owner}/${this.config.repo}/contents/${this.config.path}?ref=${this.config.branch}`,
@@ -329,7 +362,10 @@ export class GitHubStorageService {
             metadata = await this.getImageMetadata(item.name);
           } catch (error) {
             // 其他错误，记录debug日志
-            console.debug(`Failed to fetch metadata for ${item.name}:`, error);
+            this.logger.log(
+              `Failed to fetch metadata for ${item.name}:`,
+              error,
+            );
           }
 
           return {
@@ -362,7 +398,7 @@ export class GitHubStorageService {
         ([_, count]) => (count as number) > 1,
       );
       if (duplicateIds.length > 0) {
-        console.warn('发现重复的图片ID:', duplicateIds);
+        this.logger.warn('发现重复的图片ID:', duplicateIds);
         // 为重复的ID添加后缀以确保唯一性
         const processedImages = images.map((img: ImageItem, index: number) => {
           if (idCounts[img.id] > 1) {
@@ -378,28 +414,49 @@ export class GitHubStorageService {
 
       return images;
     } catch (error) {
-      console.error('Get image list failed:', error);
+      this.logger.error('Get image list failed:', error);
       throw new Error(`获取图片列表失败: ${error}`);
     }
   }
 
   // 更新图片信息（如标签、描述等）
-  async updateImageInfo(
-    _imageId: string,
-    fileName: string,
-    metadata: any,
-  ): Promise<void> {
+  async updateImageMetadata(
+    path: string,
+    metadata: Partial<Pick<ImageItem, 'name' | 'description' | 'tags'>>,
+  ): Promise<ImageItem> {
+    this.assertConfigured();
     try {
-      // 更新元数据文件
-      await this.updateImageMetadata(fileName, metadata);
+      await this.persistImageMetadata(path, metadata);
+      return {
+        id: path,
+        name: metadata.name ?? path,
+        url: this.getRawUrl(path),
+        githubUrl: `https://github.com/${this.config.owner}/${this.config.repo}/blob/${this.config.branch}/${this.config.path}/${path}`,
+        size: 0,
+        width: 0,
+        height: 0,
+        type: this.getMimeType(path),
+        tags: metadata.tags ?? [],
+        description: metadata.description ?? '',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
     } catch (error) {
-      console.error('Update image info failed:', error);
+      this.logger.error('Update image info failed:', error);
       throw new Error(`更新图片信息失败: ${error}`);
     }
   }
 
-  // 更新图片元数据文件
-  private async updateImageMetadata(
+  /** @deprecated 兼容 pixuli-common GitHubStorageService，REF-304 后移除 */
+  async updateImageInfo(
+    _imageId: string,
+    fileName: string,
+    metadata: Partial<Pick<ImageItem, 'name' | 'description' | 'tags'>>,
+  ): Promise<void> {
+    await this.updateImageMetadata(fileName, metadata);
+  }
+
+  private async persistImageMetadata(
     fileName: string,
     metadata: any,
   ): Promise<void> {
@@ -516,7 +573,7 @@ export class GitHubStorageService {
         }
       }
     } catch (error) {
-      console.error('Update image metadata failed:', error);
+      this.logger.error('Update image metadata failed:', error);
       throw new Error(`更新图片元数据失败: ${error}`);
     }
   }
@@ -537,11 +594,11 @@ export class GitHubStorageService {
       // URL格式：https://raw.githubusercontent.com/owner/repo/refs/heads/branch/path/.metadata/file.json
       const metadataUrl = `https://raw.githubusercontent.com/${this.config.owner}/${this.config.repo}/refs/heads/${this.config.branch}/${this.config.path}/.metadata/${metadataFileName}`;
 
-      const response = await fetch(metadataUrl);
+      const response = await this.fetchFn(metadataUrl);
 
       // 如果文件不存在（404），记录警告而不是错误
       if (response.status === 404) {
-        console.warn(`Metadata file not found for ${fileName} (404)`);
+        this.logger.warn(`Metadata file not found for ${fileName} (404)`);
         return null;
       }
 
@@ -569,7 +626,7 @@ export class GitHubStorageService {
    */
   async loadImageMetadata(
     images: ImageItem[],
-    _options?: { forceRefresh?: boolean; backgroundUpdate?: boolean },
+    _options?: ImageMetadataLoadOptions,
   ): Promise<ImageItem[]> {
     try {
       // const { forceRefresh = false } = options || {};
@@ -592,14 +649,14 @@ export class GitHubStorageService {
           }
           return img;
         } catch (error) {
-          console.debug(`Failed to load metadata for ${img.name}:`, error);
+          this.logger.log(`Failed to load metadata for ${img.name}:`, error);
           return img;
         }
       });
 
       return await Promise.all(metadataPromises);
     } catch (error) {
-      console.error('Load image metadata failed:', error);
+      this.logger.error('Load image metadata failed:', error);
       // 即使加载元数据失败，也返回原始图片列表
       return images;
     }

--- a/packages/plugin-provider-github/src/githubStorageService.ts
+++ b/packages/plugin-provider-github/src/githubStorageService.ts
@@ -1,0 +1,68 @@
+import type {
+  GitHubConfig,
+  ImageItem,
+  ImageUploadData,
+} from '@pixuli/core/types';
+import type { StorageProviderConfig } from '@pixuli/core/plugins';
+import {
+  DefaultPlatformAdapter,
+  type PlatformAdapter,
+} from '@pixuli/core/platform';
+import { GitHubStorageProvider } from './githubStorageProvider';
+
+/**
+ * 兼容 pixuli-common 构造方式，供 REF-304 前 apps 继续使用。
+ */
+export class GitHubStorageService {
+  private readonly provider: GitHubStorageProvider;
+
+  constructor(
+    config: GitHubConfig,
+    options: {
+      platform: 'web' | 'desktop' | 'mobile';
+      platformAdapter?: PlatformAdapter;
+    } = {
+      platform: 'web',
+      platformAdapter: new DefaultPlatformAdapter(),
+    },
+  ) {
+    this.provider = new GitHubStorageProvider({
+      platform: options.platform ?? 'web',
+      platformAdapter: options.platformAdapter ?? new DefaultPlatformAdapter(),
+    });
+    this.provider.configure(config as unknown as StorageProviderConfig);
+  }
+
+  getImageDimensions(
+    file: File | string,
+  ): Promise<{ width: number; height: number }> {
+    return this.provider.getImageDimensions(file);
+  }
+
+  uploadImage(uploadData: ImageUploadData): Promise<ImageItem> {
+    return this.provider.uploadImage(uploadData);
+  }
+
+  deleteImage(_imageId: string, fileName: string): Promise<void> {
+    return this.provider.deleteImage(fileName);
+  }
+
+  getImageList(): Promise<ImageItem[]> {
+    return this.provider.listImages();
+  }
+
+  updateImageInfo(
+    imageId: string,
+    fileName: string,
+    metadata: Partial<Pick<ImageItem, 'name' | 'description' | 'tags'>>,
+  ): Promise<void> {
+    return this.provider.updateImageInfo(imageId, fileName, metadata);
+  }
+
+  loadImageMetadata(
+    images: ImageItem[],
+    options?: Parameters<GitHubStorageProvider['loadImageMetadata']>[1],
+  ): Promise<ImageItem[]> {
+    return this.provider.loadImageMetadata(images, options);
+  }
+}

--- a/packages/plugin-provider-github/src/index.ts
+++ b/packages/plugin-provider-github/src/index.ts
@@ -1,0 +1,3 @@
+export { GitHubStorageProvider } from './githubStorageProvider';
+export { GitHubStorageService } from './githubStorageService';
+export { githubManifest } from './manifest';

--- a/packages/plugin-provider-github/src/manifest.ts
+++ b/packages/plugin-provider-github/src/manifest.ts
@@ -1,0 +1,13 @@
+import type { StoragePluginManifest } from '@pixuli/core/plugins';
+
+export const githubManifest: StoragePluginManifest = {
+  id: 'github',
+  name: 'GitHub',
+  version: '1.0.0',
+  capabilities: {
+    list: true,
+    upload: true,
+    delete: true,
+    updateMetadata: true,
+  },
+};

--- a/packages/plugin-provider-github/src/register.ts
+++ b/packages/plugin-provider-github/src/register.ts
@@ -1,0 +1,9 @@
+import type { StoragePluginRegistry } from '@pixuli/core/plugins';
+import { GitHubStorageProvider } from './githubStorageProvider';
+import { githubManifest } from './manifest';
+
+export function registerGitHubProvider(registry: StoragePluginRegistry): void {
+  registry.register(githubManifest, ctx => new GitHubStorageProvider(ctx));
+}
+
+export { githubManifest };

--- a/packages/plugin-provider-github/tsconfig.json
+++ b/packages/plugin-provider-github/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/plugin-provider-github/vitest.config.ts
+++ b/packages/plugin-provider-github/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    include: ['**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    exclude: ['**/node_modules/**', '**/dist/**'],
+  },
+});

--- a/packages/ui/src/image/image-upload/web/ImageUpload.tsx
+++ b/packages/ui/src/image/image-upload/web/ImageUpload.tsx
@@ -16,6 +16,7 @@ import type {
   ImageCropOptions,
   ImageUploadData,
   MultiImageUploadData,
+  WebImageUploadData,
 } from '@pixuli/core/types';
 import { compressImage } from '@pixuli/core/utils';
 import {
@@ -52,7 +53,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
 }) => {
   // 使用传入的翻译函数或默认中文翻译函数
   const translate = t || defaultTranslate;
-  const [uploadData, setUploadData] = useState<ImageUploadData | null>(null);
+  const [uploadData, setUploadData] = useState<WebImageUploadData | null>(null);
   const [multiUploadData, setMultiUploadData] =
     useState<MultiImageUploadData | null>(null);
   const [showForm, setShowForm] = useState(false);
@@ -418,7 +419,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
   };
 
   const handleInputChange = (
-    field: keyof ImageUploadData,
+    field: keyof WebImageUploadData,
     value: string | string[],
   ) => {
     if (uploadData) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       '@pixuli/core':
         specifier: workspace:*
         version: link:../core
+      '@pixuli/provider-github':
+        specifier: workspace:*
+        version: link:../plugin-provider-github
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -301,6 +304,25 @@ importers:
         version: 5.9.3
 
   packages/core:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.18.12
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.18.12)(@vitest/ui@2.1.9)(jsdom@25.0.1)(lightningcss@1.30.2)(terser@5.44.1)
+
+  packages/plugin-provider-github:
+    dependencies:
+      '@pixuli/core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@types/node':
         specifier: ^22.0.0

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -2,6 +2,7 @@ import { defineWorkspace } from 'vitest/config';
 
 export default defineWorkspace([
   './packages/core/vitest.config.ts',
+  './packages/plugin-provider-github/vitest.config.ts',
   './packages/ui/vitest.config.ts',
   // packages/common - 需要 jsdom 环境
   './packages/common/vitest.config.ts',


### PR DESCRIPTION
## Summary
- 新增 `packages/plugin-provider-github`（npm：`@pixuli/provider-github`），实现 `GitHubStorageProvider` 与 `registerGitHubProvider(registry)`
- 自 `pixuli-common` 迁出 GitHub 存储逻辑与单测；保留 `GitHubStorageService` 兼容层供 apps 继续使用
- `pixuli-common/services` 改为 re-export；更新 ESLint 边界路径与 vitest workspace

## Test plan
- [x] `pnpm --filter @pixuli/provider-github test`
- [x] `pnpm --filter pixuli-common test`
- [x] CI 全绿

Closes #71


Made with [Cursor](https://cursor.com)