### PR TITLE
feat(m3): REF-303 实现 @pixuli/provider-gitee

### DIFF
--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -505,7 +505,7 @@ native。
 | ------- | ----------------------------------------------- | ------------------------------------------------- | ------ | ------------------ | ------------------------------------------------------- | ---- |
 | REF-301 | [M3] 在 core 定义 StorageProvider 与 Registry   | refactor, m3, area:core, area:plugin, priority:P0 | P0     | #60                | [#70](https://github.com/trueLoving/Pixuli/issues/70)   | ✅   |
 | REF-302 | [M3] 实现 @pixuli/provider-github               | refactor, m3, area:plugin, priority:P0            | P0     | #70                | [#71](https://github.com/trueLoving/Pixuli/issues/71)   | ✅   |
-| REF-303 | [M3] 实现 @pixuli/provider-gitee                | refactor, m3, area:plugin, priority:P0            | P0     | #70                | [#72](https://github.com/trueLoving/Pixuli/issues/72)   | ⬜   |
+| REF-303 | [M3] 实现 @pixuli/provider-gitee                | refactor, m3, area:plugin, priority:P0            | P0     | #70                | [#72](https://github.com/trueLoving/Pixuli/issues/72)   | ✅   |
 | REF-304 | [M3] 重构 apps/pixuli imageStore 使用 Registry  | refactor, m3, area:web, area:desktop, priority:P0 | P0     | #71, #72, #64      | [#73](https://github.com/trueLoving/Pixuli/issues/73)   | ⬜   |
 | REF-305 | [M3] 重构 apps/mobile imageStore 使用 Registry  | refactor, m3, area:mobile, priority:P0            | P0     | #71, #72, #65      | [#74](https://github.com/trueLoving/Pixuli/issues/74)   | ⬜   |
 | REF-306 | [M3] 配置持久化增加 pluginId（导入/导出）       | refactor, m3, priority:P1                         | P1     | #73, #74           | [#75](https://github.com/trueLoving/Pixuli/issues/75)   | ⬜   |
@@ -645,7 +645,7 @@ flowchart LR
 | -------- | -------- | ------ | ------- |
 | M1       | 12       | 7      | 58%     |
 | M2       | 10       | 0      | 0%      |
-| M3       | 11       | 2      | 18%     |
+| M3       | 11       | 3      | 27%     |
 | M4       | 6        | 0      | 0%      |
 | M5       | 5        | 0      | 0%      |
 | **合计** | **44**   | **7**  | **16%** |

--- a/docs/02-system-design/07-storage-plugin-system.md
+++ b/docs/02-system-design/07-storage-plugin-system.md
@@ -521,7 +521,7 @@ const githubManifest: StoragePluginManifest = {
 | `packages/core/src/plugins/types.ts`                   | 契约定义                                 |
 | `packages/core/src/plugins/registry.ts`                | DefaultStoragePluginRegistry             |
 | `packages/common/src/services/githubStorageService.ts` | 已迁至 `packages/plugin-provider-github` |
-| `packages/common/src/services/giteeStorageService.ts`  | 待迁至 provider-gitee                    |
+| `packages/common/src/services/giteeStorageService.ts`  | 已迁至 `packages/plugin-provider-gitee`  |
 | `apps/pixuli/src/stores/imageStore.ts`                 | 待 REF-304                               |
 | `apps/mobile/stores/imageStore.ts`                     | 待 REF-305                               |
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "@pixuli/core": "workspace:*",
-    "@pixuli/provider-github": "workspace:*"
+    "@pixuli/provider-github": "workspace:*",
+    "@pixuli/provider-gitee": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/common/src/services/index.native.ts
+++ b/packages/common/src/services/index.native.ts
@@ -1,7 +1,7 @@
 /**
  * React Native 存储与日志拦截（不含 Web Canvas 图片处理）。
  */
-export { GiteeStorageService } from './giteeStorageService';
+export { GiteeStorageService } from '@pixuli/provider-gitee';
 export { GitHubStorageService } from '@pixuli/provider-github';
 export { logInterceptorService } from './logInterceptorService';
 export type { LogEntry, LogLevel } from './logInterceptorService';

--- a/packages/common/src/services/index.ts
+++ b/packages/common/src/services/index.ts
@@ -2,7 +2,7 @@
  * GitHub/Gitee 存储与日志拦截（M3 将迁至 `@pixuli/provider-*`）。
  * 应用请仅使用本路径，勿再依赖 `pixuli-common` 根入口。
  */
-export { GiteeStorageService } from './giteeStorageService';
+export { GiteeStorageService } from '@pixuli/provider-gitee';
 export { GitHubStorageService } from '@pixuli/provider-github';
 export { logInterceptorService } from './logInterceptorService';
 export type { LogEntry, LogLevel } from './logInterceptorService';

--- a/packages/plugin-provider-gitee/README.md
+++ b/packages/plugin-provider-gitee/README.md
@@ -1,0 +1,95 @@
+# @pixuli/provider-gitee
+
+Pixuli 官方 **Gitee 仓库图床**存储插件（M3 REF-303）。
+
+- **npm 包名**：`@pixuli/provider-gitee`
+- **Monorepo 目录**：`packages/plugin-provider-gitee`
+- **插件 ID**：`gitee`
+- **设计文档**：[存储插件体系设计](../../docs/02-system-design/07-storage-plugin-system.md)
+
+实现 Gitee API v5 + sidecar 元数据，符合
+[`@pixuli/core/plugins`](../core/README.md) 中的 `StorageProvider`
+契约。Manifest标注 `capabilities.needsProxy: true`（Web 部署常配合
+`/api/gitee-proxy`）。
+
+## 导出
+
+| 路径                              | 内容                                                                     |
+| --------------------------------- | ------------------------------------------------------------------------ |
+| `@pixuli/provider-gitee`          | `GiteeStorageProvider`、`GiteeStorageService`（兼容层）、`giteeManifest` |
+| `@pixuli/provider-gitee/register` | `registerGiteeProvider(registry)`                                        |
+
+## 注册到 Registry
+
+```typescript
+import { createStoragePluginRegistry } from '@pixuli/core/plugins';
+import { registerGiteeProvider } from '@pixuli/provider-gitee/register';
+
+const registry = createStoragePluginRegistry();
+registerGiteeProvider(registry);
+
+const provider = registry.create('gitee', {
+  platform: 'web',
+  platformAdapter: getPlatformAdapter(),
+});
+provider.configure({
+  owner,
+  repo,
+  branch,
+  token,
+  path,
+});
+await provider.listImages();
+```
+
+通过 **兼容层**创建时，Web 端可显式开启代理（与现 `apps/pixuli` 行为一致）：
+
+```typescript
+import { GiteeStorageProvider } from '@pixuli/provider-gitee';
+
+new GiteeStorageProvider(ctx, { useProxy: true });
+```
+
+## 配置形状
+
+与 [`GiteeConfig`](../core/src/types/gitee.ts) 一致：
+
+| 字段     | 说明         |
+| -------- | ------------ |
+| `owner`  | 仓库所有者   |
+| `repo`   | 仓库名       |
+| `branch` | 分支         |
+| `token`  | 私人令牌     |
+| `path`   | 图片目录路径 |
+
+`useProxy` 不属于持久化 config，由构造 `GiteeStorageProvider` /
+`GiteeStorageService` 时传入；Registry 默认
+`useProxy: false`，REF-304 集成时再按平台/bootstrap 决策。
+
+## 兼容层（REF-304 前）
+
+```typescript
+import { GiteeStorageService } from 'pixuli-common/services';
+
+const service = new GiteeStorageService(config, {
+  platform: 'web',
+  platformAdapter,
+  useProxy: true, // Web/PWA 经 Vercel gitee-proxy
+});
+await service.getImageList();
+```
+
+## 依赖边界
+
+- **仅依赖** `@pixuli/core`
+- **禁止**依赖 `@pixuli/ui` 等 UI 层（REF-209）
+
+## 开发
+
+```bash
+pnpm --filter @pixuli/provider-gitee test
+```
+
+## License
+
+MIT

--- a/packages/plugin-provider-gitee/package.json
+++ b/packages/plugin-provider-gitee/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@pixuli/provider-gitee",
+  "version": "1.0.0",
+  "description": "Pixuli Gitee storage provider plugin",
+  "type": "module",
+  "license": "MIT",
+  "exports": {
+    ".": "./src/index.ts",
+    "./register": "./src/register.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pixuli/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "jsdom": "^25.0.1",
+    "typescript": "^5.0.0",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/plugin-provider-gitee/src/__tests__/giteeStorageProvider.test.ts
+++ b/packages/plugin-provider-gitee/src/__tests__/giteeStorageProvider.test.ts
@@ -143,7 +143,7 @@ describe('GiteeStorageService', () => {
 
     it('应该上传图片文件（使用 URI）', async () => {
       const uploadData = {
-        uri: 'file:///path/to/image.jpg',
+        file: 'file:///path/to/image.jpg',
         name: 'image.jpg',
         description: 'Test image',
       };

--- a/packages/plugin-provider-gitee/src/__tests__/register.test.ts
+++ b/packages/plugin-provider-gitee/src/__tests__/register.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { createStoragePluginRegistry } from '@pixuli/core/plugins';
+import { registerGiteeProvider, giteeManifest } from '../register';
+import { GiteeStorageProvider } from '../giteeStorageProvider';
+
+describe('registerGiteeProvider', () => {
+  it('registers gitee manifest and creates provider', () => {
+    const registry = createStoragePluginRegistry();
+    registerGiteeProvider(registry);
+
+    expect(registry.listManifests()).toEqual([giteeManifest]);
+    const provider = registry.create('gitee', {
+      platform: 'web',
+      platformAdapter: {} as never,
+    });
+    expect(provider).toBeInstanceOf(GiteeStorageProvider);
+    expect(provider.manifest.id).toBe('gitee');
+  });
+
+  it('throws when registering gitee twice', () => {
+    const registry = createStoragePluginRegistry();
+    registerGiteeProvider(registry);
+    expect(() => registerGiteeProvider(registry)).toThrow(
+      'Storage plugin already registered: gitee',
+    );
+  });
+});

--- a/packages/plugin-provider-gitee/src/giteeStorageProvider.ts
+++ b/packages/plugin-provider-gitee/src/giteeStorageProvider.ts
@@ -3,47 +3,82 @@ import type {
   ImageItem,
   ImageUploadData,
 } from '@pixuli/core/types';
-import {
-  DefaultPlatformAdapter,
-  type PlatformAdapter,
-} from '@pixuli/core/platform';
+import type {
+  ImageListOptions,
+  ImageMetadataLoadOptions,
+  ProviderContext,
+  StorageProviderConfig,
+  StorageProviderWithMetadata,
+} from '@pixuli/core/plugins';
+import { giteeManifest } from './manifest';
 
-export class GiteeStorageService {
-  private config: GiteeConfig;
-  // private platform: 'web' | 'desktop' | 'mobile';
-  private baseUrl = 'https://gitee.com/api/v5';
-  private platformAdapter: PlatformAdapter;
-  private useProxy: boolean;
+function narrowGiteeConfig(
+  config: StorageProviderConfig | GiteeConfig,
+): GiteeConfig {
+  const { owner, repo, branch, token, path } = config;
 
-  constructor(
-    config: GiteeConfig,
-    options: {
-      platform: 'web' | 'desktop' | 'mobile';
-      platformAdapter?: PlatformAdapter;
-      useProxy?: boolean;
-    } = {
-      platform: 'web',
-      platformAdapter: new DefaultPlatformAdapter(),
-      useProxy: false,
-    },
+  if (
+    typeof owner !== 'string' ||
+    typeof repo !== 'string' ||
+    typeof branch !== 'string' ||
+    typeof token !== 'string' ||
+    typeof path !== 'string'
   ) {
-    this.config = config;
-    // this.platform = options.platform || 'web';
-    this.platformAdapter =
-      options.platformAdapter || new DefaultPlatformAdapter();
+    throw new Error('Invalid Gitee storage provider config');
+  }
+
+  return { owner, repo, branch, token, path };
+}
+
+export interface GiteeStorageProviderOptions {
+  useProxy?: boolean;
+}
+
+export class GiteeStorageProvider implements StorageProviderWithMetadata {
+  readonly manifest = giteeManifest;
+
+  private config!: GiteeConfig;
+  private readonly baseUrl = 'https://gitee.com/api/v5';
+  private readonly platformAdapter: ProviderContext['platformAdapter'];
+  private readonly fetchFn: typeof fetch;
+  private readonly logger: Pick<Console, 'log' | 'warn' | 'error'>;
+  private readonly useProxy: boolean;
+
+  constructor(ctx: ProviderContext, options: GiteeStorageProviderOptions = {}) {
+    this.platformAdapter = ctx.platformAdapter;
+    this.fetchFn =
+      ctx.fetch ??
+      ((input: RequestInfo | URL, init?: RequestInit) =>
+        globalThis.fetch(input, init));
+    this.logger = ctx.logger ?? console;
     this.useProxy = options.useProxy ?? false;
+  }
+
+  configure(config: StorageProviderConfig): void {
+    this.config = narrowGiteeConfig(config);
+  }
+
+  private assertConfigured(): void {
+    if (!this.config) {
+      throw new Error('Gitee storage provider is not configured');
+    }
+  }
+
+  getRawUrl(path: string): string {
+    this.assertConfigured();
+    const filePath = `${this.config.path}/${path}`;
+    return this.buildRawUrl(
+      this.config.owner,
+      this.config.repo,
+      this.config.branch,
+      filePath,
+    );
   }
 
   /**
    * 将 Gitee API 返回的 download_url 转换为 raw URL 格式
-   * 根据配置决定是否使用代理
-   * @param owner 仓库所有者
-   * @param repo 仓库名
-   * @param branch 分支名
-   * @param path 文件路径（相对于仓库根目录）
-   * @returns raw URL（根据 useProxy 配置决定是否使用代理）
    */
-  private getRawUrl(
+  private buildRawUrl(
     owner: string,
     repo: string,
     branch: string,
@@ -68,8 +103,7 @@ export class GiteeStorageService {
     endpoint: string,
     options: RequestInit = {},
   ): Promise<any> {
-    // Gitee API v5 使用 access_token 作为查询参数
-    // 注意：endpoint 可能已经包含查询参数（如 ref=branch），需要正确处理
+    this.assertConfigured();
     let url: string;
     if (endpoint.includes('?')) {
       // endpoint 已经包含查询参数，使用 & 连接 access_token
@@ -84,7 +118,7 @@ export class GiteeStorageService {
       ...(options.headers as Record<string, string>),
     };
 
-    const response = await fetch(url, {
+    const response = await this.fetchFn(url, {
       ...options,
       headers,
     });
@@ -152,7 +186,7 @@ export class GiteeStorageService {
     try {
       return await this.platformAdapter.getImageDimensions(file);
     } catch (error) {
-      console.warn(
+      this.logger.warn(
         'Failed to get image dimensions, using default values:',
         error,
       );
@@ -202,7 +236,7 @@ export class GiteeStorageService {
     });
 
     // 使用 raw URL 替代 API 返回的 download_url，避免跨域问题
-    const rawUrl = this.getRawUrl(
+    const rawUrl = this.buildRawUrl(
       this.config.owner,
       this.config.repo,
       this.config.branch,
@@ -227,9 +261,9 @@ export class GiteeStorageService {
     metadata: ImageItem,
   ): Promise<void> {
     try {
-      await this.updateImageMetadata(fileName, metadata);
+      await this.persistImageMetadata(fileName, metadata);
     } catch (error) {
-      console.error('Failed to upload metadata:', error);
+      this.logger.error('Failed to upload metadata:', error);
       // 元数据上传失败不应该阻止整个上传流程，但记录错误
       throw new Error(`上传元数据失败: ${error}`);
     }
@@ -246,14 +280,10 @@ export class GiteeStorageService {
    * @param uploadData 上传数据
    * @returns Promise<ImageItem> 上传后的图片信息
    */
-  async uploadImage(
-    uploadData:
-      | ImageUploadData
-      | { uri: string; name?: string; description?: string; tags?: string[] },
-  ): Promise<ImageItem> {
+  async uploadImage(uploadData: ImageUploadData): Promise<ImageItem> {
+    this.assertConfigured();
     try {
-      // 兼容 web/desktop 的 File 和 mobile 的 URI
-      const file = 'file' in uploadData ? uploadData.file : uploadData.uri;
+      const file = uploadData.file;
       const name = uploadData.name;
       const description = uploadData.description;
       const tags = uploadData.tags;
@@ -305,26 +335,27 @@ export class GiteeStorageService {
       } catch (error) {
         // 元数据上传失败时，记录警告但不影响图片上传的成功
         // 因为图片文件已经成功上传，元数据可以在后续补充
-        console.warn(
+        this.logger.warn(
           'Image file uploaded successfully, but metadata upload failed:',
           error,
         );
-        console.warn(
+        this.logger.warn(
           'You can update metadata later or it will be fetched from the image URL',
         );
       }
 
       return imageItem;
     } catch (error) {
-      console.error('Upload image failed:', error);
+      this.logger.error('Upload image failed:', error);
       throw new Error(`上传图片失败: ${error}`);
     }
   }
 
   // 删除图片
-  async deleteImage(_imageId: string, fileName: string): Promise<void> {
+  async deleteImage(path: string): Promise<void> {
+    this.assertConfigured();
     try {
-      const filePath = `${this.config.path}/${fileName}`;
+      const filePath = `${this.config.path}/${path}`;
 
       // 获取文件的当前 SHA
       const sha = await this.getFileSha(filePath, this.config.branch);
@@ -337,7 +368,7 @@ export class GiteeStorageService {
       await this.makeGiteeRequest(endpoint, {
         method: 'DELETE',
         body: JSON.stringify({
-          message: `Delete image: ${fileName}`,
+          message: `Delete image: ${path}`,
           sha,
           branch: this.config.branch,
         }),
@@ -345,13 +376,13 @@ export class GiteeStorageService {
 
       // 删除对应的元数据文件
       try {
-        await this.deleteImageMetadata(fileName);
+        await this.deleteImageMetadata(path);
       } catch (error) {
-        console.warn('Failed to delete metadata file:', error);
+        this.logger.warn('Failed to delete metadata file:', error);
         // 不抛出错误，因为图片已经删除成功
       }
     } catch (error) {
-      console.error('Delete image failed:', error);
+      this.logger.error('Delete image failed:', error);
       throw new Error(`删除图片失败: ${error}`);
     }
   }
@@ -385,13 +416,14 @@ export class GiteeStorageService {
       });
     } catch (error) {
       // 删除元数据失败不应该阻止图片删除，只记录警告
-      console.warn(`Failed to delete metadata for ${fileName}:`, error);
+      this.logger.warn(`Failed to delete metadata for ${fileName}:`, error);
       throw new Error(`Failed to delete metadata for ${fileName}: ${error}`);
     }
   }
 
   // 获取图片列表
-  async getImageList(): Promise<ImageItem[]> {
+  async listImages(_options?: ImageListOptions): Promise<ImageItem[]> {
+    this.assertConfigured();
     try {
       const endpoint = `/repos/${this.config.owner}/${this.config.repo}/contents/${encodeURIComponent(this.config.path)}?ref=${this.config.branch}`;
       const response = await this.makeGiteeRequest(endpoint, {
@@ -459,7 +491,7 @@ export class GiteeStorageService {
                     }
                   } catch (decodeError) {
                     // 如果解码失败，记录错误但继续处理其他文件
-                    console.debug(
+                    this.logger.log(
                       `Failed to decode metadata file ${file.name}:`,
                       decodeError,
                     );
@@ -467,7 +499,7 @@ export class GiteeStorageService {
                 }
               } catch (error) {
                 // 忽略单个 metadata 文件加载失败
-                console.debug(
+                this.logger.log(
                   `Failed to load metadata file ${file.name}:`,
                   error,
                 );
@@ -478,7 +510,7 @@ export class GiteeStorageService {
         }
       } catch (metadataError) {
         // .metadata 目录不存在或无法访问，使用默认值
-        console.debug(
+        this.logger.log(
           'Metadata directory not found or inaccessible:',
           metadataError,
         );
@@ -512,7 +544,7 @@ export class GiteeStorageService {
 
         // 使用 raw URL 替代 API 返回的 download_url，避免跨域问题
         const filePath = `${this.config.path}/${item.name}`;
-        const rawUrl = this.getRawUrl(
+        const rawUrl = this.buildRawUrl(
           this.config.owner,
           this.config.repo,
           this.config.branch,
@@ -548,7 +580,7 @@ export class GiteeStorageService {
         ([_, count]) => (count as number) > 1,
       );
       if (duplicateIds.length > 0) {
-        console.warn('发现重复的图片ID:', duplicateIds);
+        this.logger.warn('发现重复的图片ID:', duplicateIds);
         // 为重复的ID添加后缀以确保唯一性
         const processedImages = images.map((img: ImageItem, index: number) => {
           if (idCounts[img.id] > 1) {
@@ -564,28 +596,68 @@ export class GiteeStorageService {
 
       return images;
     } catch (error) {
-      console.error('Get image list failed:', error);
+      this.logger.error('Get image list failed:', error);
       throw new Error(`获取图片列表失败: ${error}`);
     }
   }
 
-  // 更新图片信息（如标签、描述等）
-  async updateImageInfo(
-    _imageId: string,
-    fileName: string,
-    metadata: any,
-  ): Promise<void> {
+  async updateImageMetadata(
+    path: string,
+    metadata: Partial<Pick<ImageItem, 'name' | 'description' | 'tags'>> & {
+      id?: string;
+      size?: number;
+      width?: number;
+      height?: number;
+      createdAt?: string;
+      updatedAt?: string;
+    },
+  ): Promise<ImageItem> {
+    this.assertConfigured();
     try {
-      // 更新元数据文件
-      await this.updateImageMetadata(fileName, metadata);
+      await this.persistImageMetadata(path, metadata);
+      const filePath = `${this.config.path}/${path}`;
+      return {
+        id: metadata.id ?? path,
+        name: metadata.name ?? path,
+        url: this.buildRawUrl(
+          this.config.owner,
+          this.config.repo,
+          this.config.branch,
+          filePath,
+        ),
+        githubUrl: `https://gitee.com/${this.config.owner}/${this.config.repo}/blob/${this.config.branch}/${filePath}`,
+        size: metadata.size ?? 0,
+        width: metadata.width ?? 0,
+        height: metadata.height ?? 0,
+        type: this.getMimeType(path),
+        tags: metadata.tags ?? [],
+        description: metadata.description ?? '',
+        createdAt: metadata.createdAt ?? new Date().toISOString(),
+        updatedAt: metadata.updatedAt ?? new Date().toISOString(),
+      };
     } catch (error) {
-      console.error('Update image info failed:', error);
+      this.logger.error('Update image info failed:', error);
       throw new Error(`更新图片信息失败: ${error}`);
     }
   }
 
-  // 更新图片元数据文件
-  private async updateImageMetadata(
+  /** @deprecated 兼容 pixuli-common GiteeStorageService，REF-304 后移除 */
+  async updateImageInfo(
+    _imageId: string,
+    fileName: string,
+    metadata: Partial<Pick<ImageItem, 'name' | 'description' | 'tags'>> & {
+      id?: string;
+      size?: number;
+      width?: number;
+      height?: number;
+      createdAt?: string;
+      updatedAt?: string;
+    },
+  ): Promise<void> {
+    await this.updateImageMetadata(fileName, metadata);
+  }
+
+  private async persistImageMetadata(
     fileName: string,
     metadata: any,
   ): Promise<void> {
@@ -676,7 +748,7 @@ export class GiteeStorageService {
         }
       }
     } catch (error) {
-      console.error('Update image metadata failed:', error);
+      this.logger.error('Update image metadata failed:', error);
       throw new Error(`更新图片元数据失败: ${error}`);
     }
   }
@@ -696,14 +768,14 @@ export class GiteeStorageService {
     try {
       const metadataFileName = this.getMetadataFileName(fileName);
       // 使用 Gitee raw URL 直接获取文件内容
-      const metadataUrl = this.getRawUrl(
+      const metadataUrl = this.buildRawUrl(
         this.config.owner,
         this.config.repo,
         this.config.branch,
         `${this.config.path}/.metadata/${metadataFileName}`,
       );
 
-      const response = await fetch(metadataUrl);
+      const response = await this.fetchFn(metadataUrl);
 
       if (response.status === 404) {
         return null;
@@ -732,7 +804,7 @@ export class GiteeStorageService {
    */
   async loadImageMetadata(
     images: ImageItem[],
-    _options?: { forceRefresh?: boolean; backgroundUpdate?: boolean },
+    _options?: ImageMetadataLoadOptions,
   ): Promise<ImageItem[]> {
     try {
       // 批量获取元数据
@@ -753,14 +825,14 @@ export class GiteeStorageService {
           }
           return img;
         } catch (error) {
-          console.debug(`Failed to load metadata for ${img.name}:`, error);
+          this.logger.log(`Failed to load metadata for ${img.name}:`, error);
           return img;
         }
       });
 
       return await Promise.all(metadataPromises);
     } catch (error) {
-      console.error('Load image metadata failed:', error);
+      this.logger.error('Load image metadata failed:', error);
       // 即使加载元数据失败，也返回原始图片列表
       return images;
     }

--- a/packages/plugin-provider-gitee/src/giteeStorageService.ts
+++ b/packages/plugin-provider-gitee/src/giteeStorageService.ts
@@ -1,0 +1,74 @@
+import type {
+  GiteeConfig,
+  ImageItem,
+  ImageUploadData,
+} from '@pixuli/core/types';
+import type { StorageProviderConfig } from '@pixuli/core/plugins';
+import {
+  DefaultPlatformAdapter,
+  type PlatformAdapter,
+} from '@pixuli/core/platform';
+import { GiteeStorageProvider } from './giteeStorageProvider';
+
+/**
+ * 兼容 pixuli-common 构造方式，供 REF-304 前 apps 继续使用。
+ */
+export class GiteeStorageService {
+  private readonly provider: GiteeStorageProvider;
+
+  constructor(
+    config: GiteeConfig,
+    options: {
+      platform: 'web' | 'desktop' | 'mobile';
+      platformAdapter?: PlatformAdapter;
+      useProxy?: boolean;
+    } = {
+      platform: 'web',
+      platformAdapter: new DefaultPlatformAdapter(),
+      useProxy: false,
+    },
+  ) {
+    this.provider = new GiteeStorageProvider(
+      {
+        platform: options.platform ?? 'web',
+        platformAdapter:
+          options.platformAdapter ?? new DefaultPlatformAdapter(),
+      },
+      { useProxy: options.useProxy ?? false },
+    );
+    this.provider.configure(config as unknown as StorageProviderConfig);
+  }
+
+  getImageDimensions(
+    file: File | string,
+  ): Promise<{ width: number; height: number }> {
+    return this.provider.getImageDimensions(file);
+  }
+
+  uploadImage(uploadData: ImageUploadData): Promise<ImageItem> {
+    return this.provider.uploadImage(uploadData);
+  }
+
+  deleteImage(_imageId: string, fileName: string): Promise<void> {
+    return this.provider.deleteImage(fileName);
+  }
+
+  getImageList(): Promise<ImageItem[]> {
+    return this.provider.listImages();
+  }
+
+  updateImageInfo(
+    imageId: string,
+    fileName: string,
+    metadata: Parameters<GiteeStorageProvider['updateImageInfo']>[2],
+  ): Promise<void> {
+    return this.provider.updateImageInfo(imageId, fileName, metadata);
+  }
+
+  loadImageMetadata(
+    images: ImageItem[],
+    options?: Parameters<GiteeStorageProvider['loadImageMetadata']>[1],
+  ): Promise<ImageItem[]> {
+    return this.provider.loadImageMetadata(images, options);
+  }
+}

--- a/packages/plugin-provider-gitee/src/index.ts
+++ b/packages/plugin-provider-gitee/src/index.ts
@@ -1,0 +1,4 @@
+export { GiteeStorageProvider } from './giteeStorageProvider';
+export type { GiteeStorageProviderOptions } from './giteeStorageProvider';
+export { GiteeStorageService } from './giteeStorageService';
+export { giteeManifest } from './manifest';

--- a/packages/plugin-provider-gitee/src/manifest.ts
+++ b/packages/plugin-provider-gitee/src/manifest.ts
@@ -1,0 +1,14 @@
+import type { StoragePluginManifest } from '@pixuli/core/plugins';
+
+export const giteeManifest: StoragePluginManifest = {
+  id: 'gitee',
+  name: 'Gitee',
+  version: '1.0.0',
+  capabilities: {
+    list: true,
+    upload: true,
+    delete: true,
+    updateMetadata: true,
+    needsProxy: true,
+  },
+};

--- a/packages/plugin-provider-gitee/src/register.ts
+++ b/packages/plugin-provider-gitee/src/register.ts
@@ -1,0 +1,9 @@
+import type { StoragePluginRegistry } from '@pixuli/core/plugins';
+import { GiteeStorageProvider } from './giteeStorageProvider';
+import { giteeManifest } from './manifest';
+
+export function registerGiteeProvider(registry: StoragePluginRegistry): void {
+  registry.register(giteeManifest, ctx => new GiteeStorageProvider(ctx));
+}
+
+export { giteeManifest };

--- a/packages/plugin-provider-gitee/tsconfig.json
+++ b/packages/plugin-provider-gitee/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/plugin-provider-gitee/vitest.config.ts
+++ b/packages/plugin-provider-gitee/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    include: ['**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    exclude: ['**/node_modules/**', '**/dist/**'],
+  },
+});

--- a/packages/plugin-provider-github/README.md
+++ b/packages/plugin-provider-github/README.md
@@ -1,0 +1,87 @@
+# @pixuli/provider-github
+
+Pixuli 官方 **GitHub 仓库图床**存储插件（M3 REF-302）。
+
+- **npm 包名**：`@pixuli/provider-github`
+- **Monorepo 目录**：`packages/plugin-provider-github`
+- **插件 ID**：`github`
+- **设计文档**：[存储插件体系设计](../../docs/02-system-design/07-storage-plugin-system.md)
+
+实现 GitHub Contents API + sidecar 元数据（`.metadata/`），符合
+[`@pixuli/core/plugins`](../core/README.md) 中的 `StorageProvider` 契约。
+
+## 导出
+
+| 路径                               | 内容                                                                        |
+| ---------------------------------- | --------------------------------------------------------------------------- |
+| `@pixuli/provider-github`          | `GitHubStorageProvider`、`GitHubStorageService`（兼容层）、`githubManifest` |
+| `@pixuli/provider-github/register` | `registerGitHubProvider(registry)`                                          |
+
+## 注册到 Registry
+
+```typescript
+import { createStoragePluginRegistry } from '@pixuli/core/plugins';
+import { registerGitHubProvider } from '@pixuli/provider-github/register';
+
+const registry = createStoragePluginRegistry();
+registerGitHubProvider(registry);
+
+const provider = registry.create('github', {
+  platform: 'web',
+  platformAdapter: getPlatformAdapter(),
+});
+provider.configure({
+  owner,
+  repo,
+  branch,
+  token,
+  path,
+});
+await provider.listImages();
+```
+
+## 配置形状
+
+与 [`GitHubConfig`](../core/src/types/github.ts) 一致：
+
+| 字段     | 说明           |
+| -------- | -------------- |
+| `owner`  | 仓库所有者     |
+| `repo`   | 仓库名         |
+| `branch` | 分支           |
+| `token`  | Personal Token |
+| `path`   | 图片目录路径   |
+
+## 兼容层（REF-304 前）
+
+应用仍可通过 `pixuli-common/services` 使用旧 API：
+
+```typescript
+import { GitHubStorageService } from 'pixuli-common/services';
+
+const service = new GitHubStorageService(config, {
+  platform: 'web',
+  platformAdapter,
+});
+await service.getImageList();
+```
+
+`GitHubStorageService` 内部委托给
+`GitHubStorageProvider`，方法名保持与 M2 一致（如 `getImageList` → 内部
+`listImages`）。
+
+## 依赖边界
+
+- **仅依赖** `@pixuli/core`（types、platform、plugins）
+- **禁止**依赖 `@pixuli/ui`、`react-dom`
+  等 UI 层（REF-209，`pnpm lint:boundaries`）
+
+## 开发
+
+```bash
+pnpm --filter @pixuli/provider-github test
+```
+
+## License
+
+MIT

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       '@pixuli/core':
         specifier: workspace:*
         version: link:../core
+      '@pixuli/provider-gitee':
+        specifier: workspace:*
+        version: link:../plugin-provider-gitee
       '@pixuli/provider-github':
         specifier: workspace:*
         version: link:../plugin-provider-github
@@ -304,6 +307,25 @@ importers:
         version: 5.9.3
 
   packages/core:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.18.12
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.18.12)(@vitest/ui@2.1.9)(jsdom@25.0.1)(lightningcss@1.30.2)(terser@5.44.1)
+
+  packages/plugin-provider-gitee:
+    dependencies:
+      '@pixuli/core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -10831,7 +10853,9 @@ snapshots:
       metro-runtime: 0.83.3
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
     optional: true
 
   '@react-native/normalize-colors@0.74.89': {}

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -3,6 +3,7 @@ import { defineWorkspace } from 'vitest/config';
 export default defineWorkspace([
   './packages/core/vitest.config.ts',
   './packages/plugin-provider-github/vitest.config.ts',
+  './packages/plugin-provider-gitee/vitest.config.ts',
   './packages/ui/vitest.config.ts',
   // packages/common - 需要 jsdom 环境
   './packages/common/vitest.config.ts',


### PR DESCRIPTION
## Summary
- 新增 `packages/plugin-provider-gitee`（npm：`@pixuli/provider-gitee`），实现 `GiteeStorageProvider` 与 `registerGiteeProvider(registry)`
- 自 `pixuli-common` 迁出 Gitee 存储逻辑与单测；保留 `GiteeStorageService` 兼容层（含 `useProxy`）
- `pixuli-common/services` 改为 re-export；补充 `@pixuli/provider-github` / `@pixuli/provider-gitee` 包 README

## Test plan
- [x] `pnpm --filter @pixuli/provider-gitee test`
- [x] `pnpm --filter pixuli-common test`
- [x] CI 全绿

Closes #72


Made with [Cursor](https://cursor.com)