### PR TITLE
feat(m3): REF-306 配置持久化增加 pluginId（导入/导出）

### DIFF
--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -508,7 +508,7 @@ native。
 | REF-303 | [M3] 实现 @pixuli/provider-gitee                | refactor, m3, area:plugin, priority:P0            | P0     | #70                | [#72](https://github.com/trueLoving/Pixuli/issues/72)   | ✅   |
 | REF-304 | [M3] 重构 apps/pixuli imageStore 使用 Registry  | refactor, m3, area:web, area:desktop, priority:P0 | P0     | #71, #72, #64      | [#73](https://github.com/trueLoving/Pixuli/issues/73)   | ✅   |
 | REF-305 | [M3] 重构 apps/mobile imageStore 使用 Registry  | refactor, m3, area:mobile, priority:P0            | P0     | #71, #72, #65      | [#74](https://github.com/trueLoving/Pixuli/issues/74)   | ✅   |
-| REF-306 | [M3] 配置持久化增加 pluginId（导入/导出）       | refactor, m3, priority:P1                         | P1     | #73, #74           | [#75](https://github.com/trueLoving/Pixuli/issues/75)   | ⬜   |
+| REF-306 | [M3] 配置持久化增加 pluginId（导入/导出）       | refactor, m3, priority:P1                         | P1     | #73, #74           | [#75](https://github.com/trueLoving/Pixuli/issues/75)   | ✅   |
 | REF-307 | [M3] 设置页源列表对接 registry.listManifests    | refactor, m3, area:ui, priority:P1                | P1     | #75                | [#76](https://github.com/trueLoving/Pixuli/issues/76)   | ⬜   |
 | REF-308 | [M3] 编写插件开发文档 docs/plugins/authoring.md | refactor, m3, type:docs, priority:P1              | P1     | #70                | [#77](https://github.com/trueLoving/Pixuli/issues/77)   | ⬜   |
 | REF-309 | [M3] provider 包单元测试迁移                    | refactor, m3, priority:P1                         | P1     | #71, #72           | [#78](https://github.com/trueLoving/Pixuli/issues/78)   | ⬜   |
@@ -645,7 +645,7 @@ flowchart LR
 | -------- | -------- | ------ | ------- |
 | M1       | 12       | 7      | 58%     |
 | M2       | 10       | 0      | 0%      |
-| M3       | 11       | 5      | 45%     |
+| M3       | 11       | 6      | 55%     |
 | M4       | 6        | 0      | 0%      |
 | M5       | 5        | 0      | 0%      |
 | **合计** | **44**   | **7**  | **16%** |

--- a/apps/mobile/components/navigation/DrawerMenu.tsx
+++ b/apps/mobile/components/navigation/DrawerMenu.tsx
@@ -2,6 +2,10 @@ import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { useI18n } from '@/i18n/useI18n';
 import { useImageStore } from '@/stores/imageStore';
+import {
+  getRepoConfigFromSource,
+  pluginIdToLegacyType,
+} from '@pixuli/core/sources';
 import { useSourceStore } from '@/stores/sourceStore';
 import { useRouter } from 'expo-router';
 import React from 'react';
@@ -68,10 +72,17 @@ export function DrawerMenu({ visible, onClose }: DrawerMenuProps) {
     ? sources.find(s => s.id === selectedSourceId)
     : sources[0] || null;
 
-  const allSources = sources.map(source => ({
-    ...source,
-    isActive: selectedSourceId === source.id,
-  }));
+  const allSources = sources.map(source => {
+    const repo = getRepoConfigFromSource(source);
+    return {
+      id: source.id,
+      label: source.label,
+      pluginId: source.pluginId,
+      owner: repo.owner,
+      repo: repo.repo,
+      isActive: selectedSourceId === source.id,
+    };
+  });
 
   const handleAddSource = () => {
     setConfigModalType(undefined);
@@ -82,7 +93,7 @@ export function DrawerMenu({ visible, onClose }: DrawerMenuProps) {
   const handleEditSource = (sourceId: string) => {
     const source = sources.find(s => s.id === sourceId);
     if (source) {
-      setConfigModalType(source.type);
+      setConfigModalType(pluginIdToLegacyType(source.pluginId));
       setEditingSourceId(sourceId);
       setConfigModalVisible(true);
     }
@@ -94,8 +105,8 @@ export function DrawerMenu({ visible, onClose }: DrawerMenuProps) {
 
     const deleteConfirmText = t('settings.storage.deleteConfirm');
     const confirmMessage = deleteConfirmText
-      ? deleteConfirmText.replace('{name}', source.name)
-      : `确定要删除仓库源 "${source.name}" 吗？`;
+      ? deleteConfirmText.replace('{name}', source.label)
+      : `确定要删除仓库源 "${source.label}" 吗？`;
 
     Alert.alert(t('common.confirm'), confirmMessage, [
       {
@@ -264,7 +275,7 @@ export function DrawerMenu({ visible, onClose }: DrawerMenuProps) {
                       onLongPress={() => {
                         // 长按显示操作菜单
                         Alert.alert(
-                          source.name,
+                          source.label,
                           `${source.owner}/${source.repo}`,
                           [
                             {
@@ -299,7 +310,7 @@ export function DrawerMenu({ visible, onClose }: DrawerMenuProps) {
                             },
                           ]}
                         >
-                          {source.type === 'github' ? (
+                          {source.pluginId === 'github' ? (
                             <IconSymbol
                               name="chevron.left.forwardslash.chevron.right"
                               size={22}
@@ -331,7 +342,7 @@ export function DrawerMenu({ visible, onClose }: DrawerMenuProps) {
                               dynamicStyles.sourceItemText,
                             ]}
                           >
-                            {source.name}
+                            {source.label}
                           </ThemedText>
                           <ThemedText
                             style={[

--- a/apps/mobile/components/settings/modals/StorageConfigModal.tsx
+++ b/apps/mobile/components/settings/modals/StorageConfigModal.tsx
@@ -4,6 +4,12 @@ import { useI18n } from '@/i18n/useI18n';
 import { useImageStore } from '@/stores/imageStore';
 import { useSourceStore } from '@/stores/sourceStore';
 import { showError, showSuccess } from '@/utils/toast';
+import {
+  buildPluginConfigExport,
+  getRepoConfigFromSource,
+  parsePluginConfigImport,
+  pluginIdToLegacyType,
+} from '@pixuli/core/sources';
 import type { GitHubConfig, GiteeConfig } from '@pixuli/core/types';
 import * as DocumentPicker from 'expo-document-picker';
 import { useEffect, useRef, useState } from 'react';
@@ -70,14 +76,14 @@ export function StorageConfigModal({
         if (sourceId) {
           const source = sources.find(s => s.id === sourceId);
           if (source) {
-            setSelectedType(source.type);
+            setSelectedType(pluginIdToLegacyType(source.pluginId));
+            const repo = getRepoConfigFromSource(source);
             setFormData({
-              owner: source.owner || '',
-              repo: source.repo || '',
-              branch:
-                source.branch || (source.type === 'github' ? 'main' : 'master'),
-              token: source.token || '',
-              path: source.path || 'images',
+              owner: repo.owner,
+              repo: repo.repo,
+              branch: repo.branch,
+              token: repo.token,
+              path: repo.path,
             });
           }
         } else if (initialType) {
@@ -134,14 +140,11 @@ export function StorageConfigModal({
       }
 
       const fileContent = await FileSystem.readAsStringAsync(file.uri);
-      const configData = JSON.parse(fileContent);
-
-      if (
-        !configData.config ||
-        !configData.config.owner ||
-        !configData.config.repo ||
-        !configData.config.token
-      ) {
+      const parsed = parsePluginConfigImport(
+        JSON.parse(fileContent),
+        currentType ?? 'github',
+      );
+      if (!parsed) {
         showError(
           currentType === 'github'
             ? t('settings.github.invalidFormat')
@@ -150,14 +153,20 @@ export function StorageConfigModal({
         return;
       }
 
+      const importedType = pluginIdToLegacyType(parsed.pluginId);
+      if (currentType && importedType !== currentType) {
+        setSelectedType(importedType);
+      }
+
       setFormData({
-        owner: configData.config.owner || '',
-        repo: configData.config.repo || '',
-        branch:
-          configData.config.branch ||
-          (currentType === 'github' ? 'main' : 'master'),
-        token: configData.config.token || '',
-        path: configData.config.path || 'images',
+        owner: String(parsed.config.owner ?? ''),
+        repo: String(parsed.config.repo ?? ''),
+        branch: String(
+          parsed.config.branch ??
+            (importedType === 'github' ? 'main' : 'master'),
+        ),
+        token: String(parsed.config.token ?? ''),
+        path: String(parsed.config.path ?? 'images'),
       });
 
       showSuccess(
@@ -196,23 +205,14 @@ export function StorageConfigModal({
       if (sourceId) {
         // 编辑现有源
         updateSource(sourceId, {
-          name: `${formData.owner}/${formData.repo}`,
-          owner: formData.owner,
-          repo: formData.repo,
-          branch: formData.branch,
-          token: formData.token,
-          path: formData.path,
+          label: `${formData.owner}/${formData.repo}`,
+          config: { ...formData },
         });
       } else {
-        // 添加新源
         const newSource = addSource({
-          type: currentType,
-          name: `${formData.owner}/${formData.repo}`,
-          owner: formData.owner,
-          repo: formData.repo,
-          branch: formData.branch,
-          token: formData.token,
-          path: formData.path,
+          pluginId: currentType,
+          label: `${formData.owner}/${formData.repo}`,
+          config: { ...formData },
         });
         setSelectedSourceId(newSource.id);
       }

--- a/apps/mobile/stores/imageStore.ts
+++ b/apps/mobile/stores/imageStore.ts
@@ -8,6 +8,7 @@ import type {
   MultiImageUploadData,
   UploadProgress,
 } from '@pixuli/core/types';
+import { getRepoConfigFromSource } from '@pixuli/core/sources';
 import {
   createConfiguredStorageProvider,
   hasLoadImageMetadata,
@@ -130,13 +131,15 @@ export const useImageStore = create<ImageState>((set, get) => ({
 
       if (oldGitHubConfig) {
         const migratedSource = sourceStore.addSource({
-          type: 'github',
-          name: `${oldGitHubConfig.owner}/${oldGitHubConfig.repo}`,
-          owner: oldGitHubConfig.owner,
-          repo: oldGitHubConfig.repo,
-          branch: oldGitHubConfig.branch,
-          token: oldGitHubConfig.token,
-          path: oldGitHubConfig.path,
+          pluginId: 'github',
+          label: `${oldGitHubConfig.owner}/${oldGitHubConfig.repo}`,
+          config: {
+            owner: oldGitHubConfig.owner,
+            repo: oldGitHubConfig.repo,
+            branch: oldGitHubConfig.branch,
+            token: oldGitHubConfig.token,
+            path: oldGitHubConfig.path,
+          },
         });
         sourceStore.setSelectedSourceId(migratedSource.id);
         // 迁移后清除旧配置并标记已完成迁移
@@ -144,13 +147,15 @@ export const useImageStore = create<ImageState>((set, get) => ({
         await AsyncStorage.setItem(MIGRATION_FLAG_KEY, 'true');
       } else if (oldGiteeConfig) {
         const migratedSource = sourceStore.addSource({
-          type: 'gitee',
-          name: `${oldGiteeConfig.owner}/${oldGiteeConfig.repo}`,
-          owner: oldGiteeConfig.owner,
-          repo: oldGiteeConfig.repo,
-          branch: oldGiteeConfig.branch,
-          token: oldGiteeConfig.token,
-          path: oldGiteeConfig.path,
+          pluginId: 'gitee',
+          label: `${oldGiteeConfig.owner}/${oldGiteeConfig.repo}`,
+          config: {
+            owner: oldGiteeConfig.owner,
+            repo: oldGiteeConfig.repo,
+            branch: oldGiteeConfig.branch,
+            token: oldGiteeConfig.token,
+            path: oldGiteeConfig.path,
+          },
         });
         sourceStore.setSelectedSourceId(migratedSource.id);
         // 迁移后清除旧配置并标记已完成迁移
@@ -169,15 +174,9 @@ export const useImageStore = create<ImageState>((set, get) => ({
       : sources[0] || null;
 
     if (selectedSource) {
-      const config = {
-        owner: selectedSource.owner,
-        repo: selectedSource.repo,
-        branch: selectedSource.branch,
-        token: selectedSource.token,
-        path: selectedSource.path,
-      };
+      const config = getRepoConfigFromSource(selectedSource);
 
-      if (selectedSource.type === 'github') {
+      if (selectedSource.pluginId === 'github') {
         set({
           githubConfig: config,
           giteeConfig: null,
@@ -229,26 +228,16 @@ export const useImageStore = create<ImageState>((set, get) => ({
       ? sourceStore.getSourceById(selectedSourceId)
       : null;
 
-    if (selectedSource && selectedSource.type === 'github') {
-      // 更新现有源
+    if (selectedSource && selectedSource.pluginId === 'github') {
       sourceStore.updateSource(selectedSourceId!, {
-        name: `${config.owner}/${config.repo}`,
-        owner: config.owner,
-        repo: config.repo,
-        branch: config.branch,
-        token: config.token,
-        path: config.path,
+        label: `${config.owner}/${config.repo}`,
+        config: { ...config },
       });
     } else {
-      // 创建新源
       const newSource = sourceStore.addSource({
-        type: 'github',
-        name: `${config.owner}/${config.repo}`,
-        owner: config.owner,
-        repo: config.repo,
-        branch: config.branch,
-        token: config.token,
-        path: config.path,
+        pluginId: 'github',
+        label: `${config.owner}/${config.repo}`,
+        config: { ...config },
       });
       sourceStore.setSelectedSourceId(newSource.id);
     }
@@ -274,7 +263,9 @@ export const useImageStore = create<ImageState>((set, get) => ({
     // 这个方法保留用于向后兼容
     // 从 sourceStore 中删除所有 GitHub 源
     const sourceStore = useSourceStore.getState();
-    const githubSources = sourceStore.sources.filter(s => s.type === 'github');
+    const githubSources = sourceStore.sources.filter(
+      s => s.pluginId === 'github',
+    );
 
     // 等待所有删除操作完成
     for (const source of githubSources) {
@@ -285,7 +276,7 @@ export const useImageStore = create<ImageState>((set, get) => ({
     const currentSource = sourceStore.selectedSourceId
       ? sourceStore.getSourceById(sourceStore.selectedSourceId)
       : null;
-    if (currentSource && currentSource.type === 'github') {
+    if (currentSource && currentSource.pluginId === 'github') {
       const remainingSources = sourceStore.sources;
       if (remainingSources.length > 0) {
         sourceStore.setSelectedSourceId(remainingSources[0].id);
@@ -321,26 +312,16 @@ export const useImageStore = create<ImageState>((set, get) => ({
       ? sourceStore.getSourceById(selectedSourceId)
       : null;
 
-    if (selectedSource && selectedSource.type === 'gitee') {
-      // 更新现有源
+    if (selectedSource && selectedSource.pluginId === 'gitee') {
       sourceStore.updateSource(selectedSourceId!, {
-        name: `${config.owner}/${config.repo}`,
-        owner: config.owner,
-        repo: config.repo,
-        branch: config.branch,
-        token: config.token,
-        path: config.path,
+        label: `${config.owner}/${config.repo}`,
+        config: { ...config },
       });
     } else {
-      // 创建新源
       const newSource = sourceStore.addSource({
-        type: 'gitee',
-        name: `${config.owner}/${config.repo}`,
-        owner: config.owner,
-        repo: config.repo,
-        branch: config.branch,
-        token: config.token,
-        path: config.path,
+        pluginId: 'gitee',
+        label: `${config.owner}/${config.repo}`,
+        config: { ...config },
       });
       sourceStore.setSelectedSourceId(newSource.id);
     }
@@ -366,7 +347,9 @@ export const useImageStore = create<ImageState>((set, get) => ({
     // 这个方法保留用于向后兼容
     // 从 sourceStore 中删除所有 Gitee 源
     const sourceStore = useSourceStore.getState();
-    const giteeSources = sourceStore.sources.filter(s => s.type === 'gitee');
+    const giteeSources = sourceStore.sources.filter(
+      s => s.pluginId === 'gitee',
+    );
 
     // 等待所有删除操作完成
     for (const source of giteeSources) {
@@ -377,7 +360,7 @@ export const useImageStore = create<ImageState>((set, get) => ({
     const currentSource = sourceStore.selectedSourceId
       ? sourceStore.getSourceById(sourceStore.selectedSourceId)
       : null;
-    if (currentSource && currentSource.type === 'gitee') {
+    if (currentSource && currentSource.pluginId === 'gitee') {
       const remainingSources = sourceStore.sources;
       if (remainingSources.length > 0) {
         sourceStore.setSelectedSourceId(remainingSources[0].id);
@@ -413,15 +396,9 @@ export const useImageStore = create<ImageState>((set, get) => ({
       : sourceStore.sources[0] || null;
 
     if (selectedSource) {
-      const config = {
-        owner: selectedSource.owner,
-        repo: selectedSource.repo,
-        branch: selectedSource.branch,
-        token: selectedSource.token,
-        path: selectedSource.path,
-      };
+      const config = getRepoConfigFromSource(selectedSource);
 
-      if (selectedSource.type === 'github') {
+      if (selectedSource.pluginId === 'github') {
         set({
           githubConfig: config,
           giteeConfig: null,

--- a/apps/mobile/stores/sourceStore.ts
+++ b/apps/mobile/stores/sourceStore.ts
@@ -1,66 +1,56 @@
-import { create } from 'zustand';
+import {
+  createStoredSourceEntry,
+  mergeStoredSourceUpdate,
+  normalizeStoredSources,
+  type CreateStoredSourceInput,
+  type StoredSourceEntry,
+} from '@pixuli/core/sources';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { create } from 'zustand';
 
-export interface GitHubSourceConfig {
-  id: string;
-  type: 'github';
-  name: string;
-  owner: string;
-  repo: string;
-  branch: string;
-  token: string;
-  path: string;
-  createdAt: number;
-  updatedAt: number;
-}
-
-export interface GiteeSourceConfig {
-  id: string;
-  type: 'gitee';
-  name: string;
-  owner: string;
-  repo: string;
-  branch: string;
-  token: string;
-  path: string;
-  createdAt: number;
-  updatedAt: number;
-}
-
-export type SourceConfig = GitHubSourceConfig | GiteeSourceConfig;
+export type SourceConfig = StoredSourceEntry;
+export type AddSourceInput = CreateStoredSourceInput;
+export type UpdateSourceInput = Partial<{
+  label: string;
+  pluginId: string;
+  config: StoredSourceEntry['config'];
+}>;
 
 type SourceState = {
   sources: SourceConfig[];
   selectedSourceId: string | null;
-  addSource: (
-    input:
-      | Omit<GitHubSourceConfig, 'id' | 'createdAt' | 'updatedAt'>
-      | Omit<GiteeSourceConfig, 'id' | 'createdAt' | 'updatedAt'>,
-  ) => SourceConfig;
-  updateSource: (
-    id: string,
-    input:
-      | Partial<Omit<GitHubSourceConfig, 'id' | 'createdAt' | 'type'>>
-      | Partial<Omit<GiteeSourceConfig, 'id' | 'createdAt' | 'type'>>,
-  ) => void;
+  addSource: (input: AddSourceInput) => SourceConfig;
+  updateSource: (id: string, input: UpdateSourceInput) => void;
   removeSource: (id: string) => Promise<void>;
   getSourceById: (id: string) => SourceConfig | undefined;
   setSelectedSourceId: (id: string | null) => void;
   initialize: () => Promise<void>;
 };
 
-const STORAGE_KEY = 'pixuli.sources.v1';
+const STORAGE_KEY = 'pixuli.sources.v2';
+const LEGACY_STORAGE_KEY = 'pixuli.sources.v1';
 const SELECTED_SOURCE_KEY = 'pixuli.selectedSourceId';
 
 async function loadSources(): Promise<SourceConfig[]> {
   try {
     const raw = await AsyncStorage.getItem(STORAGE_KEY);
-    if (!raw) {
-      return [];
+    if (raw) {
+      return normalizeStoredSources(JSON.parse(raw));
     }
-    const data = JSON.parse(raw);
-    if (!Array.isArray(data)) return [];
-    return data as SourceConfig[];
+
+    const legacyRaw = await AsyncStorage.getItem(LEGACY_STORAGE_KEY);
+    if (legacyRaw) {
+      const data = JSON.parse(legacyRaw);
+      if (Array.isArray(data)) {
+        const migrated = normalizeStoredSources(data);
+        if (migrated.length > 0) {
+          await saveSources(migrated);
+          return migrated;
+        }
+      }
+    }
+
+    return [];
   } catch (error) {
     console.error('Failed to load sources:', error);
     return [];
@@ -107,13 +97,10 @@ export const useSourceStore = create<SourceState>((set, get) => ({
   },
 
   addSource: input => {
-    const now = Date.now();
-    const source: SourceConfig = {
-      id: Math.random().toString(36).slice(2, 10) + Date.now().toString(36),
-      createdAt: now,
-      updatedAt: now,
-      ...input,
-    } as SourceConfig;
+    const source = createStoredSourceEntry(
+      input,
+      Math.random().toString(36).slice(2, 10) + Date.now().toString(36),
+    );
     const next = [...get().sources, source];
     set({ sources: next });
     saveSources(next);
@@ -122,7 +109,7 @@ export const useSourceStore = create<SourceState>((set, get) => ({
 
   updateSource: (id, input) => {
     const next = get().sources.map(s =>
-      s.id === id ? { ...s, ...input, updatedAt: Date.now() } : s,
+      s.id === id ? mergeStoredSourceUpdate(s, input) : s,
     );
     set({ sources: next });
     saveSources(next);
@@ -132,7 +119,6 @@ export const useSourceStore = create<SourceState>((set, get) => ({
     const next = get().sources.filter(s => s.id !== id);
     set({ sources: next });
     await saveSources(next);
-    // 如果删除的是当前选中的源，清除选中状态
     if (get().selectedSourceId === id) {
       set({ selectedSourceId: null });
       await saveSelectedSourceId(null);

--- a/apps/pixuli/src/App.tsx
+++ b/apps/pixuli/src/App.tsx
@@ -112,7 +112,7 @@ function App() {
   );
 
   // 同步选中源到配置，并在同步后加载图片
-  useSelectedSourceSync(selectedSource, () => {
+  useSelectedSourceSync(selectedSource ?? null, () => {
     if (sources.length > 0 && selectedSource) {
       handleLoadImages();
     }

--- a/apps/pixuli/src/hooks/useConfigManagement.ts
+++ b/apps/pixuli/src/hooks/useConfigManagement.ts
@@ -18,25 +18,19 @@ export function useConfigManagement() {
     useSourceStore();
 
   const handleSaveConfig = useCallback(
-    (config: any, editingSourceId: string | null) => {
-      if (editingSourceId) {
-        // 编辑现有源
-        updateSource(editingSourceId, {
-          ...config,
-          name: config.name || `${config.owner}/${config.repo}`,
-        });
-      } else {
-        // 添加新源
-        const newSource = addSource({
-          type: storageType!,
-          name: `${config.owner}/${config.repo}`,
-          ...config,
-        });
-        setSelectedSourceId(newSource.id);
-      }
-
-      // 切换到保存的源并加载图片
-      const sourceConfig = {
+    (
+      config: {
+        owner: string;
+        repo: string;
+        branch: string;
+        token: string;
+        path: string;
+        name?: string;
+      },
+      editingSourceId: string | null,
+    ) => {
+      const label = config.name || `${config.owner}/${config.repo}`;
+      const repoConfig = {
         owner: config.owner,
         repo: config.repo,
         branch: config.branch,
@@ -44,13 +38,26 @@ export function useConfigManagement() {
         path: config.path,
       };
 
-      if (storageType === 'github') {
-        setGitHubConfig(sourceConfig);
+      if (editingSourceId) {
+        updateSource(editingSourceId, {
+          label,
+          config: repoConfig,
+        });
       } else {
-        setGiteeConfig(sourceConfig);
+        const newSource = addSource({
+          pluginId: storageType!,
+          label,
+          config: repoConfig,
+        });
+        setSelectedSourceId(newSource.id);
       }
 
-      // 延迟加载，确保配置已更新
+      if (storageType === 'github') {
+        setGitHubConfig(repoConfig);
+      } else {
+        setGiteeConfig(repoConfig);
+      }
+
       setTimeout(() => {
         loadImages();
       }, 100);
@@ -68,12 +75,10 @@ export function useConfigManagement() {
 
   const handleClearConfig = useCallback(
     (editingSourceId: string | null) => {
-      // 如果正在编辑现有源，则移除该源
       if (editingSourceId) {
         removeSource(editingSourceId);
         setSelectedSourceId(null);
       }
-      // 根据存储类型清除相应的配置
       if (storageType === 'github') {
         clearGitHubConfig();
       } else if (storageType === 'gitee') {

--- a/apps/pixuli/src/hooks/useSelectedSourceSync.ts
+++ b/apps/pixuli/src/hooks/useSelectedSourceSync.ts
@@ -1,3 +1,7 @@
+import {
+  getRepoConfigFromSource,
+  type StoredSourceEntry,
+} from '@pixuli/core/sources';
 import { useEffect, useRef } from 'react';
 import { useImageStore } from '../stores/imageStore';
 
@@ -5,7 +9,7 @@ import { useImageStore } from '../stores/imageStore';
  * 同步选中源到 store 的配置
  */
 export function useSelectedSourceSync(
-  selectedSource: any,
+  selectedSource: StoredSourceEntry | null,
   onConfigSynced?: () => void,
 ) {
   const { setGitHubConfig, setGiteeConfig } = useImageStore();
@@ -14,7 +18,6 @@ export function useSelectedSourceSync(
 
   useEffect(() => {
     if (selectedSource) {
-      // 避免重复同步同一个源（但首次加载时允许同步）
       if (
         lastSyncedSourceIdRef.current === selectedSource.id &&
         !isInitialMountRef.current
@@ -22,14 +25,8 @@ export function useSelectedSourceSync(
         return;
       }
 
-      const sourceConfig = {
-        owner: selectedSource.owner,
-        repo: selectedSource.repo,
-        branch: selectedSource.branch,
-        token: selectedSource.token,
-        path: selectedSource.path,
-      };
-      if (selectedSource.type === 'github') {
+      const sourceConfig = getRepoConfigFromSource(selectedSource);
+      if (selectedSource.pluginId === 'github') {
         setGitHubConfig(sourceConfig);
         useImageStore.setState({ storageType: 'github' });
       } else {
@@ -37,13 +34,10 @@ export function useSelectedSourceSync(
         useImageStore.setState({ storageType: 'gitee' });
       }
 
-      // 标记已同步，并触发回调
-      // 注意：setGitHubConfig 和 setGiteeConfig 内部已经调用了 initializeStorage()
       lastSyncedSourceIdRef.current = selectedSource.id;
       isInitialMountRef.current = false;
 
       if (onConfigSynced) {
-        // 延迟执行，确保 store 状态已更新和存储服务已初始化
         setTimeout(() => {
           const { storageProvider, initializeStorage } =
             useImageStore.getState();

--- a/apps/pixuli/src/hooks/useSourceManagement.ts
+++ b/apps/pixuli/src/hooks/useSourceManagement.ts
@@ -1,3 +1,7 @@
+import {
+  getRepoConfigFromSource,
+  pluginIdToLegacyType,
+} from '@pixuli/core/sources';
 import { useCallback, useMemo } from 'react';
 import { useImageStore } from '../stores/imageStore';
 import { useSourceStore } from '../stores/sourceStore';
@@ -10,50 +14,38 @@ export function useSourceManagement() {
   const { sources, selectedSourceId, setSelectedSourceId, removeSource } =
     useSourceStore();
 
-  // 获取当前选中的源
   const selectedSource = useMemo(() => {
     return selectedSourceId
       ? sources.find(s => s.id === selectedSourceId)
       : sources[0] || null;
   }, [sources, selectedSourceId]);
 
-  // 构建仓库源列表（用于侧边栏）
   const sidebarSources = useMemo(() => {
-    return sources.map(source => ({
-      id: source.id,
-      name: source.name || `${source.owner}/${source.repo}`,
-      type: source.type,
-      owner: source.owner,
-      repo: source.repo,
-      path: source.path,
-      active: selectedSourceId === source.id,
-    }));
+    return sources.map(source => {
+      const repo = getRepoConfigFromSource(source);
+      return {
+        id: source.id,
+        name: source.label || `${repo.owner}/${repo.repo}`,
+        type: pluginIdToLegacyType(source.pluginId),
+        owner: repo.owner,
+        repo: repo.repo,
+        path: repo.path,
+        active: selectedSourceId === source.id,
+      };
+    });
   }, [sources, selectedSourceId]);
 
-  // 处理编辑仓库源
   const handleEditSource = useCallback(
     (sourceId: string) => {
       const source = sources.find(s => s.id === sourceId);
       if (source) {
-        // 设置存储类型
-        useImageStore.setState({ storageType: source.type });
-        // 设置配置
-        if (source.type === 'github') {
-          setGitHubConfig({
-            owner: source.owner,
-            repo: source.repo,
-            branch: source.branch,
-            token: source.token,
-            path: source.path,
-          });
+        const pluginId = pluginIdToLegacyType(source.pluginId);
+        const sourceConfig = getRepoConfigFromSource(source);
+        useImageStore.setState({ storageType: pluginId });
+        if (pluginId === 'github') {
+          setGitHubConfig(sourceConfig);
         } else {
-          setGiteeConfig({
-            owner: source.owner,
-            repo: source.repo,
-            branch: source.branch,
-            token: source.token,
-            path: source.path,
-          });
+          setGiteeConfig(sourceConfig);
         }
         return sourceId;
       }
@@ -62,13 +54,10 @@ export function useSourceManagement() {
     [sources, setGitHubConfig, setGiteeConfig],
   );
 
-  // 处理删除仓库源
   const handleDeleteSource = useCallback(
     (sourceId: string, t: (key: string) => string) => {
-      // 确认删除
       if (window.confirm(t('sidebar.confirmDeleteSource'))) {
         removeSource(sourceId);
-        // 如果删除的是当前选中的源，清除选中状态
         if (selectedSourceId === sourceId) {
           setSelectedSourceId(null);
         }
@@ -77,20 +66,14 @@ export function useSourceManagement() {
     [removeSource, selectedSourceId, setSelectedSourceId],
   );
 
-  // 处理源选择
   const handleSourceSelect = useCallback(
     (id: string) => {
       const source = sources.find(s => s.id === id);
       if (source) {
         setSelectedSourceId(id);
-        const sourceConfig = {
-          owner: source.owner,
-          repo: source.repo,
-          branch: source.branch,
-          token: source.token,
-          path: source.path,
-        };
-        if (source.type === 'github') {
+        const sourceConfig = getRepoConfigFromSource(source);
+        const pluginId = pluginIdToLegacyType(source.pluginId);
+        if (pluginId === 'github') {
           setGitHubConfig(sourceConfig);
         } else {
           setGiteeConfig(sourceConfig);

--- a/apps/pixuli/src/layouts/MainLayout.tsx
+++ b/apps/pixuli/src/layouts/MainLayout.tsx
@@ -13,6 +13,7 @@ import {
   VersionInfoModal,
 } from '@pixuli/ui';
 import type { VersionInfo } from '@pixuli/ui';
+import { getRepoConfigFromSource } from '@pixuli/core/sources';
 import type { ImageUploadData, MultiImageUploadData } from '@pixuli/core/types';
 import React from 'react';
 import {
@@ -151,14 +152,8 @@ export const MainLayout: React.FC<MainLayoutProps> = ({
             ? null
             : editingSourceId &&
                 selectedSource &&
-                selectedSource.type === 'github'
-              ? {
-                  owner: selectedSource.owner,
-                  repo: selectedSource.repo,
-                  branch: selectedSource.branch,
-                  token: selectedSource.token,
-                  path: selectedSource.path,
-                }
+                selectedSource.pluginId === 'github'
+              ? getRepoConfigFromSource(selectedSource)
               : githubConfig
         }
         onSaveConfig={onSaveConfig}
@@ -175,14 +170,8 @@ export const MainLayout: React.FC<MainLayoutProps> = ({
             ? null
             : editingSourceId &&
                 selectedSource &&
-                selectedSource.type === 'gitee'
-              ? {
-                  owner: selectedSource.owner,
-                  repo: selectedSource.repo,
-                  branch: selectedSource.branch,
-                  token: selectedSource.token,
-                  path: selectedSource.path,
-                }
+                selectedSource.pluginId === 'gitee'
+              ? getRepoConfigFromSource(selectedSource)
               : giteeConfig
         }
         onSaveConfig={onSaveConfig}

--- a/apps/pixuli/src/stores/sourceStore.ts
+++ b/apps/pixuli/src/stores/sourceStore.ts
@@ -1,89 +1,71 @@
+import {
+  createStoredSourceEntry,
+  mergeStoredSourceUpdate,
+  normalizeStoredSources,
+  type CreateStoredSourceInput,
+  type StoredSourceEntry,
+} from '@pixuli/core/sources';
 import { create } from 'zustand';
 
-export interface GitHubSourceConfig {
-  id: string;
-  name: string;
-  type: 'github';
-  owner: string;
-  repo: string;
-  branch: string;
-  token: string;
-  path: string;
-  createdAt: number;
-  updatedAt: number;
-}
-
-export interface GiteeSourceConfig {
-  id: string;
-  name: string;
-  type: 'gitee';
-  owner: string;
-  repo: string;
-  branch: string;
-  token: string;
-  path: string;
-  createdAt: number;
-  updatedAt: number;
-}
-
-export type SourceConfig = GitHubSourceConfig | GiteeSourceConfig;
+export type SourceConfig = StoredSourceEntry;
+export type AddSourceInput = CreateStoredSourceInput;
+export type UpdateSourceInput = Partial<{
+  label: string;
+  pluginId: string;
+  config: StoredSourceEntry['config'];
+}>;
 
 type SourceState = {
   sources: SourceConfig[];
   selectedSourceId: string | null;
-  addSource: (
-    input:
-      | Omit<GitHubSourceConfig, 'id' | 'createdAt' | 'updatedAt'>
-      | Omit<GiteeSourceConfig, 'id' | 'createdAt' | 'updatedAt'>,
-  ) => SourceConfig;
-  updateSource: (
-    id: string,
-    input:
-      | Partial<Omit<GitHubSourceConfig, 'id' | 'createdAt' | 'type'>>
-      | Partial<Omit<GiteeSourceConfig, 'id' | 'createdAt' | 'type'>>,
-  ) => void;
+  addSource: (input: AddSourceInput) => SourceConfig;
+  updateSource: (id: string, input: UpdateSourceInput) => void;
   removeSource: (id: string) => void;
   getSourceById: (id: string) => SourceConfig | undefined;
   setSelectedSourceId: (id: string | null) => void;
 };
 
-const STORAGE_KEY = 'pixuli.sources.v2';
+const STORAGE_KEY = 'pixuli.sources.v3';
 
 function loadSources(): SourceConfig[] {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) {
-      // 尝试迁移旧数据
-      const oldKey = 'pixuli.github.sources.v1';
-      const oldRaw = localStorage.getItem(oldKey);
-      if (oldRaw) {
-        try {
-          const oldData = JSON.parse(oldRaw);
-          if (Array.isArray(oldData)) {
-            // 迁移旧数据，添加 type 字段
-            const migrated = oldData.map((s: any) => ({
-              ...s,
-              type: 'github' as const,
-            }));
-            saveSources(migrated);
-            localStorage.removeItem(oldKey);
-            return migrated;
-          }
-        } catch {
-          // ignore migration error
+    if (raw) {
+      return normalizeStoredSources(JSON.parse(raw));
+    }
+
+    const v2Raw = localStorage.getItem('pixuli.sources.v2');
+    if (v2Raw) {
+      const data = JSON.parse(v2Raw);
+      if (Array.isArray(data)) {
+        const migrated = normalizeStoredSources(
+          data.map((s: Record<string, unknown>) =>
+            s.type || s.pluginId ? s : { ...s, type: 'github' },
+          ),
+        );
+        if (migrated.length > 0) {
+          saveSources(migrated);
+          return migrated;
         }
       }
-      return [];
     }
-    const data = JSON.parse(raw);
-    if (!Array.isArray(data)) return [];
-    // 确保所有源都有 type 字段（兼容旧数据）
-    return data.map((s: any) => {
-      if (!s.type) {
-        return { ...s, type: 'github' };
+
+    const v1Raw = localStorage.getItem('pixuli.github.sources.v1');
+    if (v1Raw) {
+      const data = JSON.parse(v1Raw);
+      if (Array.isArray(data)) {
+        const migrated = normalizeStoredSources(
+          data.map((s: Record<string, unknown>) => ({ ...s, type: 'github' })),
+        );
+        if (migrated.length > 0) {
+          saveSources(migrated);
+          localStorage.removeItem('pixuli.github.sources.v1');
+          return migrated;
+        }
       }
-      return s;
-    }) as SourceConfig[];
+    }
+
+    return [];
   } catch {
     return [];
   }
@@ -127,13 +109,7 @@ export const useSourceStore = create<SourceState>((set, get) => {
     sources: initial,
     selectedSourceId: initialSelectedId,
     addSource: input => {
-      const now = Date.now();
-      const source: SourceConfig = {
-        id: Math.random().toString(36).slice(2, 10),
-        createdAt: now,
-        updatedAt: now,
-        ...input,
-      } as SourceConfig;
+      const source = createStoredSourceEntry(input);
       const next = [...get().sources, source];
       set({ sources: next });
       saveSources(next);
@@ -141,7 +117,7 @@ export const useSourceStore = create<SourceState>((set, get) => {
     },
     updateSource: (id, input) => {
       const next = get().sources.map(s =>
-        s.id === id ? { ...s, ...input, updatedAt: Date.now() } : s,
+        s.id === id ? mergeStoredSourceUpdate(s, input) : s,
       );
       set({ sources: next });
       saveSources(next);

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -9,6 +9,7 @@
 | `@pixuli/core`               | 主入口                                                    |
 | `@pixuli/core/types`         | 图片、GitHub/Gitee、日志等类型                            |
 | `@pixuli/core/plugins`       | `StorageProvider` 契约、`StoragePluginRegistry`、配置类型 |
+| `@pixuli/core/sources`       | `StoredSourceEntry` 持久化归一化、单条配置导入/导出       |
 | `@pixuli/core/platform`      | `PlatformAdapter`                                         |
 | `@pixuli/core/utils`         | filter、sort、fileSize、image 工具                        |
 | `@pixuli/core/locales`       | 应用级词条与 `deepMerge`                                  |

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,8 @@
     "./platform": "./src/platform/index.ts",
     "./utils": "./src/utils/index.ts",
     "./locales": "./src/locales/index.ts",
-    "./operation-log": "./src/operation-log/index.ts"
+    "./operation-log": "./src/operation-log/index.ts",
+    "./sources": "./src/sources/index.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/core/src/sources/__tests__/sources.test.ts
+++ b/packages/core/src/sources/__tests__/sources.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPluginConfigExport,
+  createStoredSourceEntry,
+  normalizeStoredSourceEntry,
+  normalizeStoredSources,
+  parsePluginConfigImport,
+} from '../index';
+
+describe('normalizeStoredSourceEntry', () => {
+  it('accepts StoredSourceEntry shape', () => {
+    const entry = normalizeStoredSourceEntry({
+      id: 'a1',
+      label: 'my/repo',
+      pluginId: 'github',
+      config: {
+        owner: 'o',
+        repo: 'r',
+        branch: 'main',
+        token: 't',
+        path: 'images',
+      },
+      createdAt: 1,
+      updatedAt: 2,
+    });
+    expect(entry).toMatchObject({
+      id: 'a1',
+      label: 'my/repo',
+      pluginId: 'github',
+    });
+  });
+
+  it('migrates legacy flat entry with type and name', () => {
+    const entry = normalizeStoredSourceEntry({
+      id: 'b2',
+      type: 'gitee',
+      name: 'owner/repo',
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'master',
+      token: 'secret',
+      path: 'pics',
+      createdAt: 10,
+      updatedAt: 20,
+    });
+    expect(entry?.pluginId).toBe('gitee');
+    expect(entry?.label).toBe('owner/repo');
+    expect(entry?.config).toMatchObject({
+      owner: 'owner',
+      repo: 'repo',
+      token: 'secret',
+    });
+  });
+
+  it('rejects invalid entries', () => {
+    expect(normalizeStoredSourceEntry(null)).toBeNull();
+    expect(normalizeStoredSourceEntry({ id: 'x' })).toBeNull();
+  });
+});
+
+describe('normalizeStoredSources', () => {
+  it('filters invalid items', () => {
+    const list = normalizeStoredSources([
+      { id: '1', type: 'github', owner: 'a', repo: 'b', token: 't' },
+      { id: 'bad' },
+    ]);
+    expect(list).toHaveLength(1);
+    expect(list[0].pluginId).toBe('github');
+  });
+});
+
+describe('plugin config import/export', () => {
+  it('exports with pluginId', () => {
+    const payload = buildPluginConfigExport({
+      pluginId: 'github',
+      config: { owner: 'a', repo: 'b', token: 't' },
+      platform: 'web',
+    });
+    expect(payload.version).toBe('2.0');
+    expect(payload.pluginId).toBe('github');
+  });
+
+  it('parses v2 export', () => {
+    const parsed = parsePluginConfigImport(
+      buildPluginConfigExport({
+        pluginId: 'gitee',
+        config: { owner: 'a', repo: 'b', token: 't' },
+      }),
+      'github',
+    );
+    expect(parsed?.pluginId).toBe('gitee');
+    expect(parsed?.config.owner).toBe('a');
+  });
+
+  it('parses v1 export without pluginId', () => {
+    const parsed = parsePluginConfigImport(
+      {
+        version: '1.0',
+        config: {
+          owner: 'a',
+          repo: 'b',
+          token: 't',
+          branch: 'main',
+          path: 'images',
+        },
+      },
+      'github',
+    );
+    expect(parsed?.pluginId).toBe('github');
+  });
+
+  it('infers pluginId from legacy type field', () => {
+    const parsed = parsePluginConfigImport(
+      { type: 'gitee', config: { owner: 'a', repo: 'b', token: 't' } },
+      'github',
+    );
+    expect(parsed?.pluginId).toBe('gitee');
+  });
+});
+
+describe('createStoredSourceEntry', () => {
+  it('creates entry with timestamps', () => {
+    const entry = createStoredSourceEntry({
+      pluginId: 'github',
+      label: 'test',
+      config: { owner: 'a', repo: 'b', token: 't' },
+    });
+    expect(entry.pluginId).toBe('github');
+    expect(entry.createdAt).toBeLessThanOrEqual(Date.now());
+  });
+});

--- a/packages/core/src/sources/importExport.ts
+++ b/packages/core/src/sources/importExport.ts
@@ -1,0 +1,68 @@
+import type { StorageProviderConfig } from '../plugins/types';
+import { pickRepoConfig } from './importExportHelpers';
+
+export const PLUGIN_CONFIG_EXPORT_VERSION = '2.0';
+
+export interface PluginConfigExportPayload {
+  version: string;
+  pluginId: string;
+  platform?: string;
+  timestamp: string;
+  config: StorageProviderConfig;
+}
+
+export function buildPluginConfigExport(params: {
+  pluginId: string;
+  config: StorageProviderConfig;
+  platform?: string;
+}): PluginConfigExportPayload {
+  return {
+    version: PLUGIN_CONFIG_EXPORT_VERSION,
+    pluginId: params.pluginId,
+    platform: params.platform,
+    timestamp: new Date().toISOString(),
+    config: { ...params.config },
+  };
+}
+
+export type ParsedPluginConfigImport = {
+  pluginId: string;
+  config: StorageProviderConfig;
+};
+
+/**
+ * 解析单条仓库配置的导入 JSON（v2 含 pluginId；v1 仅 config，用 defaultPluginId 推断）。
+ */
+export function parsePluginConfigImport(
+  data: unknown,
+  defaultPluginId: string,
+): ParsedPluginConfigImport | null {
+  if (!data || typeof data !== 'object') {
+    return null;
+  }
+  const record = data as Record<string, unknown>;
+
+  let pluginId =
+    typeof record.pluginId === 'string' && record.pluginId.length > 0
+      ? record.pluginId
+      : defaultPluginId;
+
+  let configRaw: unknown = record.config;
+  if (!configRaw && pickRepoConfig(record)) {
+    configRaw = record;
+  }
+  if (!configRaw || typeof configRaw !== 'object') {
+    return null;
+  }
+
+  const config = pickRepoConfig(configRaw as Record<string, unknown>);
+  if (!config) {
+    return null;
+  }
+
+  if (record.type === 'github' || record.type === 'gitee') {
+    pluginId = record.type;
+  }
+
+  return { pluginId, config };
+}

--- a/packages/core/src/sources/importExportHelpers.ts
+++ b/packages/core/src/sources/importExportHelpers.ts
@@ -1,0 +1,24 @@
+import type { StorageProviderConfig } from '../plugins/types';
+
+export function pickRepoConfig(
+  raw: Record<string, unknown>,
+): StorageProviderConfig | null {
+  const owner = raw.owner;
+  const repo = raw.repo;
+  const token = raw.token;
+  if (
+    typeof owner !== 'string' ||
+    typeof repo !== 'string' ||
+    typeof token !== 'string'
+  ) {
+    return null;
+  }
+  const config: StorageProviderConfig = { owner, repo, token };
+  if (typeof raw.branch === 'string') {
+    config.branch = raw.branch;
+  }
+  if (typeof raw.path === 'string') {
+    config.path = raw.path;
+  }
+  return config;
+}

--- a/packages/core/src/sources/index.ts
+++ b/packages/core/src/sources/index.ts
@@ -1,0 +1,17 @@
+export type { StoredSourceEntry } from '../plugins/types';
+export {
+  createStoredSourceEntry,
+  getRepoConfigFromSource,
+  mergeStoredSourceUpdate,
+  normalizeStoredSourceEntry,
+  normalizeStoredSources,
+  pluginIdToLegacyType,
+  type CreateStoredSourceInput,
+} from './normalize';
+export {
+  buildPluginConfigExport,
+  parsePluginConfigImport,
+  PLUGIN_CONFIG_EXPORT_VERSION,
+  type PluginConfigExportPayload,
+  type ParsedPluginConfigImport,
+} from './importExport';

--- a/packages/core/src/sources/normalize.ts
+++ b/packages/core/src/sources/normalize.ts
@@ -1,0 +1,158 @@
+import type { StorageProviderConfig } from '../plugins/types';
+import type { StoredSourceEntry } from '../plugins/types';
+import { pickRepoConfig } from './importExportHelpers';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function inferPluginId(raw: Record<string, unknown>): string | null {
+  if (typeof raw.pluginId === 'string' && raw.pluginId.length > 0) {
+    return raw.pluginId;
+  }
+  if (raw.type === 'github' || raw.type === 'gitee') {
+    return raw.type;
+  }
+  return null;
+}
+
+function inferLabel(
+  raw: Record<string, unknown>,
+  config: StorageProviderConfig,
+): string {
+  if (typeof raw.label === 'string' && raw.label.length > 0) {
+    return raw.label;
+  }
+  if (typeof raw.name === 'string' && raw.name.length > 0) {
+    return raw.name;
+  }
+  const owner = config.owner;
+  const repo = config.repo;
+  if (typeof owner === 'string' && typeof repo === 'string') {
+    return `${owner}/${repo}`;
+  }
+  return '未命名源';
+}
+
+/**
+ * 将磁盘上的单条源（新格式或旧扁平格式）规范为 StoredSourceEntry。
+ */
+export function normalizeStoredSourceEntry(
+  raw: unknown,
+): StoredSourceEntry | null {
+  if (!isRecord(raw) || typeof raw.id !== 'string' || raw.id.length === 0) {
+    return null;
+  }
+
+  const pluginId = inferPluginId(raw);
+  if (!pluginId) {
+    return null;
+  }
+
+  let config: StorageProviderConfig | null = null;
+  if (isRecord(raw.config)) {
+    config = pickRepoConfig(raw.config);
+  }
+  if (!config) {
+    config = pickRepoConfig(raw);
+  }
+  if (!config) {
+    return null;
+  }
+
+  const createdAt =
+    typeof raw.createdAt === 'number' ? raw.createdAt : Date.now();
+  const updatedAt =
+    typeof raw.updatedAt === 'number' ? raw.updatedAt : createdAt;
+
+  return {
+    id: raw.id,
+    label: inferLabel(raw, config),
+    pluginId,
+    config,
+    createdAt,
+    updatedAt,
+  };
+}
+
+export function normalizeStoredSources(data: unknown): StoredSourceEntry[] {
+  if (!Array.isArray(data)) {
+    return [];
+  }
+  const result: StoredSourceEntry[] = [];
+  for (const item of data) {
+    const entry = normalizeStoredSourceEntry(item);
+    if (entry) {
+      result.push(entry);
+    }
+  }
+  return result;
+}
+
+export type CreateStoredSourceInput = {
+  pluginId: string;
+  label: string;
+  config: StorageProviderConfig;
+};
+
+export function createStoredSourceEntry(
+  input: CreateStoredSourceInput,
+  id?: string,
+): StoredSourceEntry {
+  const now = Date.now();
+  return {
+    id: id ?? Math.random().toString(36).slice(2, 10),
+    label: input.label,
+    pluginId: input.pluginId,
+    config: { ...input.config },
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function mergeStoredSourceUpdate(
+  entry: StoredSourceEntry,
+  patch: Partial<{
+    label: string;
+    pluginId: string;
+    config: StorageProviderConfig | Partial<StorageProviderConfig>;
+  }>,
+): StoredSourceEntry {
+  const next: StoredSourceEntry = {
+    ...entry,
+    updatedAt: Date.now(),
+  };
+  if (patch.label !== undefined) {
+    next.label = patch.label;
+  }
+  if (patch.pluginId !== undefined) {
+    next.pluginId = patch.pluginId;
+  }
+  if (patch.config !== undefined) {
+    next.config = { ...entry.config, ...patch.config };
+  }
+  return next;
+}
+
+/** 从持久化条目读取仓库连接字段（供 imageStore / UI 使用） */
+export function getRepoConfigFromSource(entry: StoredSourceEntry): {
+  owner: string;
+  repo: string;
+  branch: string;
+  token: string;
+  path: string;
+} {
+  const c = entry.config;
+  const defaultBranch = entry.pluginId === 'gitee' ? 'master' : 'main';
+  return {
+    owner: String(c.owner ?? ''),
+    repo: String(c.repo ?? ''),
+    branch: String(c.branch ?? defaultBranch),
+    token: String(c.token ?? ''),
+    path: String(c.path ?? 'images'),
+  };
+}
+
+export function pluginIdToLegacyType(pluginId: string): 'github' | 'gitee' {
+  return pluginId === 'gitee' ? 'gitee' : 'github';
+}

--- a/packages/ui/src/config/gitee-config/web/GiteeConfigModal.tsx
+++ b/packages/ui/src/config/gitee-config/web/GiteeConfigModal.tsx
@@ -1,6 +1,10 @@
 import { Download, Save, Trash2, Upload, X } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 import { defaultTranslate } from '@pixuli/ui/locales';
+import {
+  buildPluginConfigExport,
+  parsePluginConfigImport,
+} from '@pixuli/core/sources';
 import type { GiteeConfig } from '@pixuli/core/types';
 import { showError, showSuccess } from '@pixuli/ui/feedback/toast';
 import './GiteeConfigModal.css';
@@ -96,12 +100,11 @@ const GiteeConfigModal: React.FC<GiteeConfigModalProps> = ({
         return;
       }
 
-      const configData = {
-        version: '1.0',
-        platform: platform,
-        timestamp: new Date().toISOString(),
-        config: giteeConfig,
-      };
+      const configData = buildPluginConfigExport({
+        pluginId: 'gitee',
+        platform,
+        config: { ...giteeConfig },
+      });
 
       const blob = new Blob([JSON.stringify(configData, null, 2)], {
         type: 'application/json',
@@ -136,26 +139,18 @@ const GiteeConfigModal: React.FC<GiteeConfigModalProps> = ({
       reader.onload = e => {
         try {
           const content = e.target?.result as string;
-          const configData = JSON.parse(content);
-
-          // 验证配置格式
-          if (
-            !configData.config ||
-            !configData.config.owner ||
-            !configData.config.repo ||
-            !configData.config.token
-          ) {
+          const parsed = parsePluginConfigImport(JSON.parse(content), 'gitee');
+          if (!parsed) {
             showError(translate('messages.invalidFormat'));
             return;
           }
 
-          // 更新表单数据
           setFormData({
-            owner: configData.config.owner || '',
-            repo: configData.config.repo || '',
-            branch: configData.config.branch || 'main',
-            token: configData.config.token || '',
-            path: configData.config.path || 'images',
+            owner: String(parsed.config.owner ?? ''),
+            repo: String(parsed.config.repo ?? ''),
+            branch: String(parsed.config.branch ?? 'master'),
+            token: String(parsed.config.token ?? ''),
+            path: String(parsed.config.path ?? 'images'),
           });
 
           showSuccess(translate('messages.configImported'));

--- a/packages/ui/src/config/github-config/web/GitHubConfigModal.tsx
+++ b/packages/ui/src/config/github-config/web/GitHubConfigModal.tsx
@@ -1,6 +1,10 @@
 import { Download, Github, Save, Trash2, Upload, X } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 import { defaultTranslate } from '@pixuli/ui/locales';
+import {
+  buildPluginConfigExport,
+  parsePluginConfigImport,
+} from '@pixuli/core/sources';
 import type { GitHubConfig } from '@pixuli/core/types';
 import { showError, showSuccess } from '@pixuli/ui/feedback/toast';
 import './GitHubConfigModal.css';
@@ -96,12 +100,11 @@ const GitHubConfigModal: React.FC<GitHubConfigModalProps> = ({
         return;
       }
 
-      const configData = {
-        version: '1.0',
-        platform: platform,
-        timestamp: new Date().toISOString(),
-        config: githubConfig,
-      };
+      const configData = buildPluginConfigExport({
+        pluginId: 'github',
+        platform,
+        config: { ...githubConfig },
+      });
 
       const blob = new Blob([JSON.stringify(configData, null, 2)], {
         type: 'application/json',
@@ -136,26 +139,18 @@ const GitHubConfigModal: React.FC<GitHubConfigModalProps> = ({
       reader.onload = e => {
         try {
           const content = e.target?.result as string;
-          const configData = JSON.parse(content);
-
-          // 验证配置格式
-          if (
-            !configData.config ||
-            !configData.config.owner ||
-            !configData.config.repo ||
-            !configData.config.token
-          ) {
+          const parsed = parsePluginConfigImport(JSON.parse(content), 'github');
+          if (!parsed) {
             showError(translate('messages.invalidFormat'));
             return;
           }
 
-          // 更新表单数据
           setFormData({
-            owner: configData.config.owner || '',
-            repo: configData.config.repo || '',
-            branch: configData.config.branch || 'main',
-            token: configData.config.token || '',
-            path: configData.config.path || 'images',
+            owner: String(parsed.config.owner ?? ''),
+            repo: String(parsed.config.repo ?? ''),
+            branch: String(parsed.config.branch ?? 'main'),
+            token: String(parsed.config.token ?? ''),
+            path: String(parsed.config.path ?? 'images'),
           });
 
           showSuccess(translate('messages.configImported'));


### PR DESCRIPTION
## Summary

- 新增 `@pixuli/core/sources`：`StoredSourceEntry` 归一化、旧格式 `type`→`pluginId` 迁移、单条配置导入/导出 v2.0（含 `pluginId`）
- 重构 `apps/pixuli` / `apps/mobile` 的 `sourceStore`：持久化 `{ pluginId, label, config }`（Web `pixuli.sources.v3`，Mobile `pixuli.sources.v2`）
- 更新 hooks、Drawer、StorageConfigModal 与 GitHub/Gitee ConfigModal 导入导出逻辑
- `REFACTOR_PLAN.md`：REF-306 ✅，M3 进度 6/11（55%）

Closes #75

## Test plan

- [x] `cd packages/core && pnpm test`
- [x] `cd apps/pixuli && pnpm exec tsc --noEmit`
- [x] `cd apps/mobile && pnpm exec tsc --noEmit`
- [x] Web：添加/编辑源后刷新，列表与当前源正常；导出/导入 JSON 含 `pluginId`
- [x] Mobile：同上；从旧 v1 源数据升级后仍可加载
- [x] 导入 v1 无 `pluginId` 的配置文件，表单仍能正确填充


Made with [Cursor](https://cursor.com)