### PR TITLE
feat(m3): REF-307 添加源与源列表对接 registry.listManifests

### DIFF
--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -510,7 +510,7 @@ native。
 | REF-304 | [M3] 重构 apps/pixuli imageStore 使用 Registry  | refactor, m3, area:web, area:desktop, priority:P0      | P0     | #71, #72, #64      | [#73](https://github.com/trueLoving/Pixuli/issues/73)   | ✅   |
 | REF-305 | [M3] 重构 apps/mobile imageStore 使用 Registry  | refactor, m3, area:mobile, priority:P0                 | P0     | #71, #72, #65      | [#74](https://github.com/trueLoving/Pixuli/issues/74)   | ✅   |
 | REF-306 | [M3] 配置持久化增加 pluginId（导入/导出）       | refactor, m3, priority:P1                              | P1     | #73, #74           | [#75](https://github.com/trueLoving/Pixuli/issues/75)   | ✅   |
-| REF-307 | [M3] 设置页源列表对接 registry.listManifests    | refactor, m3, area:ui, priority:P1                     | P1     | #75                | [#76](https://github.com/trueLoving/Pixuli/issues/76)   | ⬜   |
+| REF-307 | [M3] 设置页源列表对接 registry.listManifests    | refactor, m3, area:ui, priority:P1                     | P1     | #75                | [#76](https://github.com/trueLoving/Pixuli/issues/76)   | ✅   |
 | REF-308 | [M3] 编写插件开发文档 docs/plugins/authoring.md | refactor, m3, type:docs, priority:P1                   | P1     | #70                | [#77](https://github.com/trueLoving/Pixuli/issues/77)   | ⬜   |
 | REF-309 | [M3] provider 包单元测试迁移                    | refactor, m3, priority:P1                              | P1     | #71, #72           | [#78](https://github.com/trueLoving/Pixuli/issues/78)   | ⬜   |
 | REF-310 | [M3] M3 回归：GitHub/Gitee 全流程               | refactor, m3, priority:P0                              | P0     | #73–#78, #109      | [#79](https://github.com/trueLoving/Pixuli/issues/79)   | ⬜   |
@@ -652,10 +652,10 @@ flowchart LR
 | -------- | -------- | ------ | ------- |
 | M1       | 12       | 7      | 58%     |
 | M2       | 10       | 0      | 0%      |
-| M3       | 12       | 6      | 50%     |
+| M3       | 12       | 7      | 58%     |
 | M4       | 6        | 0      | 0%      |
 | M5       | 5        | 0      | 0%      |
-| **合计** | **45**   | **7**  | **16%** |
+| **合计** | **45**   | **8**  | **18%** |
 
 ---
 

--- a/apps/mobile/components/navigation/DrawerMenu.tsx
+++ b/apps/mobile/components/navigation/DrawerMenu.tsx
@@ -6,6 +6,7 @@ import {
   getRepoConfigFromSource,
   pluginIdToLegacyType,
 } from '@pixuli/core/sources';
+import { isStoragePluginRegistered } from '@/storage/registry';
 import { useSourceStore } from '@/stores/sourceStore';
 import { useRouter } from 'expo-router';
 import React from 'react';
@@ -81,6 +82,7 @@ export function DrawerMenu({ visible, onClose }: DrawerMenuProps) {
       owner: repo.owner,
       repo: repo.repo,
       isActive: selectedSourceId === source.id,
+      available: isStoragePluginRegistered(source.pluginId),
     };
   });
 
@@ -93,6 +95,13 @@ export function DrawerMenu({ visible, onClose }: DrawerMenuProps) {
   const handleEditSource = (sourceId: string) => {
     const source = sources.find(s => s.id === sourceId);
     if (source) {
+      if (!isStoragePluginRegistered(source.pluginId)) {
+        Alert.alert(
+          t('common.error'),
+          t('sidebar.pluginUnavailable') || '插件未安装或不可用',
+        );
+        return;
+      }
       setConfigModalType(pluginIdToLegacyType(source.pluginId));
       setEditingSourceId(sourceId);
       setConfigModalVisible(true);
@@ -162,6 +171,14 @@ export function DrawerMenu({ visible, onClose }: DrawerMenuProps) {
   const handleSwitchSource = async (sourceId: string) => {
     if (selectedSourceId === sourceId) {
       return; // Already active
+    }
+    const source = sources.find(s => s.id === sourceId);
+    if (source && !isStoragePluginRegistered(source.pluginId)) {
+      Alert.alert(
+        t('common.error'),
+        t('sidebar.pluginUnavailable') || '插件未安装或不可用',
+      );
+      return;
     }
     try {
       setSelectedSourceId(sourceId);
@@ -259,6 +276,7 @@ export function DrawerMenu({ visible, onClose }: DrawerMenuProps) {
               </View>
               {allSources.length > 0 ? (
                 allSources.map((source, index) => {
+                  const unavailable = !source.available;
                   return (
                     <TouchableOpacity
                       key={source.id}
@@ -270,8 +288,10 @@ export function DrawerMenu({ visible, onClose }: DrawerMenuProps) {
                         source.isActive && {
                           backgroundColor: colors.primary + '10',
                         },
+                        unavailable && styles.sourceItemUnavailable,
                       ]}
                       onPress={() => handleSwitchSource(source.id)}
+                      disabled={unavailable}
                       onLongPress={() => {
                         // 长按显示操作菜单
                         Alert.alert(
@@ -351,7 +371,10 @@ export function DrawerMenu({ visible, onClose }: DrawerMenuProps) {
                             ]}
                             numberOfLines={1}
                           >
-                            {source.owner}/{source.repo}
+                            {unavailable
+                              ? t('sidebar.pluginUnavailable') ||
+                                '插件未安装或不可用'
+                              : `${source.owner}/${source.repo}`}
                           </ThemedText>
                         </View>
                       </View>
@@ -557,6 +580,9 @@ const styles = StyleSheet.create({
   },
   sourceItemLast: {
     borderBottomWidth: 0,
+  },
+  sourceItemUnavailable: {
+    opacity: 0.5,
   },
   sourceItemText: {
     fontSize: 17,

--- a/apps/mobile/components/settings/modals/AddSourceModal.tsx
+++ b/apps/mobile/components/settings/modals/AddSourceModal.tsx
@@ -1,7 +1,12 @@
 import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { useI18n } from '@/i18n/useI18n';
-import React from 'react';
+import { listStoragePluginManifests } from '@/storage/registry';
+import {
+  getManifestDescription,
+  isKnownBuiltinPluginId,
+} from '@pixuli/core/plugins';
+import React, { useMemo } from 'react';
 import { Modal, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { IconSymbol } from '../../ui/IconSymbol';
 import { ThemedText } from '../../ui/ThemedText';
@@ -10,7 +15,7 @@ import { ThemedView } from '../../ui/ThemedView';
 interface AddSourceModalProps {
   visible: boolean;
   onClose: () => void;
-  onSelect: (type: 'github' | 'gitee') => void;
+  onSelect: (pluginId: string) => void;
 }
 
 export function AddSourceModal({
@@ -22,20 +27,14 @@ export function AddSourceModal({
   const colorScheme = useColorScheme() ?? 'light';
   const colors = Colors[colorScheme];
 
-  const sources = [
-    {
-      type: 'github' as const,
-      name: 'GitHub',
-      icon: 'link',
-      description: t('settings.github.title') || 'GitHub 配置',
-    },
-    {
-      type: 'gitee' as const,
-      name: 'Gitee',
-      icon: 'link',
-      description: t('settings.gitee.title') || 'Gitee 配置',
-    },
-  ];
+  const pluginOptions = useMemo(() => {
+    return listStoragePluginManifests().map(manifest => ({
+      pluginId: manifest.id,
+      name: manifest.name,
+      description: getManifestDescription(manifest, key => t(key)),
+      supported: isKnownBuiltinPluginId(manifest.id),
+    }));
+  }, [t]);
 
   const dynamicStyles = StyleSheet.create({
     modalOverlay: {
@@ -74,69 +73,86 @@ export function AddSourceModal({
         >
           <View style={styles.header}>
             <ThemedText style={[styles.title, { color: colors.text }]}>
-              {t('settings.storage.add') || '添加存储配置'}
+              {t('settings.storage.selectType') || '选择仓库源类型'}
             </ThemedText>
             <TouchableOpacity onPress={onClose} style={styles.closeButton}>
-              <IconSymbol name="xmark" size={24} color={colors.text} />
+              <IconSymbol name="xmark" size={22} color={colors.text} />
             </TouchableOpacity>
           </View>
 
           <View style={styles.content}>
-            {sources.map((source, index) => (
-              <TouchableOpacity
-                key={source.type}
-                style={[
-                  styles.sourceItem,
-                  dynamicStyles.sourceItem,
-                  index === sources.length - 1 && styles.sourceItemLast,
-                ]}
-                onPress={() => {
-                  onSelect(source.type);
-                  onClose();
-                }}
-                activeOpacity={0.6}
+            {pluginOptions.length === 0 ? (
+              <ThemedText
+                style={[styles.emptyText, { color: colors.sectionTitle }]}
               >
-                <View style={styles.sourceItemLeft}>
-                  <View
-                    style={[
-                      styles.iconContainer,
-                      {
-                        backgroundColor: colors.primary + '20',
-                      },
-                    ]}
-                  >
-                    <IconSymbol
-                      name={source.icon as any}
-                      size={22}
-                      color={colors.primary}
-                    />
-                  </View>
-                  <View style={styles.sourceItemContent}>
-                    <ThemedText
+                {t('sidebar.noStoragePlugins')}
+              </ThemedText>
+            ) : (
+              pluginOptions.map((option, index) => (
+                <TouchableOpacity
+                  key={option.pluginId}
+                  style={[
+                    styles.sourceItem,
+                    dynamicStyles.sourceItem,
+                    index === pluginOptions.length - 1 && styles.sourceItemLast,
+                    !option.supported && styles.sourceItemDisabled,
+                  ]}
+                  onPress={() => {
+                    if (!option.supported) {
+                      return;
+                    }
+                    onSelect(option.pluginId);
+                    onClose();
+                  }}
+                  disabled={!option.supported}
+                  activeOpacity={0.6}
+                >
+                  <View style={styles.sourceItemLeft}>
+                    <View
                       style={[
-                        styles.sourceItemText,
-                        dynamicStyles.sourceItemText,
+                        styles.iconContainer,
+                        {
+                          backgroundColor: colors.primary + '20',
+                        },
                       ]}
                     >
-                      {source.name}
-                    </ThemedText>
-                    <ThemedText
-                      style={[
-                        styles.sourceItemSubtext,
-                        dynamicStyles.sourceItemSubtext,
-                      ]}
-                    >
-                      {source.description}
-                    </ThemedText>
+                      <IconSymbol
+                        name={
+                          option.pluginId === 'gitee'
+                            ? 'link'
+                            : 'chevron.left.forwardslash.chevron.right'
+                        }
+                        size={22}
+                        color={colors.primary}
+                      />
+                    </View>
+                    <View style={styles.sourceItemContent}>
+                      <ThemedText
+                        style={[
+                          styles.sourceItemText,
+                          dynamicStyles.sourceItemText,
+                        ]}
+                      >
+                        {option.name}
+                      </ThemedText>
+                      <ThemedText
+                        style={[
+                          styles.sourceItemSubtext,
+                          dynamicStyles.sourceItemSubtext,
+                        ]}
+                      >
+                        {option.description}
+                      </ThemedText>
+                    </View>
                   </View>
-                </View>
-                <IconSymbol
-                  name="chevron.right"
-                  size={18}
-                  color={colors.sectionTitle}
-                />
-              </TouchableOpacity>
-            ))}
+                  <IconSymbol
+                    name="chevron.right"
+                    size={18}
+                    color={colors.sectionTitle}
+                  />
+                </TouchableOpacity>
+              ))
+            )}
           </View>
         </ThemedView>
       </TouchableOpacity>
@@ -154,62 +170,68 @@ const styles = StyleSheet.create({
   modalContent: {
     width: '100%',
     maxWidth: 400,
-    borderRadius: 16,
-    borderWidth: 1,
+    borderRadius: 12,
     overflow: 'hidden',
   },
   header: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
     alignItems: 'center',
-    paddingHorizontal: 20,
-    paddingVertical: 16,
+    justifyContent: 'space-between',
+    padding: 16,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#E5E5E5',
+    borderBottomColor: '#E5E5EA',
   },
   title: {
-    fontSize: 20,
-    fontWeight: '700',
+    fontSize: 18,
+    fontWeight: '600',
   },
   closeButton: {
     padding: 4,
   },
   content: {
-    padding: 8,
+    paddingVertical: 8,
   },
   sourceItem: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
+    paddingHorizontal: 16,
     paddingVertical: 14,
-    paddingHorizontal: 20,
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
   sourceItemLast: {
     borderBottomWidth: 0,
   },
+  sourceItemDisabled: {
+    opacity: 0.5,
+  },
   sourceItemLeft: {
     flexDirection: 'row',
     alignItems: 'center',
     flex: 1,
+    gap: 12,
   },
   iconContainer: {
-    width: 36,
-    height: 36,
+    width: 40,
+    height: 40,
     borderRadius: 8,
-    justifyContent: 'center',
     alignItems: 'center',
-    marginRight: 12,
+    justifyContent: 'center',
   },
   sourceItemContent: {
     flex: 1,
   },
   sourceItemText: {
-    fontSize: 17,
-    fontWeight: '400',
+    fontSize: 16,
+    fontWeight: '500',
+    marginBottom: 2,
   },
   sourceItemSubtext: {
     fontSize: 13,
-    marginTop: 2,
+  },
+  emptyText: {
+    textAlign: 'center',
+    padding: 24,
+    fontSize: 14,
   },
 });

--- a/apps/mobile/components/settings/modals/StorageConfigModal.tsx
+++ b/apps/mobile/components/settings/modals/StorageConfigModal.tsx
@@ -2,7 +2,12 @@ import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { useI18n } from '@/i18n/useI18n';
 import { useImageStore } from '@/stores/imageStore';
+import { listStoragePluginManifests } from '@/storage/registry';
 import { useSourceStore } from '@/stores/sourceStore';
+import {
+  getManifestDescription,
+  isKnownBuiltinPluginId,
+} from '@pixuli/core/plugins';
 import { showError, showSuccess } from '@/utils/toast';
 import {
   buildPluginConfigExport,
@@ -12,7 +17,7 @@ import {
 } from '@pixuli/core/sources';
 import type { GitHubConfig, GiteeConfig } from '@pixuli/core/types';
 import * as DocumentPicker from 'expo-document-picker';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   Modal,
@@ -64,6 +69,19 @@ export function StorageConfigModal({
     path: 'images',
   });
   const prevVisibleRef = useRef(false);
+
+  const pluginOptions = useMemo(
+    () =>
+      listStoragePluginManifests()
+        .filter(manifest => isKnownBuiltinPluginId(manifest.id))
+        .map(manifest => ({
+          pluginId: manifest.id,
+          legacyType: manifest.id as 'github' | 'gitee',
+          name: manifest.name,
+          description: getManifestDescription(manifest, key => t(key)),
+        })),
+    [t],
+  );
 
   useEffect(() => {
     const wasVisible = prevVisibleRef.current;
@@ -344,128 +362,96 @@ export function StorageConfigModal({
                 </ThemedText>
               </View>
               <View style={styles.typeOptions}>
-                <TouchableOpacity
-                  style={[
-                    styles.typeOption,
-                    {
-                      backgroundColor: colors.cardBackground,
-                      borderColor: colors.cardBorder,
-                    },
-                    selectedType === 'github' && {
-                      backgroundColor: colors.primary + '10',
-                      borderColor: colors.primary,
-                    },
-                  ]}
-                  onPress={() => {
-                    setSelectedType('github');
-                    setFormData({
-                      owner: '',
-                      repo: '',
-                      branch: 'main',
-                      token: '',
-                      path: 'images',
-                    });
-                  }}
-                  activeOpacity={0.7}
-                >
-                  <View
+                {pluginOptions.length === 0 ? (
+                  <ThemedText
                     style={[
-                      styles.typeOptionIcon,
-                      {
-                        backgroundColor: colors.primary + '20',
-                      },
+                      styles.typeOptionDesc,
+                      { color: colors.sectionTitle, textAlign: 'center' },
                     ]}
                   >
-                    <IconSymbol
-                      name="chevron.left.forwardslash.chevron.right"
-                      size={24}
-                      color={colors.primary}
-                    />
-                  </View>
-                  <View style={styles.typeOptionContent}>
-                    <ThemedText
-                      style={[styles.typeOptionTitle, { color: colors.text }]}
-                    >
-                      GitHub
-                    </ThemedText>
-                    <ThemedText
+                    {t('sidebar.noStoragePlugins') || '当前没有可用的存储插件'}
+                  </ThemedText>
+                ) : (
+                  pluginOptions.map(option => (
+                    <TouchableOpacity
+                      key={option.pluginId}
                       style={[
-                        styles.typeOptionDesc,
-                        { color: colors.sectionTitle },
+                        styles.typeOption,
+                        {
+                          backgroundColor: colors.cardBackground,
+                          borderColor: colors.cardBorder,
+                        },
+                        selectedType === option.legacyType && {
+                          backgroundColor: colors.primary + '10',
+                          borderColor: colors.primary,
+                        },
                       ]}
+                      onPress={() => {
+                        setSelectedType(option.legacyType);
+                        setFormData({
+                          owner: '',
+                          repo: '',
+                          branch:
+                            option.legacyType === 'github' ? 'main' : 'master',
+                          token: '',
+                          path: 'images',
+                        });
+                      }}
+                      activeOpacity={0.7}
                     >
-                      {t('settings.github.title') || 'GitHub 配置'}
-                    </ThemedText>
-                  </View>
-                  {selectedType === 'github' && (
-                    <IconSymbol
-                      name="checkmark.circle.fill"
-                      size={22}
-                      color={colors.primary}
-                    />
-                  )}
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[
-                    styles.typeOption,
-                    {
-                      backgroundColor: colors.cardBackground,
-                      borderColor: colors.cardBorder,
-                    },
-                    selectedType === 'gitee' && {
-                      backgroundColor: colors.primary + '10',
-                      borderColor: colors.primary,
-                    },
-                  ]}
-                  onPress={() => {
-                    setSelectedType('gitee');
-                    setFormData({
-                      owner: '',
-                      repo: '',
-                      branch: 'master',
-                      token: '',
-                      path: 'images',
-                    });
-                  }}
-                  activeOpacity={0.7}
-                >
-                  <View
-                    style={[
-                      styles.typeOptionIcon,
-                      {
-                        backgroundColor: colors.primary + '20',
-                      },
-                    ]}
-                  >
-                    <ThemedText
-                      style={[styles.giteeIconText, { color: colors.primary }]}
-                    >
-                      码
-                    </ThemedText>
-                  </View>
-                  <View style={styles.typeOptionContent}>
-                    <ThemedText
-                      style={[styles.typeOptionTitle, { color: colors.text }]}
-                    >
-                      Gitee
-                    </ThemedText>
-                    <ThemedText
-                      style={[
-                        styles.typeOptionDesc,
-                        { color: colors.sectionTitle },
-                      ]}
-                    >
-                      {t('settings.gitee.title') || 'Gitee 配置'}
-                    </ThemedText>
-                  </View>
-                  {selectedType === 'gitee' && (
-                    <IconSymbol
-                      name="checkmark.circle.fill"
-                      size={22}
-                      color={colors.primary}
-                    />
-                  )}
-                </TouchableOpacity>
+                      <View
+                        style={[
+                          styles.typeOptionIcon,
+                          {
+                            backgroundColor: colors.primary + '20',
+                          },
+                        ]}
+                      >
+                        {option.legacyType === 'gitee' ? (
+                          <ThemedText
+                            style={[
+                              styles.giteeIconText,
+                              { color: colors.primary },
+                            ]}
+                          >
+                            码
+                          </ThemedText>
+                        ) : (
+                          <IconSymbol
+                            name="chevron.left.forwardslash.chevron.right"
+                            size={24}
+                            color={colors.primary}
+                          />
+                        )}
+                      </View>
+                      <View style={styles.typeOptionContent}>
+                        <ThemedText
+                          style={[
+                            styles.typeOptionTitle,
+                            { color: colors.text },
+                          ]}
+                        >
+                          {option.name}
+                        </ThemedText>
+                        <ThemedText
+                          style={[
+                            styles.typeOptionDesc,
+                            { color: colors.sectionTitle },
+                          ]}
+                        >
+                          {option.description}
+                        </ThemedText>
+                      </View>
+                      {selectedType === option.legacyType && (
+                        <IconSymbol
+                          name="checkmark.circle.fill"
+                          size={22}
+                          color={colors.primary}
+                        />
+                      )}
+                    </TouchableOpacity>
+                  ))
+                )}
               </View>
             </View>
           )}

--- a/apps/mobile/storage/createProvider.ts
+++ b/apps/mobile/storage/createProvider.ts
@@ -5,14 +5,21 @@ import type {
   StorageProviderWithMetadata,
 } from '@pixuli/core/plugins';
 import { DefaultPlatformAdapter } from '@pixuli/core/platform';
+import {
+  getStoragePluginDisplayName,
+  isKnownBuiltinPluginId,
+} from '@pixuli/core/plugins';
 import { storageRegistry } from './registry';
 
 export type StoragePluginId = 'github' | 'gitee';
 
 export function createConfiguredStorageProvider(
-  pluginId: StoragePluginId,
+  pluginId: string,
   config: GitHubConfig | GiteeConfig,
 ): StorageProvider {
+  if (!isKnownBuiltinPluginId(pluginId)) {
+    throw new Error(`Unsupported storage plugin: ${pluginId}`);
+  }
   const provider = storageRegistry.create(pluginId, {
     platform: 'mobile',
     platformAdapter: new DefaultPlatformAdapter(),
@@ -21,8 +28,11 @@ export function createConfiguredStorageProvider(
   return provider;
 }
 
-export function storagePluginLabel(pluginId: StoragePluginId | null): string {
-  return pluginId === 'gitee' ? 'Gitee' : 'GitHub';
+export function storagePluginLabel(pluginId: string | null): string {
+  if (!pluginId) {
+    return '存储';
+  }
+  return getStoragePluginDisplayName(storageRegistry, pluginId);
 }
 
 export function hasLoadImageMetadata(

--- a/apps/mobile/storage/registry.ts
+++ b/apps/mobile/storage/registry.ts
@@ -1,4 +1,8 @@
-import { createStoragePluginRegistry } from '@pixuli/core/plugins';
+import {
+  createStoragePluginRegistry,
+  isStoragePluginRegistered as isPluginRegisteredOnRegistry,
+  type StoragePluginManifest,
+} from '@pixuli/core/plugins';
 import { registerGitHubProvider } from '@pixuli/provider-github/register';
 import { registerGiteeProvider } from '@pixuli/provider-gitee/register';
 
@@ -16,3 +20,11 @@ export function bootstrapStorageProviders(): void {
 }
 
 bootstrapStorageProviders();
+
+export function listStoragePluginManifests(): StoragePluginManifest[] {
+  return storageRegistry.listManifests();
+}
+
+export function isStoragePluginRegistered(pluginId: string): boolean {
+  return isPluginRegisteredOnRegistry(storageRegistry, pluginId);
+}

--- a/apps/pixuli/src/App.tsx
+++ b/apps/pixuli/src/App.tsx
@@ -141,9 +141,11 @@ function App() {
 
   // 处理源类型选择
   const handleSelectSourceType = useCallback(
-    (type: 'github' | 'gitee') => {
+    (pluginId: string) => {
       setEditingSourceId(null);
-      useImageStore.setState({ storageType: type });
+      useImageStore.setState({
+        storageType: pluginId as 'github' | 'gitee',
+      });
       closeSourceTypeMenu();
       openConfigModal();
     },

--- a/apps/pixuli/src/features/source-type-menu/SourceTypeMenu.tsx
+++ b/apps/pixuli/src/features/source-type-menu/SourceTypeMenu.tsx
@@ -1,20 +1,66 @@
+import {
+  getManifestDescription,
+  isKnownBuiltinPluginId,
+  type StoragePluginManifest,
+} from '@pixuli/core/plugins';
 import { Github, X } from 'lucide-react';
 import React from 'react';
 
 interface SourceTypeMenuProps {
   isOpen: boolean;
+  manifests: StoragePluginManifest[];
   onClose: () => void;
-  onSelect: (type: 'github' | 'gitee') => void;
+  onSelect: (pluginId: string) => void;
   t: (key: string) => string;
+}
+
+function PluginTypeIcon({
+  pluginId,
+  name,
+}: {
+  pluginId: string;
+  name: string;
+}) {
+  if (pluginId === 'github') {
+    return (
+      <div className="flex-shrink-0 w-10 h-10 bg-gray-900 rounded-lg flex items-center justify-center group-hover:bg-gray-800 transition-colors">
+        <Github size={24} className="text-white" />
+      </div>
+    );
+  }
+  if (pluginId === 'gitee') {
+    return (
+      <div className="flex-shrink-0 w-10 h-10 bg-red-600 rounded-lg flex items-center justify-center group-hover:bg-red-700 transition-colors">
+        <span className="text-white font-bold text-sm">码</span>
+      </div>
+    );
+  }
+  return (
+    <div className="flex-shrink-0 w-10 h-10 bg-gray-500 rounded-lg flex items-center justify-center">
+      <span className="text-white font-semibold text-sm">
+        {name.slice(0, 1).toUpperCase()}
+      </span>
+    </div>
+  );
+}
+
+function hoverClassForPlugin(pluginId: string): string {
+  if (pluginId === 'gitee') {
+    return 'hover:border-red-500 hover:bg-red-50';
+  }
+  return 'hover:border-blue-500 hover:bg-blue-50';
 }
 
 export const SourceTypeMenu: React.FC<SourceTypeMenuProps> = ({
   isOpen,
+  manifests,
   onClose,
   onSelect,
   t,
 }) => {
-  if (!isOpen) return null;
+  if (!isOpen) {
+    return null;
+  }
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
@@ -26,42 +72,46 @@ export const SourceTypeMenu: React.FC<SourceTypeMenuProps> = ({
           <button
             onClick={onClose}
             className="text-gray-400 hover:text-gray-600 transition-colors"
+            type="button"
           >
             <X size={20} />
           </button>
         </div>
         <div className="p-4 space-y-3">
-          <button
-            onClick={() => onSelect('github')}
-            className="w-full flex items-center gap-3 p-4 border border-gray-200 rounded-lg hover:border-blue-500 hover:bg-blue-50 transition-all group"
-          >
-            <div className="flex-shrink-0 w-10 h-10 bg-gray-900 rounded-lg flex items-center justify-center group-hover:bg-gray-800 transition-colors">
-              <Github size={24} className="text-white" />
-            </div>
-            <div className="flex-1 text-left">
-              <div className="font-semibold text-gray-900">GitHub</div>
-              <div className="text-sm text-gray-500">
-                {t('sidebar.githubDescription')}
-              </div>
-            </div>
-          </button>
-          <button
-            onClick={() => onSelect('gitee')}
-            className="w-full flex items-center gap-3 p-4 border border-gray-200 rounded-lg hover:border-red-500 hover:bg-red-50 transition-all group"
-          >
-            <div className="flex-shrink-0 w-10 h-10 bg-red-600 rounded-lg flex items-center justify-center group-hover:bg-red-700 transition-colors">
-              <span className="text-white font-bold text-sm">码</span>
-            </div>
-            <div className="flex-1 text-left">
-              <div className="font-semibold text-gray-900">Gitee</div>
-              <div className="text-sm text-gray-500">
-                {t('sidebar.giteeDescription')}
-              </div>
-            </div>
-          </button>
+          {manifests.length === 0 ? (
+            <p className="text-sm text-gray-500 text-center py-4">
+              {t('sidebar.noStoragePlugins')}
+            </p>
+          ) : (
+            manifests.map(manifest => (
+              <button
+                key={manifest.id}
+                type="button"
+                onClick={() => {
+                  if (!isKnownBuiltinPluginId(manifest.id)) {
+                    return;
+                  }
+                  onSelect(manifest.id);
+                }}
+                disabled={!isKnownBuiltinPluginId(manifest.id)}
+                className={`w-full flex items-center gap-3 p-4 border border-gray-200 rounded-lg transition-all group disabled:opacity-50 disabled:cursor-not-allowed ${hoverClassForPlugin(manifest.id)}`}
+              >
+                <PluginTypeIcon pluginId={manifest.id} name={manifest.name} />
+                <div className="flex-1 text-left">
+                  <div className="font-semibold text-gray-900">
+                    {manifest.name}
+                  </div>
+                  <div className="text-sm text-gray-500">
+                    {getManifestDescription(manifest, t)}
+                  </div>
+                </div>
+              </button>
+            ))
+          )}
         </div>
         <div className="p-4 border-t border-gray-200">
           <button
+            type="button"
             onClick={onClose}
             className="w-full px-4 py-2 text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors"
           >

--- a/apps/pixuli/src/hooks/useSourceManagement.ts
+++ b/apps/pixuli/src/hooks/useSourceManagement.ts
@@ -3,6 +3,7 @@ import {
   pluginIdToLegacyType,
 } from '@pixuli/core/sources';
 import { useCallback, useMemo } from 'react';
+import { isStoragePluginRegistered } from '../storage/registry';
 import { useImageStore } from '../stores/imageStore';
 import { useSourceStore } from '../stores/sourceStore';
 
@@ -23,14 +24,16 @@ export function useSourceManagement() {
   const sidebarSources = useMemo(() => {
     return sources.map(source => {
       const repo = getRepoConfigFromSource(source);
+      const legacyType = pluginIdToLegacyType(source.pluginId);
       return {
         id: source.id,
         name: source.label || `${repo.owner}/${repo.repo}`,
-        type: pluginIdToLegacyType(source.pluginId),
+        type: legacyType,
         owner: repo.owner,
         repo: repo.repo,
         path: repo.path,
         active: selectedSourceId === source.id,
+        available: isStoragePluginRegistered(source.pluginId),
       };
     });
   }, [sources, selectedSourceId]);
@@ -38,18 +41,21 @@ export function useSourceManagement() {
   const handleEditSource = useCallback(
     (sourceId: string) => {
       const source = sources.find(s => s.id === sourceId);
-      if (source) {
-        const pluginId = pluginIdToLegacyType(source.pluginId);
-        const sourceConfig = getRepoConfigFromSource(source);
-        useImageStore.setState({ storageType: pluginId });
-        if (pluginId === 'github') {
-          setGitHubConfig(sourceConfig);
-        } else {
-          setGiteeConfig(sourceConfig);
-        }
-        return sourceId;
+      if (!source) {
+        return null;
       }
-      return null;
+      if (!isStoragePluginRegistered(source.pluginId)) {
+        return null;
+      }
+      const legacyType = pluginIdToLegacyType(source.pluginId);
+      const sourceConfig = getRepoConfigFromSource(source);
+      useImageStore.setState({ storageType: legacyType });
+      if (legacyType === 'github') {
+        setGitHubConfig(sourceConfig);
+      } else {
+        setGiteeConfig(sourceConfig);
+      }
+      return sourceId;
     },
     [sources, setGitHubConfig, setGiteeConfig],
   );
@@ -69,17 +75,18 @@ export function useSourceManagement() {
   const handleSourceSelect = useCallback(
     (id: string) => {
       const source = sources.find(s => s.id === id);
-      if (source) {
-        setSelectedSourceId(id);
-        const sourceConfig = getRepoConfigFromSource(source);
-        const pluginId = pluginIdToLegacyType(source.pluginId);
-        if (pluginId === 'github') {
-          setGitHubConfig(sourceConfig);
-        } else {
-          setGiteeConfig(sourceConfig);
-        }
-        loadImages();
+      if (!source || !isStoragePluginRegistered(source.pluginId)) {
+        return;
       }
+      setSelectedSourceId(id);
+      const sourceConfig = getRepoConfigFromSource(source);
+      const legacyType = pluginIdToLegacyType(source.pluginId);
+      if (legacyType === 'github') {
+        setGitHubConfig(sourceConfig);
+      } else {
+        setGiteeConfig(sourceConfig);
+      }
+      loadImages();
     },
     [sources, setSelectedSourceId, setGitHubConfig, setGiteeConfig, loadImages],
   );

--- a/apps/pixuli/src/hooks/useUIState.ts
+++ b/apps/pixuli/src/hooks/useUIState.ts
@@ -49,9 +49,11 @@ export function useUIState() {
     setShowSourceTypeMenu(true);
   }, []);
 
-  const handleSelectSourceType = useCallback((type: 'github' | 'gitee') => {
+  const handleSelectSourceType = useCallback((pluginId: string) => {
     setEditingSourceId(null);
-    useImageStore.setState({ storageType: type });
+    useImageStore.setState({
+      storageType: pluginId as 'github' | 'gitee',
+    });
     setShowSourceTypeMenu(false);
     setShowConfigModal(true);
   }, []);

--- a/apps/pixuli/src/layouts/MainLayout.tsx
+++ b/apps/pixuli/src/layouts/MainLayout.tsx
@@ -28,6 +28,7 @@ import { useI18n } from '../i18n/useI18n';
 import { useImageStore } from '../stores/imageStore';
 import { useSourceStore } from '../stores/sourceStore';
 import { useUIStore } from '../stores/uiStore';
+import { listStoragePluginManifests } from '../storage/registry';
 import { getPlatform } from '../utils/platform';
 import { AppMain } from './AppMain';
 import { Sidebar } from './Sidebar';
@@ -53,7 +54,7 @@ interface MainLayoutProps {
   // 配置相关 props（用于弹窗）
   onSaveConfig: (config: any) => void;
   onClearConfig: () => void;
-  onSelectSourceType: (type: 'github' | 'gitee') => void;
+  onSelectSourceType: (pluginId: string) => void;
 }
 
 export const MainLayout: React.FC<MainLayoutProps> = ({
@@ -138,6 +139,7 @@ export const MainLayout: React.FC<MainLayoutProps> = ({
       {/* 仓库类型选择菜单 */}
       <SourceTypeMenu
         isOpen={showSourceTypeMenu}
+        manifests={listStoragePluginManifests()}
         onClose={closeSourceTypeMenu}
         onSelect={onSelectSourceType}
         t={t}

--- a/apps/pixuli/src/storage/createProvider.ts
+++ b/apps/pixuli/src/storage/createProvider.ts
@@ -4,6 +4,10 @@ import type {
   StorageProviderConfig,
 } from '@pixuli/core/plugins';
 import { DefaultPlatformAdapter } from '@pixuli/core/platform';
+import {
+  getStoragePluginDisplayName,
+  isKnownBuiltinPluginId,
+} from '@pixuli/core/plugins';
 import { storageRegistry } from './registry';
 
 export type StoragePluginId = 'github' | 'gitee';
@@ -13,9 +17,12 @@ export function getAppPlatform(): 'web' | 'desktop' {
 }
 
 export function createConfiguredStorageProvider(
-  pluginId: StoragePluginId,
+  pluginId: string,
   config: GitHubConfig | GiteeConfig,
 ): StorageProvider {
+  if (!isKnownBuiltinPluginId(pluginId)) {
+    throw new Error(`Unsupported storage plugin: ${pluginId}`);
+  }
   const provider = storageRegistry.create(pluginId, {
     platform: getAppPlatform(),
     platformAdapter: new DefaultPlatformAdapter(),
@@ -24,6 +31,9 @@ export function createConfiguredStorageProvider(
   return provider;
 }
 
-export function storagePluginLabel(pluginId: StoragePluginId | null): string {
-  return pluginId === 'gitee' ? 'Gitee' : 'GitHub';
+export function storagePluginLabel(pluginId: string | null): string {
+  if (!pluginId) {
+    return '存储';
+  }
+  return getStoragePluginDisplayName(storageRegistry, pluginId);
 }

--- a/apps/pixuli/src/storage/registry.ts
+++ b/apps/pixuli/src/storage/registry.ts
@@ -1,4 +1,8 @@
-import { createStoragePluginRegistry } from '@pixuli/core/plugins';
+import {
+  createStoragePluginRegistry,
+  isStoragePluginRegistered as isPluginRegisteredOnRegistry,
+  type StoragePluginManifest,
+} from '@pixuli/core/plugins';
 import { registerGitHubProvider } from '@pixuli/provider-github/register';
 import { registerGiteeProvider } from '@pixuli/provider-gitee/register';
 
@@ -16,3 +20,11 @@ export function bootstrapStorageProviders(): void {
 }
 
 bootstrapStorageProviders();
+
+export function listStoragePluginManifests(): StoragePluginManifest[] {
+  return storageRegistry.listManifests();
+}
+
+export function isStoragePluginRegistered(pluginId: string): boolean {
+  return isPluginRegisteredOnRegistry(storageRegistry, pluginId);
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,16 +4,16 @@
 
 ## 子路径导出
 
-| 路径                         | 内容                                                      |
-| ---------------------------- | --------------------------------------------------------- |
-| `@pixuli/core`               | 主入口                                                    |
-| `@pixuli/core/types`         | 图片、GitHub/Gitee、日志等类型                            |
-| `@pixuli/core/plugins`       | `StorageProvider` 契约、`StoragePluginRegistry`、配置类型 |
-| `@pixuli/core/sources`       | `StoredSourceEntry` 持久化归一化、单条配置导入/导出       |
-| `@pixuli/core/platform`      | `PlatformAdapter`                                         |
-| `@pixuli/core/utils`         | filter、sort、fileSize、image 工具                        |
-| `@pixuli/core/locales`       | 应用级词条与 `deepMerge`                                  |
-| `@pixuli/core/operation-log` | `OperationLogService`                                     |
+| 路径                         | 内容                                                               |
+| ---------------------------- | ------------------------------------------------------------------ |
+| `@pixuli/core`               | 主入口                                                             |
+| `@pixuli/core/types`         | 图片、GitHub/Gitee、日志等类型                                     |
+| `@pixuli/core/plugins`       | `StorageProvider` 契约、`StoragePluginRegistry`、`manifestUi` 辅助 |
+| `@pixuli/core/sources`       | `StoredSourceEntry` 持久化归一化、单条配置导入/导出                |
+| `@pixuli/core/platform`      | `PlatformAdapter`                                                  |
+| `@pixuli/core/utils`         | filter、sort、fileSize、image 工具                                 |
+| `@pixuli/core/locales`       | 应用级词条与 `deepMerge`                                           |
+| `@pixuli/core/operation-log` | `OperationLogService`                                              |
 
 ## 依赖边界
 

--- a/packages/core/src/plugins/__tests__/manifestUi.test.ts
+++ b/packages/core/src/plugins/__tests__/manifestUi.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { createStoragePluginRegistry } from '../registry';
+import type { StoragePluginManifest } from '../types';
+import {
+  getManifestDescription,
+  getStoragePluginDisplayName,
+  isKnownBuiltinPluginId,
+  isStoragePluginRegistered,
+} from '../manifestUi';
+
+const testManifest: StoragePluginManifest = {
+  id: 'github',
+  name: 'GitHub',
+  version: '1.0.0',
+  capabilities: {
+    list: true,
+    upload: true,
+    delete: true,
+    updateMetadata: true,
+  },
+};
+
+describe('manifestUi', () => {
+  it('isStoragePluginRegistered and getStoragePluginDisplayName', () => {
+    const registry = createStoragePluginRegistry();
+    registry.register(testManifest, () => ({}) as never);
+    expect(isStoragePluginRegistered(registry, 'github')).toBe(true);
+    expect(isStoragePluginRegistered(registry, 'unknown')).toBe(false);
+    expect(getStoragePluginDisplayName(registry, 'github')).toBe('GitHub');
+    expect(getStoragePluginDisplayName(registry, 'unknown')).toBe('unknown');
+  });
+
+  it('getManifestDescription prefers translate', () => {
+    const desc = getManifestDescription(testManifest, key =>
+      key === 'sidebar.githubDescription' ? 'GitHub 仓库' : key,
+    );
+    expect(desc).toBe('GitHub 仓库');
+  });
+
+  it('isKnownBuiltinPluginId', () => {
+    expect(isKnownBuiltinPluginId('github')).toBe(true);
+    expect(isKnownBuiltinPluginId('custom')).toBe(false);
+  });
+});

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -1,5 +1,11 @@
 export * from './types';
 export {
+  getManifestDescription,
+  getStoragePluginDisplayName,
+  isKnownBuiltinPluginId,
+  isStoragePluginRegistered,
+} from './manifestUi';
+export {
   createStoragePluginRegistry,
   DefaultStoragePluginRegistry,
 } from './registry';

--- a/packages/core/src/plugins/manifestUi.ts
+++ b/packages/core/src/plugins/manifestUi.ts
@@ -1,0 +1,39 @@
+import type { StoragePluginManifest, StoragePluginRegistry } from './types';
+
+export function isStoragePluginRegistered(
+  registry: StoragePluginRegistry,
+  pluginId: string,
+): boolean {
+  return registry.getManifest(pluginId) !== undefined;
+}
+
+export function getStoragePluginDisplayName(
+  registry: StoragePluginRegistry,
+  pluginId: string,
+): string {
+  return registry.getManifest(pluginId)?.name ?? pluginId;
+}
+
+/**
+ * 添加源列表等场景的说明文案：优先 i18n `sidebar.{id}Description`，否则回退 manifest.name。
+ */
+export function getManifestDescription(
+  manifest: StoragePluginManifest,
+  translate?: (key: string) => string,
+): string {
+  const key = `sidebar.${manifest.id}Description`;
+  if (translate) {
+    const value = translate(key);
+    if (value && value !== key) {
+      return value;
+    }
+  }
+  return manifest.name;
+}
+
+/** 已知内置插件 id，用于图标等 UI 分支（M3 P0 仅 github / gitee）。 */
+export function isKnownBuiltinPluginId(
+  pluginId: string,
+): pluginId is 'github' | 'gitee' {
+  return pluginId === 'github' || pluginId === 'gitee';
+}

--- a/packages/plugin-provider-gitee/src/manifest.ts
+++ b/packages/plugin-provider-gitee/src/manifest.ts
@@ -4,6 +4,7 @@ export const giteeManifest: StoragePluginManifest = {
   id: 'gitee',
   name: 'Gitee',
   version: '1.0.0',
+  icon: 'gitee',
   capabilities: {
     list: true,
     upload: true,

--- a/packages/plugin-provider-github/src/manifest.ts
+++ b/packages/plugin-provider-github/src/manifest.ts
@@ -4,6 +4,7 @@ export const githubManifest: StoragePluginManifest = {
   id: 'github',
   name: 'GitHub',
   version: '1.0.0',
+  icon: 'github',
   capabilities: {
     list: true,
     upload: true,

--- a/packages/ui/src/layout/sidebar/locales/en-US.json
+++ b/packages/ui/src/layout/sidebar/locales/en-US.json
@@ -17,6 +17,8 @@
     "selectSourceType": "Select Repository Type",
     "githubDescription": "Store images in GitHub repository",
     "giteeDescription": "Store images in Gitee repository",
+    "noStoragePlugins": "No storage plugins available",
+    "pluginUnavailable": "Plugin not installed or unavailable",
     "mainNav": "Features",
     "browseMode": "Browse Mode",
     "filter": "Filter",

--- a/packages/ui/src/layout/sidebar/locales/zh-CN.json
+++ b/packages/ui/src/layout/sidebar/locales/zh-CN.json
@@ -17,6 +17,8 @@
     "selectSourceType": "选择仓库类型",
     "githubDescription": "使用 GitHub 仓库存储图片",
     "giteeDescription": "使用 Gitee 仓库存储图片",
+    "noStoragePlugins": "当前没有可用的存储插件",
+    "pluginUnavailable": "插件未安装或不可用",
     "mainNav": "功能",
     "browseMode": "浏览模式",
     "filter": "筛选",

--- a/packages/ui/src/layout/sidebar/web/Sidebar.css
+++ b/packages/ui/src/layout/sidebar/web/Sidebar.css
@@ -646,6 +646,20 @@
   background: var(--active-bg, #e5e7eb);
 }
 
+.sidebar-source-item--unavailable {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.sidebar-source-item--unavailable:hover {
+  background: transparent;
+}
+
+.sidebar-source-item--unavailable .sidebar-source-path {
+  color: var(--text-muted, #9ca3af);
+  font-style: italic;
+}
+
 .sidebar-source-item.active .sidebar-source-icon {
   color: var(--text-primary, #111827);
 }

--- a/packages/ui/src/layout/sidebar/web/Sidebar.tsx
+++ b/packages/ui/src/layout/sidebar/web/Sidebar.tsx
@@ -42,6 +42,8 @@ export interface SidebarSource {
   repo: string;
   path: string;
   active?: boolean;
+  /** 对应 pluginId 是否已在 Registry 注册（REF-307） */
+  available?: boolean;
 }
 
 interface SidebarProps {
@@ -544,32 +546,49 @@ const Sidebar: React.FC<SidebarProps> = ({
           </div>
         ) : (
           <div className="sidebar-source-list">
-            {sources.map(source => (
-              <button
-                key={source.id}
-                className={`sidebar-source-item ${
-                  selectedSourceId === source.id ? 'active' : ''
-                }`}
-                onClick={() => onSourceSelect(source.id)}
-                onContextMenu={e => handleContextMenu(e, source.id)}
-                title={`${source.owner}/${source.repo}`}
-              >
-                <div className="sidebar-source-icon">
-                  {source.type === 'github' ? (
-                    <Github size={16} />
-                  ) : (
-                    <div className="gitee-icon">码</div>
-                  )}
-                </div>
-                <div className="sidebar-source-info">
-                  <div className="sidebar-source-name">{source.name}</div>
-                  <div className="sidebar-source-path">
-                    {source.owner}/{source.repo}
+            {sources.map(source => {
+              const unavailable = source.available === false;
+              return (
+                <button
+                  key={source.id}
+                  type="button"
+                  className={`sidebar-source-item ${
+                    selectedSourceId === source.id ? 'active' : ''
+                  } ${unavailable ? 'sidebar-source-item--unavailable' : ''}`}
+                  onClick={() => {
+                    if (!unavailable) {
+                      onSourceSelect(source.id);
+                    }
+                  }}
+                  onContextMenu={e => handleContextMenu(e, source.id)}
+                  title={
+                    unavailable
+                      ? translate('sidebar.pluginUnavailable')
+                      : `${source.owner}/${source.repo}`
+                  }
+                  disabled={unavailable}
+                >
+                  <div className="sidebar-source-icon">
+                    {source.type === 'github' ? (
+                      <Github size={16} />
+                    ) : (
+                      <div className="gitee-icon">码</div>
+                    )}
                   </div>
-                </div>
-                {source.active && <div className="sidebar-source-active-dot" />}
-              </button>
-            ))}
+                  <div className="sidebar-source-info">
+                    <div className="sidebar-source-name">{source.name}</div>
+                    <div className="sidebar-source-path">
+                      {unavailable
+                        ? translate('sidebar.pluginUnavailable')
+                        : `${source.owner}/${source.repo}`}
+                    </div>
+                  </div>
+                  {source.active && !unavailable && (
+                    <div className="sidebar-source-active-dot" />
+                  )}
+                </button>
+              );
+            })}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- 新增 `@pixuli/core/plugins` 的 `manifestUi`：`isStoragePluginRegistered`、`getStoragePluginDisplayName`、`getManifestDescription`
- Web `SourceTypeMenu`、Mobile `StorageConfigModal` / `AddSourceModal` 由 `listStoragePluginManifests()` 渲染可选插件，替代硬编码 github/gitee
- 侧边栏与 Mobile Drawer：对已保存但 Registry 未注册的源显示「插件不可用」并禁止切换
- GitHub/Gitee manifest 补充 `icon` 字段；`storagePluginLabel` 从 Registry 读取名称
- `REFACTOR_PLAN.md`：REF-307 ✅，M3 进度 7/12（58%）

Closes #76

## Test plan

- [x] `cd packages/core && pnpm test`
- [x] `cd apps/pixuli && pnpm exec tsc --noEmit`
- [x] `cd apps/mobile && pnpm exec tsc --noEmit`
- [ ] Web：添加源菜单显示 GitHub/Gitee（来自 manifest）；源列表正常切换
- [ ] Mobile：添加源 → 类型选择与 Web 一致；Drawer 源列表行为正常
- [ ] （可选）手动将某源 `pluginId` 改为未注册值，确认显示不可用且无法切换


Made with [Cursor](https://cursor.com)