### PR TITLE
docs(m3): REF-308 存储插件开发指南

### DIFF
--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -34,7 +34,7 @@
 | M1     | 减负与归档          |                  | 展示裁剪、wasm/server 归档、死代码删除                                |
 | M2     | core / ui 拆分      |                  | 新建包、迁移 import、兼容层                                           |
 | M3     | 存储插件 P0         |                  | Provider 接口、双端 imageStore、pluginId 配置、删除 `packages/common` |
-| M4     | 文档与 CI           |                  | PRD/README/CI 与架构一致                                              |
+| M4     | 文档与 CI           |                  | PRD/README/CI、docs/Wiki 梳理；历史版本盘点与后续发布策略             |
 | M5     | 平台能力 L3（持续） |                  | PWA 归位、Desktop 离线/更新规划                                       |
 
 ---
@@ -369,6 +369,9 @@ Closes #42 Related: REF-101
 | REF-404 | [#83](https://github.com/trueLoving/Pixuli/issues/83)   |
 | REF-405 | [#84](https://github.com/trueLoving/Pixuli/issues/84)   |
 | REF-406 | [#85](https://github.com/trueLoving/Pixuli/issues/85)   |
+| REF-407 | [#111](https://github.com/trueLoving/Pixuli/issues/111) |
+| REF-408 | [#112](https://github.com/trueLoving/Pixuli/issues/112) |
+| REF-409 | [#113](https://github.com/trueLoving/Pixuli/issues/113) |
 | REF-501 | [#86](https://github.com/trueLoving/Pixuli/issues/86)   |
 | REF-502 | [#87](https://github.com/trueLoving/Pixuli/issues/87)   |
 | REF-503 | [#88](https://github.com/trueLoving/Pixuli/issues/88)   |
@@ -502,20 +505,20 @@ native。
 
 ### 里程碑 M3 — 存储插件体系 P0
 
-| ID      | 建议标题                                        | Labels                                                 | 优先级 | Depends on         | GitHub #                                                | 状态 |
-| ------- | ----------------------------------------------- | ------------------------------------------------------ | ------ | ------------------ | ------------------------------------------------------- | ---- |
-| REF-301 | [M3] 在 core 定义 StorageProvider 与 Registry   | refactor, m3, area:core, area:plugin, priority:P0      | P0     | #60                | [#70](https://github.com/trueLoving/Pixuli/issues/70)   | ✅   |
-| REF-302 | [M3] 实现 @pixuli/provider-github               | refactor, m3, area:plugin, priority:P0                 | P0     | #70                | [#71](https://github.com/trueLoving/Pixuli/issues/71)   | ✅   |
-| REF-303 | [M3] 实现 @pixuli/provider-gitee                | refactor, m3, area:plugin, priority:P0                 | P0     | #70                | [#72](https://github.com/trueLoving/Pixuli/issues/72)   | ✅   |
-| REF-304 | [M3] 重构 apps/pixuli imageStore 使用 Registry  | refactor, m3, area:web, area:desktop, priority:P0      | P0     | #71, #72, #64      | [#73](https://github.com/trueLoving/Pixuli/issues/73)   | ✅   |
-| REF-305 | [M3] 重构 apps/mobile imageStore 使用 Registry  | refactor, m3, area:mobile, priority:P0                 | P0     | #71, #72, #65      | [#74](https://github.com/trueLoving/Pixuli/issues/74)   | ✅   |
-| REF-306 | [M3] 配置持久化增加 pluginId（导入/导出）       | refactor, m3, priority:P1                              | P1     | #73, #74           | [#75](https://github.com/trueLoving/Pixuli/issues/75)   | ✅   |
-| REF-307 | [M3] 设置页源列表对接 registry.listManifests    | refactor, m3, area:ui, priority:P1                     | P1     | #75                | [#76](https://github.com/trueLoving/Pixuli/issues/76)   | ✅   |
-| REF-308 | [M3] 编写插件开发文档 docs/plugins/authoring.md | refactor, m3, type:docs, priority:P1                   | P1     | #70                | [#77](https://github.com/trueLoving/Pixuli/issues/77)   | ⬜   |
-| REF-309 | [M3] provider 包单元测试迁移                    | refactor, m3, priority:P1                              | P1     | #71, #72           | [#78](https://github.com/trueLoving/Pixuli/issues/78)   | ⬜   |
-| REF-310 | [M3] M3 回归：GitHub/Gitee 全流程               | refactor, m3, priority:P0                              | P0     | #73–#78, #109      | [#79](https://github.com/trueLoving/Pixuli/issues/79)   | ⬜   |
-| REF-311 | [M3] 删除 `packages/common` 整包                | refactor, m3, type:removal, priority:P0                | P0     | #73, #74, #78, #79 | [#100](https://github.com/trueLoving/Pixuli/issues/100) | ⬜   |
-| REF-312 | [Bug] 编辑仓库源时配置表单未回显                | bug, refactor, m3, area:web, area:desktop, priority:P1 | P1     | #75, #76           | [#109](https://github.com/trueLoving/Pixuli/issues/109) | ⬜   |
+| ID      | 建议标题                                             | Labels                                                 | 优先级 | Depends on         | GitHub #                                                | 状态 |
+| ------- | ---------------------------------------------------- | ------------------------------------------------------ | ------ | ------------------ | ------------------------------------------------------- | ---- |
+| REF-301 | [M3] 在 core 定义 StorageProvider 与 Registry        | refactor, m3, area:core, area:plugin, priority:P0      | P0     | #60                | [#70](https://github.com/trueLoving/Pixuli/issues/70)   | ✅   |
+| REF-302 | [M3] 实现 @pixuli/provider-github                    | refactor, m3, area:plugin, priority:P0                 | P0     | #70                | [#71](https://github.com/trueLoving/Pixuli/issues/71)   | ✅   |
+| REF-303 | [M3] 实现 @pixuli/provider-gitee                     | refactor, m3, area:plugin, priority:P0                 | P0     | #70                | [#72](https://github.com/trueLoving/Pixuli/issues/72)   | ✅   |
+| REF-304 | [M3] 重构 apps/pixuli imageStore 使用 Registry       | refactor, m3, area:web, area:desktop, priority:P0      | P0     | #71, #72, #64      | [#73](https://github.com/trueLoving/Pixuli/issues/73)   | ✅   |
+| REF-305 | [M3] 重构 apps/mobile imageStore 使用 Registry       | refactor, m3, area:mobile, priority:P0                 | P0     | #71, #72, #65      | [#74](https://github.com/trueLoving/Pixuli/issues/74)   | ✅   |
+| REF-306 | [M3] 配置持久化增加 pluginId（导入/导出）            | refactor, m3, priority:P1                              | P1     | #73, #74           | [#75](https://github.com/trueLoving/Pixuli/issues/75)   | ✅   |
+| REF-307 | [M3] 设置页源列表对接 registry.listManifests         | refactor, m3, area:ui, priority:P1                     | P1     | #75                | [#76](https://github.com/trueLoving/Pixuli/issues/76)   | ✅   |
+| REF-308 | [M3] 编写插件开发文档 08-storage-plugin-authoring.md | refactor, m3, type:docs, priority:P1                   | P1     | #70                | [#77](https://github.com/trueLoving/Pixuli/issues/77)   | ✅   |
+| REF-309 | [M3] provider 包单元测试迁移                         | refactor, m3, priority:P1                              | P1     | #71, #72           | [#78](https://github.com/trueLoving/Pixuli/issues/78)   | ⬜   |
+| REF-310 | [M3] M3 回归：GitHub/Gitee 全流程                    | refactor, m3, priority:P0                              | P0     | #73–#78, #109      | [#79](https://github.com/trueLoving/Pixuli/issues/79)   | ⬜   |
+| REF-311 | [M3] 删除 `packages/common` 整包                     | refactor, m3, type:removal, priority:P0                | P0     | #73, #74, #78, #79 | [#100](https://github.com/trueLoving/Pixuli/issues/100) | ⬜   |
+| REF-312 | [Bug] 编辑仓库源时配置表单未回显                     | bug, refactor, m3, area:web, area:desktop, priority:P1 | P1     | #75, #76           | [#109](https://github.com/trueLoving/Pixuli/issues/109) | ⬜   |
 
 <details>
 <summary>REF-301 ~ REF-312 Issue 正文模板</summary>
@@ -533,7 +536,8 @@ native。
 
 **REF-307** — 添加源 UI 按 manifest 列表渲染。
 
-**REF-308** — 最小 provider-example 骨架 + 安全说明（Token 本地存储）。
+**REF-308** —
+[08-storage-plugin-authoring.md](docs/02-system-design/08-storage-plugin-authoring.md)：内置/热加载模式、命名与安全、最小 example 骨架 + 检查清单。
 
 **REF-309** — 迁移 `services/__tests__/*` 到 provider 包。
 
@@ -568,14 +572,107 @@ P0，见 [#102](https://github.com/trueLoving/Pixuli/issues/102)（#70 / #76 /
 
 ### 里程碑 M4 — 文档与 CI
 
-| ID      | 建议标题                                                | Labels                               | 优先级 | Depends on | GitHub #                                              | 状态 |
-| ------- | ------------------------------------------------------- | ------------------------------------ | ------ | ---------- | ----------------------------------------------------- | ---- |
-| REF-401 | [M4] 更新 PRD：三端底线、展示裁剪、无官方 Server        | refactor, m4, type:docs, priority:P1 | P1     | #46, #56   | [#80](https://github.com/trueLoving/Pixuli/issues/80) | ⬜   |
-| REF-402 | [M4] 新增 docs/backlog.md 承接已移除/未做需求           | refactor, m4, type:docs, priority:P1 | P1     | #80        | [#81](https://github.com/trueLoving/Pixuli/issues/81) | ⬜   |
-| REF-403 | [M4] 更新 README 结构、环境要求、维护范围               | refactor, m4, type:docs, priority:P1 | P1     | #54, #56   | [#82](https://github.com/trueLoving/Pixuli/issues/82) | ⬜   |
-| REF-404 | [M4] 更新 CHANGELOG 记录 Breaking Changes               | refactor, m4, type:docs, priority:P1 | P1     | #58        | [#83](https://github.com/trueLoving/Pixuli/issues/83) | ⬜   |
-| REF-405 | [M4] CI：移除 benchmark workflow；desktop 构建去掉 wasm | refactor, m4, priority:P1            | P1     | #54, #55   | [#84](https://github.com/trueLoving/Pixuli/issues/84) | ⬜   |
-| REF-406 | [M4] archive/README 说明 wasm/server 归档策略           | refactor, m4, type:docs, priority:P2 | P2     | #54, #56   | [#85](https://github.com/trueLoving/Pixuli/issues/85) | ⬜   |
+| ID      | 建议标题                                                | Labels                               | 优先级 | Depends on | GitHub #                                                | 状态 |
+| ------- | ------------------------------------------------------- | ------------------------------------ | ------ | ---------- | ------------------------------------------------------- | ---- |
+| REF-401 | [M4] 更新 PRD：三端底线、展示裁剪、无官方 Server        | refactor, m4, type:docs, priority:P1 | P1     | #46, #56   | [#80](https://github.com/trueLoving/Pixuli/issues/80)   | ⬜   |
+| REF-402 | [M4] 新增 docs/backlog.md 承接已移除/未做需求           | refactor, m4, type:docs, priority:P1 | P1     | #80        | [#81](https://github.com/trueLoving/Pixuli/issues/81)   | ⬜   |
+| REF-403 | [M4] 更新 README 结构、环境要求、维护范围               | refactor, m4, type:docs, priority:P1 | P1     | #54, #56   | [#82](https://github.com/trueLoving/Pixuli/issues/82)   | ⬜   |
+| REF-404 | [M4] 更新 CHANGELOG 记录 Breaking Changes               | refactor, m4, type:docs, priority:P1 | P1     | #58        | [#83](https://github.com/trueLoving/Pixuli/issues/83)   | ⬜   |
+| REF-405 | [M4] CI：移除 benchmark workflow；desktop 构建去掉 wasm | refactor, m4, priority:P1            | P1     | #54, #55   | [#84](https://github.com/trueLoving/Pixuli/issues/84)   | ⬜   |
+| REF-406 | [M4] archive/README 说明 wasm/server 归档策略           | refactor, m4, type:docs, priority:P2 | P2     | #54, #56   | [#85](https://github.com/trueLoving/Pixuli/issues/85)   | ⬜   |
+| REF-407 | [M4] 梳理整理 `docs/` 目录（纠错、去重、与现架构对齐）  | refactor, m4, type:docs, priority:P1 | P1     | #80, #82   | [#111](https://github.com/trueLoving/Pixuli/issues/111) | ⬜   |
+| REF-408 | [M4] 梳理 GitHub Wiki 产品使用手册（新人从零上手）      | refactor, m4, type:docs, priority:P1 | P1     | #80, #111  | [#112](https://github.com/trueLoving/Pixuli/issues/112) | ⬜   |
+| REF-409 | [M4] 历史发布版本梳理与后续版本发布策略                 | refactor, m4, type:docs, priority:P1 | P1     | #58, #83   | [#113](https://github.com/trueLoving/Pixuli/issues/113) | ⬜   |
+
+<details>
+<summary>REF-407 / REF-408 / REF-409 范围说明（点击展开）</summary>
+
+**文档分层（目标态）**
+
+| 载体                                                         | 读者             | 内容定位                                                                |
+| ------------------------------------------------------------ | ---------------- | ----------------------------------------------------------------------- |
+| **`docs/`**（仓库内）                                        | 开发、产品、协作 | PRD、系统设计、业务设计、插件开发；随代码版本演进，以 PR 评审           |
+| **[GitHub Wiki](https://github.com/trueLoving/Pixuli/wiki)** | 终端用户、新人   | **产品使用手册**：安装、首次配置、日常操作、三端差异、FAQ；少讲实现细节 |
+| **`docs/01-product/02-Pixuli-Usage-Tutorial.md`**            | 同上（源稿）     | 可作为 Wiki 同步源或精简后迁入 Wiki，避免双份长期分叉                   |
+
+**REF-407 — `docs/` 梳理整理**
+
+背景：M1～M3 重构后，部分文档仍引用
+`packages/common`、已移除浏览模式、wasm/server 主路径等，存在**过时、重复、职责不清**问题。
+
+- [ ] 全量审计 `docs/`（含 `docs/README.md` 索引）：标注与当前代码不一致处
+- [ ] **纠错**：模块职责（`@pixuli/core` / `@pixuli/ui` /
+      `provider-*`）、三端底线、已裁剪功能（幻灯片/时间线等）
+- [ ] **去重**：合并重复叙述；系统设计与业务设计边界清晰；过时教程段落删除或迁
+      `docs/backlog.md`（REF-402）
+- [ ] **索引**：更新 `docs/README.md` 与各文档头部「相关文档」互链
+- [ ] 与 REF-401（PRD）、REF-403（README）结论一致，必要时在文首增加「最后核对版本 / 适用分支」说明
+
+验收：新人读 `docs/README`
+可按角色找到正确文档；`grep packages/common`（docs 内）仅出现在历史/迁移说明或 backlog。
+
+**REF-408 — GitHub Wiki 使用手册**
+
+目标：Wiki 作为**对外产品手册**，让新人**从零开始**完成：了解 Pixuli
+→ 选端（Web/Desktop/Mobile）→ 配置 GitHub/Gitee 源 → 上传与管理图片。
+
+- [ ] 规划 Wiki 目录结构（建议）：首页 / 快速开始 / 仓库源配置 / 图片管理 / 实用工具 / 三端说明 / 常见问题 / 更新日志链接
+- [ ] 对照当前产品 UI 与 REF-401 后 PRD 修订正文（不写已移除能力）
+- [ ] Web / Desktop / Mobile 分节说明安装或访问方式、界面差异
+- [ ] 配置步骤配图或分步说明（Token 获取、owner/repo/path）；强调 Token 仅存本地
+- [ ] 在仓库 README 与 Wiki 首页互相链接；`docs/01-product`
+      中注明 Wiki 为面向用户的发布副本
+
+验收：非技术用户仅读 Wiki 即可完成首次配置并上传一张图；Wiki 与 REF-407 后的
+`docs/` 无矛盾表述。
+
+**建议顺序**：REF-401 → REF-407 ∥ REF-403 →
+REF-408（Wiki 依赖 docs/ 纠错结果，避免把过时内容同步到 Wiki）。
+
+**REF-409 — 历史发布版本梳理与后续发布策略**
+
+背景：仓库已有 [CHANGELOG.md](CHANGELOG.md) 与 GitHub Releases（如
+`v1.3.0-desktop`、`v1.0.0-mobile`），但**三端版本号不统一**、标签命名无书面约定；M1～M3 重构将产生 Breaking
+Changes，需明确「下一版」如何发。
+
+**Part A — 历史版本梳理**
+
+- [ ] 盘点 GitHub [Releases](https://github.com/trueLoving/Pixuli/releases)
+      与 tags（desktop / mobile / 历史命名）
+- [ ] 对照
+      `CHANGELOG.md`：补缺、纠错、标注已过时条目（如 Upyun、幻灯片等已移除能力）
+- [ ] 整理**版本—能力矩阵**表：各版本三端交付物、下载入口、是否仍建议升级
+- [ ] 明确 Web/PWA 是否曾有独立版本号；若无，在文档中说明「随 main 部署、无安装包」
+
+**Part B — 后续发布策略（目标态文档）**
+
+建议产出 `docs/01-product/03-release-versioning.md`（或
+`docs/02-system-design/09-release-versioning.md`）：
+
+- [ ] **版本号规则**：SemVer
+      2.0；是否 monorepo 统一版本 vs 分端独立（`1.4.0-desktop` /
+      `1.1.0-mobile`）
+- [ ] **标签与 Release 命名**：如
+      `v{semver}-desktop`、`v{semver}-mobile`；Web 是否打 tag
+- [ ] **发布节奏**：重构里程碑（M1/M2/M3）与对外版本的对应关系；何时发 major
+- [ ] **CHANGELOG 维护**：与 #83（REF-404）分工——#83 记本次 Breaking；本 Issue 定**长期流程**（谁写、何时写、Keep
+      a Changelog 分类）
+- [ ] **CI/CD 衔接**：`release-desktop.yml`、Mobile 发版流程、GitHub
+      Release 自动生成说明
+- [ ] **用户沟通**：Wiki /
+      README 如何展示「当前稳定版」与「升级说明」；重构后首个推荐版本号建议
+
+验收：
+
+- [ ] 存在一份可执行的《版本发布策略》文档，维护者按文档即可发下一版 Desktop/Mobile
+- [ ] 历史 Releases 有对照表，用户能判断自己安装的版本是否过旧、是否含已下线功能
+- [ ] 与 #83 不重复：#83 完成**本轮**
+      CHANGELOG 条目；本 Issue 完成**制度与历史盘点**
+
+**建议顺序**：#58（M1 回归）后启动 ∥ #83；#112（Wiki）可链到 Releases
+/ 升级说明章节。
+
+</details>
 
 ---
 
@@ -652,10 +749,10 @@ flowchart LR
 | -------- | -------- | ------ | ------- |
 | M1       | 12       | 7      | 58%     |
 | M2       | 10       | 0      | 0%      |
-| M3       | 12       | 7      | 58%     |
-| M4       | 6        | 0      | 0%      |
+| M3       | 12       | 8      | 67%     |
+| M4       | 9        | 0      | 0%      |
 | M5       | 5        | 0      | 0%      |
-| **合计** | **45**   | **8**  | **18%** |
+| **合计** | **48**   | **9**  | **19%** |
 
 ---
 
@@ -670,7 +767,12 @@ flowchart LR
 | 执行 Checklist       | `.local/简化执行-checklist.md`      |
 
 > 建议：M4 中将 `.local` 核心内容迁入
-> `docs/architecture/`，便于协作者不依赖本地文件。
+> `docs/architecture/`，便于协作者不依赖本地文件（可纳入 REF-407）。
+>
+> **对外用户文档**：仓库内 `docs/01-product/` 面向协作者与版本管理；**GitHub
+> Wiki**
+> 作为终端用户使用手册（REF-408），二者避免长期双份维护，以 Wiki 为发布面、
+> `docs/` 为源稿或定期同步。
 
 ---
 

--- a/docs/02-system-design/07-storage-plugin-system.md
+++ b/docs/02-system-design/07-storage-plugin-system.md
@@ -6,6 +6,8 @@
 - **关联 Issue**：[#70](https://github.com/trueLoving/Pixuli/issues/70)
 - **相关文档**：
   - [00-System-Design](./00-System-Design.md) — 系统分层与数据流
+  - [08-storage-plugin-authoring](./08-storage-plugin-authoring.md)
+    — 插件开发实操（REF-308）
   - [03-business-design/01-repository-source-management](../03-business-design/01-repository-source-management.md)
     — 仓库源业务模型
   - [REFACTOR_PLAN.md](../../REFACTOR_PLAN.md) — M3 REF-301～311 任务表
@@ -478,18 +480,18 @@ function createProvider(
 
 ## 十一、M3 迁移路线图
 
-| ID          | 内容                                     | 与本文关系                       |
-| ----------- | ---------------------------------------- | -------------------------------- |
-| **REF-301** | core 契约与 Registry **定稿 + 代码对齐** | **本文档 + types/registry 补全** |
-| REF-302     | `@pixuli/provider-github`                | §6 实现 GitHub                   |
-| REF-303     | `@pixuli/provider-gitee`                 | §6 实现 Gitee                    |
-| REF-304/305 | apps imageStore → Registry               | §7.2                             |
-| REF-306     | 持久化 `pluginId`                        | §8.2                             |
-| REF-307     | UI 读 `listManifests`                    | §7.3                             |
-| REF-308     | 插件开发文档 `docs/plugins/authoring.md` | 基于本文扩展                     |
-| REF-309     | 单测迁移                                 | §10.3                            |
-| REF-310     | M3 回归                                  | §10.3                            |
-| REF-311     | 删除 `packages/common`                   | §4.1 移除 legacy                 |
+| ID          | 内容                                          | 与本文关系                       |
+| ----------- | --------------------------------------------- | -------------------------------- |
+| **REF-301** | core 契约与 Registry **定稿 + 代码对齐**      | **本文档 + types/registry 补全** |
+| REF-302     | `@pixuli/provider-github`                     | §6 实现 GitHub                   |
+| REF-303     | `@pixuli/provider-gitee`                      | §6 实现 Gitee                    |
+| REF-304/305 | apps imageStore → Registry                    | §7.2                             |
+| REF-306     | 持久化 `pluginId`                             | §8.2                             |
+| REF-307     | UI 读 `listManifests`                         | §7.3                             |
+| REF-308     | 插件开发文档 `08-storage-plugin-authoring.md` | 基于本文扩展                     |
+| REF-309     | 单测迁移                                      | §10.3                            |
+| REF-310     | M3 回归                                       | §10.3                            |
+| REF-311     | 删除 `packages/common`                        | §4.1 移除 legacy                 |
 
 建议实施顺序：**301 → 302 ∥ 303 → 304 ∥ 305 → 309 → 310 →
 311**；306/307 可与 304 并行（P1）。
@@ -529,4 +531,6 @@ const githubManifest: StoragePluginManifest = {
 
 - M3 各 REF 合并后，更新 [00-System-Design](./00-System-Design.md)
   中「模块与职责」一节，将 `packages/common` 替换为 provider 包描述。
-- REF-308 产出 `docs/plugins/authoring.md` 作为本文的**开发者实操**补充。
+- REF-308 产出
+  [08-storage-plugin-authoring.md](./08-storage-plugin-authoring.md)
+  作为本文的**开发者实操**补充。

--- a/docs/02-system-design/08-storage-plugin-authoring.md
+++ b/docs/02-system-design/08-storage-plugin-authoring.md
@@ -1,0 +1,656 @@
+# 存储插件开发指南
+
+- **文档版本**：1.0
+- **所属目录**：`docs/02-system-design`
+- **计划编号**：REF-308（M3 存储插件 P0）
+- **关联 Issue**：[#77](https://github.com/trueLoving/Pixuli/issues/77)
+- **前置阅读**：
+  - [07-storage-plugin-system.md](./07-storage-plugin-system.md)
+    — 架构、契约与 Registry 设计
+  - [03-business-design/01-repository-source-management](../03-business-design/01-repository-source-management.md)
+    — 仓库源业务模型
+
+本文是面向**第三方与内部开发者**的实操文档：如何从零实现一个符合 Pixuli 约定的存储 Provider 包，并接入应用 Registry。架构背景与术语以
+[07-storage-plugin-system.md](./07-storage-plugin-system.md)
+为准，本文侧重**步骤、约定与安全**。
+
+---
+
+## 目录
+
+- [一、读者与目标](#一读者与目标)
+- [二、两种集成模式](#二两种集成模式)
+- [三、快速开始（内置模式）](#三快速开始内置模式)
+- [四、包结构与命名约定](#四包结构与命名约定)
+- [五、实现清单（Manifest / Register / Provider）](#五实现清单manifest--register--provider)
+- [六、配置与 configSchema](#六配置与-configschema)
+- [七、安全：Token 与敏感数据](#七安全token-与敏感数据)
+- [八、注册到应用与 UI 消费](#八注册到应用与-ui-消费)
+- [九、测试与调试](#九测试与调试)
+- [十、热加载（Backlog）](#十热加载backlog)
+- [十一、最小示例骨架](#十一最小示例骨架)
+- [十二、检查清单](#十二检查清单)
+
+---
+
+## 一、读者与目标
+
+### 1.1 适合谁读
+
+- 希望为 Pixuli 增加新图床后端（自建 API、其他 Git 托管、对象存储等）的开发者。
+- 需要 fork Monorepo 或发布独立 npm 包 `@your-scope/provider-*` 的维护者。
+
+### 1.2 读完应能完成
+
+1. 创建一个仅依赖 `@pixuli/core` 的 Provider npm 包。
+2. 实现 `StoragePluginManifest` + `registerXxxProvider(registry)` +
+   `StorageProvider`。
+3. 在 `apps/pixuli` 或 `apps/mobile` 的 `bootstrapStorageProviders()`
+   中注册（内置模式）。
+4. 理解 Token 仅存客户端、不得写入 Manifest 的安全边界。
+5. （可选）为 REF-307 之后的动态表单准备 `configSchema`。
+
+### 1.3 不在本文范围
+
+- 插件市场 UI、从 URL 安装 bundle、签名校验（见
+  [#102](https://github.com/trueLoving/Pixuli/issues/102)）。
+- 图片处理类 Processor 插件（见
+  [02-cross-image-process.md](./02-cross-image-process.md)）。
+
+---
+
+## 二、两种集成模式
+
+| 模式                 | 适用场景                                             | 注册方式                                                                                         | M3 状态                     |
+| -------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------- |
+| **内置（官方路径）** | `@pixuli/provider-*` 作为 workspace 依赖，随应用发版 | 应用 `storage/registry.ts` 内 `bootstrapStorageProviders()` 调用 `registerXxxProvider(registry)` | **已支持**                  |
+| **热加载**           | 社区/自建 Provider，不随主应用发版                   | Loader 下载并校验 bundle 后，调用同一 `registry.register(manifest, factory)` API                 | **API 预留，Loader 未实现** |
+
+### 2.1 内置模式（推荐起步）
+
+```text
+packages/plugin-provider-{id}/
+    manifest.ts ──► StoragePluginManifest
+    register.ts ──► registerXxxProvider(registry)
+    {id}StorageProvider.ts ──► implements StorageProvider
+apps/pixuli|mobile/storage/registry.ts
+    bootstrapStorageProviders()
+        registerGitHubProvider(registry)
+        registerGiteeProvider(registry)
+        registerYourProvider(registry)   // 新增
+```
+
+### 2.2 热加载模式（计划中）
+
+M3 保证以下在 **API 层面** 可行，便于后续 Loader 接入而无需改契约：
+
+- `StoragePluginRegistry.register(manifest, factory)` 与 `listManifests()`。
+- 重复注册同一 `pluginId` 抛出
+  `StoragePluginAlreadyRegisteredError`（覆盖策略见 #102）。
+- 用户已保存的 `StoredSourceEntry.pluginId`
+  在插件未注册时，UI 显示「插件不可用」（REF-307）。
+
+**尚未提供**：bundle 格式、HTTPS 源白名单、代码签名、沙箱隔离。第三方实现热加载时需自行承担安全评审。
+
+---
+
+## 三、快速开始（内置模式）
+
+以下步骤假设在 Pixuli Monorepo 内新增
+`packages/plugin-provider-example`（`pluginId: example`），仅作演示；生产环境请替换为真实后端 ID。
+
+### 步骤 1：创建包目录
+
+```text
+packages/plugin-provider-example/
+├── package.json
+├── tsconfig.json
+├── vitest.config.ts
+├── README.md
+└── src/
+    ├── manifest.ts
+    ├── register.ts
+    ├── exampleStorageProvider.ts
+    ├── index.ts
+    └── __tests__/
+        └── register.test.ts
+```
+
+### 步骤 2：`package.json`
+
+```json
+{
+  "name": "@pixuli/provider-example",
+  "version": "0.0.0",
+  "description": "Pixuli example storage provider (documentation skeleton)",
+  "type": "module",
+  "license": "MIT",
+  "exports": {
+    ".": "./src/index.ts",
+    "./register": "./src/register.ts"
+  },
+  "scripts": {
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@pixuli/core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^2.1.8"
+  }
+}
+```
+
+将包加入根目录 `pnpm-workspace.yaml`（若尚未包含 `packages/*` 通配则显式添加）。
+
+### 步骤 3：实现 Manifest 与 Register
+
+见 [§五](#五实现清单manifest--register--provider) 与
+[§十一](#十一最小示例骨架)。
+
+### 步骤 4：在应用中 Bootstrap
+
+**Web / Desktop**（`apps/pixuli/src/storage/registry.ts`）：
+
+```typescript
+import { registerExampleProvider } from '@pixuli/provider-example/register';
+
+export function bootstrapStorageProviders(): void {
+  if (bootstrapped) return;
+  registerGitHubProvider(storageRegistry);
+  registerGiteeProvider(storageRegistry);
+  registerExampleProvider(storageRegistry); // 新增
+  bootstrapped = true;
+}
+```
+
+**Mobile**（`apps/mobile/storage/registry.ts`）：同样增加 `register` 调用，并在
+`apps/mobile/package.json` 增加 workspace 依赖。
+
+### 步骤 5：配置 UI（M3 P0 过渡）
+
+REF-307 之后，「添加源」列表来自 `storageRegistry.listManifests()`。若新插件
+**无** 专用配置 Modal，需满足其一：
+
+- `pluginId` 为 `github` / `gitee` 之一且复用现有 Modal（不推荐冒用）。
+- 在 `@pixuli/ui` 或应用层增加该 `pluginId` 的配置表单（当前 P0 做法）。
+- 提供 `configSchema`，待动态表单落地后自动渲染（REF-307 已预留字段）。
+
+### 步骤 6：验证
+
+```bash
+pnpm --filter @pixuli/provider-example test
+cd apps/pixuli && pnpm exec tsc --noEmit
+```
+
+手工：添加源 → 保存 `StoredSourceEntry`（含 `pluginId`）→ 列表 / 上传 / 删除。
+
+---
+
+## 四、包结构与命名约定
+
+### 4.1 npm 包名
+
+| 类型   | 约定                                               | 示例                      |
+| ------ | -------------------------------------------------- | ------------------------- |
+| 官方   | `@pixuli/provider-{pluginId}`                      | `@pixuli/provider-github` |
+| 第三方 | `@your-scope/provider-{pluginId}` 或 scoped 私有包 | `@acme/provider-minio`    |
+
+Monorepo **物理目录**可与 npm 名不同：`packages/plugin-provider-github` →
+`@pixuli/provider-github`。
+
+### 4.2 pluginId（全局唯一）
+
+- 仅使用 **小写 ASCII**、`[a-z0-9-]`，建议 2～32 字符。
+- **禁止**与已占用官方 ID 冲突：`github`、`gitee`（及未来官方预留表）。
+- 第三方建议带前缀，如 `acme-minio`、`community-xxx`，降低冲突与钓鱼风险。
+- `pluginId` 同时用于：`registry.create(pluginId)`、持久化
+  `StoredSourceEntry.pluginId`、导入导出 JSON。
+
+### 4.3 导出约定
+
+每个 Provider 包 **必须** 提供：
+
+| 子路径       | 内容                                                         |
+| ------------ | ------------------------------------------------------------ |
+| `.`          | `XxxStorageProvider`、`xxxManifest`（可选兼容 Service）      |
+| `./register` | `registerXxxProvider(registry: StoragePluginRegistry): void` |
+
+`register.ts` **仅** 依赖 `@pixuli/core/plugins`，不得 import `apps/*` 或
+`@pixuli/ui`。
+
+### 4.4 依赖边界
+
+| 允许                                             | 禁止                               |
+| ------------------------------------------------ | ---------------------------------- |
+| `@pixuli/core`（`types`、`plugins`、`platform`） | `@pixuli/ui`、`react`、`react-dom` |
+| `fetch`、`octokit` 等实现所需库                  | `pixuli-common`（REF-311 后删除）  |
+| 经 `ProviderContext.platformAdapter` 读文件      | 直接 `import` 应用 store           |
+
+CI 通过 `pnpm lint:boundaries` 强制执行（REF-209）。
+
+---
+
+## 五、实现清单（Manifest / Register / Provider）
+
+### 5.1 Manifest
+
+```typescript
+// src/manifest.ts
+import type { StoragePluginManifest } from '@pixuli/core/plugins';
+
+export const exampleManifest: StoragePluginManifest = {
+  id: 'example', // 全局唯一 pluginId
+  name: 'Example Host',
+  version: '0.1.0',
+  icon: 'example', // 可选，供 UI 图标映射
+  capabilities: {
+    list: true,
+    upload: true,
+    delete: true,
+    updateMetadata: false, // 不支持则 UI 应隐藏编辑元数据
+    needsProxy: false, // Web 调 Gitee 等需代理时为 true
+    maxUploadBytes: 5 * 1024 * 1024, // 可选
+  },
+  // 可选：供未来动态表单；不得含 token 等 secret
+  configSchema: {
+    type: 'object',
+    required: ['endpoint', 'token'],
+    properties: {
+      endpoint: { type: 'string', title: 'API 地址' },
+      token: { type: 'string', format: 'password', title: '访问令牌' },
+      path: { type: 'string', default: 'images' },
+    },
+  },
+};
+```
+
+**禁止**在 Manifest 中放置 `token`、`secret`、`apiKey` 默认值或示例真值。
+
+### 5.2 Register
+
+```typescript
+// src/register.ts
+import type { StoragePluginRegistry } from '@pixuli/core/plugins';
+import { ExampleStorageProvider } from './exampleStorageProvider';
+import { exampleManifest } from './manifest';
+
+export function registerExampleProvider(registry: StoragePluginRegistry): void {
+  registry.register(exampleManifest, ctx => new ExampleStorageProvider(ctx));
+}
+
+export { exampleManifest };
+```
+
+### 5.3 Provider 类
+
+必须实现 `@pixuli/core/plugins` 中的 `StorageProvider`：
+
+| 方法                   | 说明                                                            |
+| ---------------------- | --------------------------------------------------------------- |
+| `readonly manifest`    | 通常 `= exampleManifest`                                        |
+| `configure(config)`    | 保存并 narrow `StorageProviderConfig`；**之后**才可调用业务方法 |
+| `validateConfig?`      | 保存前校验，返回 `{ ok, message? }`                             |
+| `listImages`           | 返回 `ImageItem[]`                                              |
+| `uploadImage`          | 入参 `ImageUploadData`（`file` 可为 `File \| string` URI）      |
+| `deleteImage(path)`    | 仓库内路径 / 文件名，**不是** imageId                           |
+| `updateImageMetadata?` | 与 capabilities.updateMetadata 一致                             |
+| `getRawUrl(path)`      | CDN / raw 直链                                                  |
+
+**Mobile 懒加载元数据**：可实现
+`StorageProviderWithMetadata.loadImageMetadata`，见 `@pixuli/provider-github` 的
+`GitHubStorageProvider`。
+
+**平台差异**：文件读、Base64、MIME 通过 `ctx.platformAdapter`
+完成，勿在 Provider 内写死 `document` / `FileReader`。
+
+```typescript
+// 构造时注入
+constructor(ctx: ProviderContext) {
+  this.platformAdapter = ctx.platformAdapter;
+  this.fetchFn = ctx.fetch ?? globalThis.fetch.bind(globalThis);
+}
+```
+
+### 5.4 配置形状（config）
+
+- 契约层类型为 `StorageProviderConfig`（`Record<string, unknown>`）。
+- 建议在包内定义 `ExampleConfig` 接口，并在 `configure` 内做 narrow（参考
+  `narrowGitHubConfig`）。
+- 若与官方字段一致（owner/repo/branch/token/path），可复用 `@pixuli/core/types`
+  的 `GitHubConfig` / `GiteeConfig` 类型，但 **pluginId 仍应独立**。
+
+持久化由应用写入 `StoredSourceEntry`（REF-306）：
+
+```json
+{
+  "id": "abc",
+  "label": "my/repo",
+  "pluginId": "example",
+  "config": { "endpoint": "https://...", "token": "...", "path": "images" },
+  "createdAt": 0,
+  "updatedAt": 0
+}
+```
+
+---
+
+## 六、配置与 configSchema
+
+### 6.1 与 UI 的关系
+
+| 阶段       | 行为                                                                                    |
+| ---------- | --------------------------------------------------------------------------------------- |
+| M3 P0      | GitHub/Gitee 使用 `@pixuli/ui` 专用 Modal；其它 pluginId 需应用侧单独表单或暂不支持添加 |
+| REF-307 后 | 「添加源」列表来自 `listManifests()`；有 `configSchema` 时可逐步改为动态表单            |
+
+### 6.2 configSchema 建议
+
+- 使用 JSON Schema 子集或项目约定的简化对象（见官方 manifest 演进）。
+- 敏感字段标记 `format: "password"`，UI 掩码显示、日志脱敏。
+- **不要**在 schema 的 `default` 中写真实 Token。
+
+### 6.3 导入 / 导出单条配置
+
+应用导出格式（REF-306）：
+
+```json
+{
+  "version": "2.0",
+  "pluginId": "github",
+  "timestamp": "2026-01-01T00:00:00.000Z",
+  "config": {
+    "owner": "...",
+    "repo": "...",
+    "token": "...",
+    "branch": "main",
+    "path": "images"
+  }
+}
+```
+
+Provider 文档应说明本插件 `config` 字段含义；工具函数见 `@pixuli/core/sources`
+的 `buildPluginConfigExport` / `parsePluginConfigImport`。
+
+---
+
+## 七、安全：Token 与敏感数据
+
+### 7.1 存储位置
+
+| 数据                           | 存储位置                                                             | 禁止                                                |
+| ------------------------------ | -------------------------------------------------------------------- | --------------------------------------------------- |
+| Personal Access Token、API Key | 客户端 `localStorage` / `AsyncStorage`（`StoredSourceEntry.config`） | 上传 Pixuli 官方服务器、写入 Manifest、明文写入仓库 |
+| 插件代码                       | npm 包或（未来）签名的热加载 bundle                                  | 在代码中硬编码用户 Token                            |
+
+### 7.2 Provider 实现要求
+
+1. **仅通过 HTTPS** 调用远端 API；Mobile 代理需求通过应用层配置（如 Gitee
+   `needsProxy`）。
+2. **日志**：禁止 `console.log` 完整 `Authorization`
+   头或 token 字段；错误信息勿回显 token。
+3. **Manifest**：仅描述能力与表单结构，**零 secret**。
+4. **热加载插件**（未来）：不得将用户 config 回传至插件作者服务器，除非用户明确知情同意（产品层策略，非 M3 范围）。
+
+### 7.3 用户导出备份
+
+导出 JSON 含 token 时，UI 应提示用户妥善保管；导入仅在本地解析，不经服务端。
+
+### 7.4 依赖供应链
+
+第三方包应锁定依赖版本、避免 postinstall 脚本读取环境变量中的用户配置。Monorepo 内置包接受
+`pnpm lint:boundaries` 与 CI 审查。
+
+---
+
+## 八、注册到应用与 UI 消费
+
+### 8.1 Registry 单例
+
+各应用维护模块级单例（已存在）：
+
+- `apps/pixuli/src/storage/registry.ts`
+- `apps/mobile/storage/registry.ts`
+
+对外辅助：
+
+```typescript
+listStoragePluginManifests(): StoragePluginManifest[];
+isStoragePluginRegistered(pluginId: string): boolean;
+```
+
+### 8.2 imageStore 流程
+
+```text
+用户选择源 (StoredSourceEntry)
+    → getRepoConfigFromSource(entry)
+    → createConfiguredStorageProvider(entry.pluginId, config)
+    → storageRegistry.create(pluginId, { platform, platformAdapter })
+    → provider.configure(config)
+    → listImages / uploadImage / ...
+```
+
+若 `!isStoragePluginRegistered(entry.pluginId)`：**不得**
+`create`；侧栏显示不可用（REF-307）。
+
+### 8.3 添加源 UI
+
+```typescript
+import { listStoragePluginManifests } from '../storage/registry';
+
+const manifests = listStoragePluginManifests();
+// 渲染 manifest.name、getManifestDescription(manifest, t)
+// onSelect(manifest.id) → 打开配置 Modal → addSource({ pluginId, label, config })
+```
+
+---
+
+## 九、测试与调试
+
+### 9.1 Provider 包单测
+
+| 用例               | 说明                                                                  |
+| ------------------ | --------------------------------------------------------------------- |
+| `register.test.ts` | `register` 后 `listManifests()` 含本 manifest；`create` 返回实例      |
+| Provider 方法      | mock `fetch` 经 `ProviderContext.fetch` 注入；覆盖 list/upload/delete |
+| `validateConfig`   | 缺字段时 `ok: false`                                                  |
+
+```bash
+pnpm --filter @pixuli/provider-{id} test
+```
+
+### 9.2 与 Registry 集成
+
+```typescript
+import { createStoragePluginRegistry } from '@pixuli/core/plugins';
+import { registerExampleProvider } from '@pixuli/provider-example/register';
+
+const registry = createStoragePluginRegistry();
+registerExampleProvider(registry);
+const provider = registry.create('example', {
+  platform: 'web',
+  platformAdapter: new DefaultPlatformAdapter(),
+});
+provider.configure({
+  /* ... */
+});
+```
+
+### 9.3 手工回归
+
+纳入 REF-310 清单：配置源、列表、上传、删除、切换源、导入导出含 `pluginId`。
+
+---
+
+## 十、热加载（Backlog）
+
+关联 [#102](https://github.com/trueLoving/Pixuli/issues/102)。设计预期：
+
+| 场景                 | 期望行为                                            |
+| -------------------- | --------------------------------------------------- |
+| Bootstrap 已注册     | 出现在「添加源」列表（M3 已实现）                   |
+| 配置存在但插件未注册 | 源列表「插件不可用」，禁止 `create`（M3 已实现）    |
+| 热加载安装新插件后   | 再次 `listManifests()`，新类型出现在添加列表        |
+| `configSchema` 变更  | 编辑已有源时提示重新校验（与 REF-306 导入导出联动） |
+
+Loader 实现前，第三方可将包发布为 npm，由用户自行 fork Pixuli 走 **内置模式**
+集成。
+
+---
+
+## 十一、最小示例骨架
+
+以下为可运行的**最小** Provider（`listImages`
+返回空数组），用于验证注册链路与类型检查。完整 GitHub 实现见
+`packages/plugin-provider-github`。
+
+### `src/manifest.ts`
+
+```typescript
+import type { StoragePluginManifest } from '@pixuli/core/plugins';
+
+export const exampleManifest: StoragePluginManifest = {
+  id: 'example',
+  name: 'Example',
+  version: '0.0.1',
+  icon: 'example',
+  capabilities: {
+    list: true,
+    upload: false,
+    delete: false,
+    updateMetadata: false,
+  },
+};
+```
+
+### `src/exampleStorageProvider.ts`
+
+```typescript
+import type { ImageItem, ImageUploadData } from '@pixuli/core/types';
+import type {
+  ProviderContext,
+  StorageProvider,
+  StorageProviderConfig,
+} from '@pixuli/core/plugins';
+import { exampleManifest } from './manifest';
+
+export class ExampleStorageProvider implements StorageProvider {
+  readonly manifest = exampleManifest;
+  private configured = false;
+
+  constructor(_ctx: ProviderContext) {}
+
+  configure(_config: StorageProviderConfig): void {
+    this.configured = true;
+  }
+
+  async listImages(): Promise<ImageItem[]> {
+    if (!this.configured) throw new Error('Example provider is not configured');
+    return [];
+  }
+
+  async uploadImage(_data: ImageUploadData): Promise<ImageItem> {
+    throw new Error('Example provider does not support upload');
+  }
+
+  async deleteImage(_path: string): Promise<void> {
+    throw new Error('Example provider does not support delete');
+  }
+
+  getRawUrl(path: string): string {
+    return `https://example.invalid/${path}`;
+  }
+}
+```
+
+### `src/register.ts`
+
+```typescript
+import type { StoragePluginRegistry } from '@pixuli/core/plugins';
+import { ExampleStorageProvider } from './exampleStorageProvider';
+import { exampleManifest } from './manifest';
+
+export function registerExampleProvider(registry: StoragePluginRegistry): void {
+  registry.register(exampleManifest, ctx => new ExampleStorageProvider(ctx));
+}
+
+export { exampleManifest };
+```
+
+### `src/index.ts`
+
+```typescript
+export { ExampleStorageProvider } from './exampleStorageProvider';
+export { exampleManifest } from './manifest';
+```
+
+### `src/__tests__/register.test.ts`
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { createStoragePluginRegistry } from '@pixuli/core/plugins';
+import { exampleManifest, registerExampleProvider } from '../register';
+
+describe('registerExampleProvider', () => {
+  it('registers manifest and creates provider', () => {
+    const registry = createStoragePluginRegistry();
+    registerExampleProvider(registry);
+    expect(registry.listManifests()).toEqual([exampleManifest]);
+    const provider = registry.create('example', {
+      platform: 'web',
+      platformAdapter: {
+        /* mock */
+      } as never,
+    });
+    provider.configure({});
+    expect(provider.manifest.id).toBe('example');
+  });
+});
+```
+
+> **注意**：`pluginId: example` 仅用于文档与本地试验；合并到主分支前请勿与官方
+> `github`/`gitee` 同时注册到生产 bootstrap，除非产品确认需要该后端。
+
+---
+
+## 十二、检查清单
+
+发布或提交 Provider 前请确认：
+
+- [ ] `pluginId` 全局唯一，未与 `github` / `gitee` 冲突
+- [ ] 包名、目录、`register` 导出符合 §4
+- [ ] 仅依赖 `@pixuli/core`（及实现必需的 HTTP 库）
+- [ ] Manifest **无** secret；config 内 token 字段仅出现在用户持久化数据
+- [ ] `configure` 之后才可 list/upload/delete
+- [ ] `deleteImage` 使用路径参数，与 `imageStore` 调用方式一致
+- [ ] `capabilities` 与实现一致（不支持的方法勿标 `true`）
+- [ ] 单测通过；`tsc --noEmit` 通过
+- [ ] 已在目标应用 `bootstrapStorageProviders` 注册（内置模式）
+- [ ] README 说明 config 字段与 `pluginId`
+- [ ] 安全：HTTPS、日志不脱敏 token
+
+---
+
+## 相关源码索引
+
+| 路径                                      | 说明                            |
+| ----------------------------------------- | ------------------------------- |
+| `packages/core/src/plugins/types.ts`      | 契约定义                        |
+| `packages/core/src/plugins/registry.ts`   | DefaultStoragePluginRegistry    |
+| `packages/core/src/plugins/manifestUi.ts` | UI 辅助（描述文案、是否已注册） |
+| `packages/core/src/sources/`              | StoredSourceEntry、导入导出     |
+| `packages/plugin-provider-github/`        | 官方参考实现                    |
+| `packages/plugin-provider-gitee/`         | 官方参考实现                    |
+| `apps/pixuli/src/storage/registry.ts`     | Web/Desktop bootstrap           |
+| `apps/mobile/storage/registry.ts`         | Mobile bootstrap                |
+
+---
+
+## 文档维护
+
+- 契约变更时同步更新
+  [07-storage-plugin-system.md](./07-storage-plugin-system.md)
+  与本文 §五、§十一。
+- 热加载 (#102) 落地后增补 §10 的 Loader API 与安全模型。
+- REF-309 单测迁移完成后，在 §9 增加官方包的测试目录链接。

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@
 | [05-Dify-Integration-And-Image-Processing-Design.md](02-system-design/05-Dify-Integration-And-Image-Processing-Design.md) | Dify 集成与图片处理选型：Dify 工作流 run API 接入（图片分析 image→text、图片生成 text→image）；压缩/编辑/格式转换采用传统实现（WASM/原生/服务端）的选型依据与架构阶段。                                      |
 | [06-unified-app-mobile-integration.md](02-system-design/06-unified-app-mobile-integration.md)                             | 移动端与 apps/pixuli 统一：可行性分析（Web/Desktop 共一工程、Mobile 独立 RN）、方案 A/B/C 对比与决策；方案 A（Capacitor 套壳）落地：目标与原则、技术选型、工程结构、分阶段步骤、配置示例、风险与应对。       |
 | [07-storage-plugin-system.md](02-system-design/07-storage-plugin-system.md)                                               | **M3 存储插件体系**：`StorageProvider` / Registry 契约、`@pixuli/provider-*` 包约定、imageStore 集成、配置持久化演进、与 `pixuli-common` 迁移及 REF-301～311 路线图（REF-301 设计基线）。                    |
+| [08-storage-plugin-authoring.md](02-system-design/08-storage-plugin-authoring.md)                                         | **M3 存储插件开发指南**（REF-308）：第三方实现 Provider 的步骤、内置/热加载模式、命名与安全（Token 本地存储）、最小示例骨架与检查清单。                                                                      |
 
 ---
 

--- a/packages/plugin-provider-gitee/README.md
+++ b/packages/plugin-provider-gitee/README.md
@@ -5,7 +5,7 @@ Pixuli 官方 **Gitee 仓库图床**存储插件（M3 REF-303）。
 - **npm 包名**：`@pixuli/provider-gitee`
 - **Monorepo 目录**：`packages/plugin-provider-gitee`
 - **插件 ID**：`gitee`
-- **设计文档**：[存储插件体系设计](../../docs/02-system-design/07-storage-plugin-system.md)
+- **设计文档**：[存储插件体系设计](../../docs/02-system-design/07-storage-plugin-system.md)、[开发指南](../../docs/02-system-design/08-storage-plugin-authoring.md)
 
 实现 Gitee API v5 + sidecar 元数据，符合
 [`@pixuli/core/plugins`](../core/README.md) 中的 `StorageProvider`

--- a/packages/plugin-provider-github/README.md
+++ b/packages/plugin-provider-github/README.md
@@ -5,7 +5,7 @@ Pixuli 官方 **GitHub 仓库图床**存储插件（M3 REF-302）。
 - **npm 包名**：`@pixuli/provider-github`
 - **Monorepo 目录**：`packages/plugin-provider-github`
 - **插件 ID**：`github`
-- **设计文档**：[存储插件体系设计](../../docs/02-system-design/07-storage-plugin-system.md)
+- **设计文档**：[存储插件体系设计](../../docs/02-system-design/07-storage-plugin-system.md)、[开发指南](../../docs/02-system-design/08-storage-plugin-authoring.md)
 
 实现 GitHub Contents API + sidecar 元数据（`.metadata/`），符合
 [`@pixuli/core/plugins`](../core/README.md) 中的 `StorageProvider` 契约。


### PR DESCRIPTION
## Summary

- 新增 `docs/02-system-design/08-storage-plugin-authoring.md`：内置 vs 热加载、包结构、`manifest`/`register`/`Provider`、Token 安全、最小 example 骨架与检查清单
- 更新 `07-storage-plugin-system.md`、`docs/README.md` 及 GitHub/Gitee provider README 交叉链接
- `REFACTOR_PLAN.md`：REF-308 标记完成；顺带登记 M4 REF-407/408/409 与 Issue #111/#112/#113 映射

Closes #77

## Test plan

- [x] 通读 08 文档链接与代码路径是否一致
- [x] 确认 `docs/README.md` 索引可导航到 08


Made with [Cursor](https://cursor.com)