### PR TITLE
[M4] REF-414 AI 编程辅助：Agent 规则与 Skill 体系

### DIFF
--- a/.cursor/rules/electron-desktop.mdc
+++ b/.cursor/rules/electron-desktop.mdc
@@ -1,0 +1,32 @@
+---
+description: Electron 桌面与 Vite Host 集成：main/preload、Gitee 代理、禁止 Renderer 打包 Node
+globs: apps/pixuli/electron/**,apps/pixuli/plugins/**,apps/pixuli/api/**,apps/pixuli/vite.config.ts
+alwaysApply: false
+---
+
+# Electron & Desktop Host
+
+## 进程边界
+
+- **Main**：`apps/pixuli/electron/main/` — Node API、`startGiteeProxyServer`（`/proxy/node`）
+- **Preload**：`electron/preload/` — `contextBridge` 暴露 `giteeProxyBase`（`ipc sendSync('gitee:proxy-base')`）
+- **Renderer**：普通 React；**禁止** `node:http`、`fs`、provider `/proxy/node|server` 静态 import
+
+## Gitee 代理（三宿主）
+
+| 环境 | 集成点 |
+| --- | --- |
+| Web dev | `apps/pixuli/plugins/viteGiteeProxyPlugin.ts` — `configureServer` 内 `ssrLoadModule('@pixuli/provider-gitee/proxy/server')` |
+| Web 生产 | `api/gitee-proxy.entry.ts` → `pnpm build:vercel-api` → `api/gitee-proxy.js` |
+| Desktop 打包 | main 启动 `startGiteeProxyServer`；preload 注入 base URL |
+
+`vite.config.ts`：`ssr.noExternal` 含 `@pixuli/provider-gitee`；dev 插件用**动态 import**，避免 build 时解析 workspace TS。
+
+## 常量
+
+- 代理路径：`@pixuli/provider-gitee/proxy/constants`（登记 `.js`）；勿 `./constants.ts` 相对导入
+
+## 桌面开发
+
+- `pnpm dev:desktop` — 改 main/preload 后需重启
+- 与 Web 共用 `apps/pixuli/src`；平台分支用 `__IS_WEB__` 或 `getAppPlatform()`

--- a/.cursor/rules/pixuli-monorepo.mdc
+++ b/.cursor/rules/pixuli-monorepo.mdc
@@ -1,0 +1,30 @@
+---
+description: Pixuli monorepo 全局约束：三端底线、包边界、TS 策略与测试
+alwaysApply: true
+---
+
+# Pixuli Monorepo
+
+## 底线
+
+- 维护 Web + Desktop（`apps/pixuli`）+ Mobile（`apps/mobile`）；无官方 Server
+- 存储仅经 `@pixuli/core/plugins` 契约 + `@pixuli/provider-*`；应用不直接调 Git API 细节
+- `@pixuli/core` 与 `provider-*` **禁止**依赖 `@pixuli/ui`
+
+## 包与导入
+
+- Workspace 包名：`@pixuli/core`、`@pixuli/ui`、`@pixuli/provider-github`、`@pixuli/provider-gitee`
+- Provider 注册：`registerGitHubProvider` / `registerGiteeProvider` 从各包 `/register` 导入
+- 应用创建实例：`storageRegistry.create(pluginId, ctx)`（见 `apps/*/storage/createProvider.ts`）
+- 已删除 `packages/common`；勿引用 `pixuli-common`
+
+## TypeScript
+
+- 业务代码一律 `.ts`/`.tsx`；例外见 `docs/02-system-design/05-TypeScript-JavaScript-Policy.md`
+- 勿在 `api/gitee-proxy.js` 手改逻辑（esbuild 产物）；改 `gitee-proxy.entry.ts` 后 `pnpm build:vercel-api`
+
+## 改动原则
+
+- 最小 diff；匹配现有命名与目录约定
+- 完成功能后：`pnpm test`；涉及 Web 构建时考虑 `pnpm build:web`
+- REF Issue PR：标题含 `REF-xxx`；关闭 Issue 用 `Fixes #n`；同步 `REFACTOR_PLAN.md`

--- a/.cursor/rules/storage-plugin.mdc
+++ b/.cursor/rules/storage-plugin.mdc
@@ -1,0 +1,39 @@
+---
+description: StorageProvider 插件开发：Registry、register、manifest、createProvider
+globs: packages/plugin-provider-*/**,packages/core/src/plugins/**,apps/**/storage/**
+alwaysApply: false
+---
+
+# Storage Plugin
+
+## 契约（@pixuli/core/plugins）
+
+- `StoragePluginManifest` + `StorageProviderFactory` → `registry.register(manifest, factory)`
+- `registry.create(pluginId, ProviderContext)` 返回 `StorageProvider`
+- `ProviderContext`：`platform`、`platformAdapter`、可选 `giteeProxyBase`（Gitee）
+
+## 官方插件结构
+
+```text
+packages/plugin-provider-{id}/src/
+  manifest.ts          # id、capabilities、configSchema
+  register.ts          # registerXxxProvider(registry)
+  *StorageProvider.ts  # 实现 list/upload/delete/buildImageUrl
+  index.ts             # 公开 API
+```
+
+## 应用侧
+
+- Bootstrap：`apps/pixuli/src/storage/registry.ts` · `apps/mobile/storage/registry.ts`
+- 配置后创建：`createConfiguredStorageProvider(pluginId, config)` → `provider.configure(config)`
+
+## 禁止
+
+- Provider 包内引入 React / `@pixuli/ui`
+- core 内写 GitHub/Gitee API 具体实现（应在 provider 包）
+- Renderer import `@pixuli/provider-gitee/proxy` 聚合入口或 `/proxy/node`
+
+## 参考
+
+- `docs/02-system-design/04-Plugin-System.md` §第二部分
+- 单测：`packages/*/src/__tests__/register.test.ts`、`packages/core/src/plugins/__tests__/`

--- a/.cursor/skills/gitee-host-integration/SKILL.md
+++ b/.cursor/skills/gitee-host-integration/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: gitee-host-integration
+description: >-
+  Integrates Gitee image proxy across Vite dev, Vercel serverless, and Electron
+  main/preload. Use when fixing Gitee CORS, gitee-proxy, viteGiteeProxyPlugin,
+  startGiteeProxyServer, giteeProxyBase, or @pixuli/provider-gitee/proxy paths.
+---
+
+# Gitee Host Integration
+
+## Subpath rules (critical)
+
+| Import                                  | Allowed in                                     |
+| --------------------------------------- | ---------------------------------------------- |
+| `@pixuli/provider-gitee/proxy/client`   | Renderer                                       |
+| `@pixuli/provider-gitee/proxy/url`      | Renderer, provider                             |
+| `@pixuli/provider-gitee/proxy/server`   | Vite dev middleware, Vercel entry (via bundle) |
+| `@pixuli/provider-gitee/proxy/node`     | Electron main only                             |
+| `@pixuli/provider-gitee/proxy` (barrel) | **Avoid** in app — pulls node modules          |
+
+## Three hosts
+
+### 1. Web dev
+
+- `apps/pixuli/plugins/viteGiteeProxyPlugin.ts` wraps provider plugin
+- Uses `server.ssrLoadModule('@pixuli/provider-gitee/proxy/server')` — no static
+  provider import in plugin file
+- `vite.config.ts`: `ssr.noExternal: ['@pixuli/provider-gitee']`,
+  `server.fs.allow` for monorepo root
+
+### 2. Web production (Vercel)
+
+- SSOT logic: `@pixuli/provider-gitee/proxy/server`
+- Entry: `apps/pixuli/api/gitee-proxy.entry.ts`
+- Build: `pnpm build:vercel-api` → `api/gitee-proxy.js` (committed artifact)
+- **Never** hand-edit `gitee-proxy.js`; Node cannot import workspace `.ts` at
+  runtime
+
+### 3. Desktop
+
+- Main:
+  `import { startGiteeProxyServer } from '@pixuli/provider-gitee/proxy/node'`
+- Preload: expose `window.giteeProxyBase` from
+  `ipcRenderer.sendSync('gitee:proxy-base')`
+- Renderer: `getGiteeProviderContextFields()` from `/proxy/client`
+
+## Constants
+
+- Use `@pixuli/provider-gitee/proxy/constants` (`.js` registered exception)
+- Do not add `./constants.ts` relative imports in paths loaded by Node/Vite SSR
+  outside package exports
+
+## After changes
+
+```bash
+pnpm build:vercel-api   # if server proxy logic changed
+pnpm dev:web            # smoke Gitee image load
+pnpm dev:desktop        # smoke packaged proxy + preload
+```
+
+## Docs
+
+- `docs/02-system-design/05-TypeScript-JavaScript-Policy.md` §三、§四
+- `docs/02-system-design/04-Plugin-System.md` (REF-313)
+- Future: REF-411 Host Bootstrap — keep glue thin until Registry declares
+  `hostIntegrations`

--- a/.cursor/skills/ref-issue-pr/SKILL.md
+++ b/.cursor/skills/ref-issue-pr/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: ref-issue-pr
+description: >-
+  Works REF-* refactor issues into PRs and keeps REFACTOR_PLAN.md in sync. Use
+  when implementing GitHub Issues with REF- prefix, milestone M1–M6, or updating
+  refactor tracking tables.
+---
+
+# REF Issue → PR
+
+## Before coding
+
+1. Read issue body on GitHub (`gh issue view <n>`) for **计划编号** (REF-xxx)
+2. Open matching row in [REFACTOR_PLAN.md](../../REFACTOR_PLAN.md) — check
+   **Depends on**, **Labels**, **建议顺序**
+3. Read linked docs under `docs/` (not `.local/` unless available)
+
+## Implementation
+
+- Smallest correct diff; match monorepo conventions
+  ([AGENTS.md](../../AGENTS.md))
+- Run `pnpm test`; add tests for provider/core changes
+- Do not commit unless user asks
+
+## PR
+
+```markdown
+## Summary
+
+- …
+
+## Test plan
+
+- [ ] pnpm test
+- [ ] …
+
+Fixes #<issue> # only if PR fully closes the issue Related: REF-<id>
+```
+
+- Title: `[M4] REF-414 …` or `fix(m3): … (REF-313)`
+- Link milestone label if applicable (`m4`, `refactor`, etc.)
+
+## After merge
+
+1. Set REFACTOR_PLAN table **状态** to ✅ for completed REF-xxx
+2. Ensure **GitHub #** column has issue link (create issue first if 「待建」)
+3. Update §六进度表 counts if closing milestone items
+4. User-facing docs → `docs/01-product` / Wiki source; **Agent/Skill** →
+   `AGENTS.md` / `.cursor/` when architecture boundaries change
+
+## Issue creation (batch)
+
+```bash
+gh issue create \
+  --title "[M6] …" \
+  --label "refactor,m6,area:product,priority:P1" \
+  --milestone "M6-产品体验与能力边界" \
+  --body "$(cat <<'EOF'
+## 计划编号
+REF-xxx
+…
+EOF
+)"
+```
+
+Then paste `#number` into REFACTOR_PLAN mapping tables.

--- a/.cursor/skills/storage-provider/SKILL.md
+++ b/.cursor/skills/storage-provider/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: storage-provider
+description: >-
+  Implements or modifies Pixuli StorageProvider plugins (register, manifest,
+  registry.create). Use when adding providers, editing @pixuli/provider-*,
+  storageRegistry, createConfiguredStorageProvider, or StoragePluginRegistry.
+---
+
+# Storage Provider
+
+## Quick map
+
+| What               | Where                                                                    |
+| ------------------ | ------------------------------------------------------------------------ |
+| Registry factory   | `createStoragePluginRegistry()` — `@pixuli/core/plugins`                 |
+| App registry       | `apps/pixuli/src/storage/registry.ts`, `apps/mobile/storage/registry.ts` |
+| Create + configure | `createConfiguredStorageProvider()` — `apps/*/storage/createProvider.ts` |
+| GitHub register    | `registerGitHubProvider` — `@pixuli/provider-github/register`            |
+| Gitee register     | `registerGiteeProvider` — `@pixuli/provider-gitee/register`              |
+
+## Add or change a provider
+
+1. Read `docs/02-system-design/04-Plugin-System.md` §第二部分
+2. In provider package: `manifest.ts` → `*StorageProvider.ts` → `register.ts` →
+   export in `package.json` `exports`
+3. Register in both app `registry.ts` bootstrap functions
+4. Extend `createConfiguredStorageProvider` if new `pluginId` / config type
+5. Add Vitest: `register.test.ts` + provider behavior tests
+6. **Do not** add UI or depend on `@pixuli/ui` from provider or core
+
+## ProviderContext
+
+```typescript
+storageRegistry.create(pluginId, {
+  platform: 'web' | 'desktop' | 'mobile',
+  platformAdapter: new DefaultPlatformAdapter(),
+  // Gitee Web/Desktop only:
+  ...getGiteeProviderContextFields(__IS_WEB__),
+});
+```
+
+## Gitee-specific
+
+- `registerGiteeProvider` passes `proxyBaseUrl: ctx.giteeProxyBase` into
+  provider
+- Proxy URL building: `@pixuli/provider-gitee/proxy/url` in provider
+  implementation
+- Host integration is **not** in provider register — see skill
+  `gitee-host-integration`
+
+## Verify
+
+```bash
+pnpm test --filter @pixuli/provider-github
+pnpm test --filter @pixuli/provider-gitee
+pnpm test --filter @pixuli/core
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,114 @@
+# Pixuli — AI Agent Guide
+
+> **REF-414** · 协作者与 Cursor/Copilot 等 AI 助手的仓库级上下文。用户向文档见
+> [docs/](docs/README.md) 与
+> [GitHub Wiki](https://github.com/trueLoving/Pixuli/wiki)。
+
+## 产品底线（不可破坏）
+
+| 项          | 约定                                                                                 |
+| ----------- | ------------------------------------------------------------------------------------ |
+| **三端**    | Web（含 PWA）、Desktop（Electron）、Mobile（Expo）均维护                             |
+| **存储**    | GitHub / Gitee 经 `StorageProvider` 插件；**无官方 NestJS Server**                   |
+| **UI 共享** | Web + Desktop 共用 `apps/pixuli` + `@pixuli/ui`；Mobile 独立 RN（M5 目标 Capacitor） |
+| **分层**    | L1 业务 · L2 网格/列表 · L3 各端平台能力；**core/provider 禁止依赖 ui**              |
+
+重构追踪：[REFACTOR_PLAN.md](REFACTOR_PLAN.md)（Issue 映射、里程碑、§九 工程基线）。
+
+## Monorepo 结构
+
+```text
+apps/pixuli/          Web + Desktop（Vite + React + electron/）
+apps/mobile/          Expo + React Native
+packages/core/        @pixuli/core — types, StoragePluginRegistry, platform
+packages/ui/          @pixuli/ui — web 入口 + ./native 子路径
+packages/plugin-provider-github/   @pixuli/provider-github
+packages/plugin-provider-gitee/    @pixuli/provider-gitee（含 proxy 子路径）
+archive/              wasm, server, benchmark（非 workspace，勿接入主构建）
+```
+
+**常用命令**（根目录）：`pnpm test` · `pnpm dev:web` · `pnpm dev:desktop` ·
+`pnpm build:web`（含 `build:vercel-api`）· `pnpm build:desktop`
+
+## 存储插件（M3 已落地）
+
+| 步骤         | 位置                                                                          |
+| ------------ | ----------------------------------------------------------------------------- |
+| 注册表单例   | `apps/pixuli/src/storage/registry.ts` · `apps/mobile/storage/registry.ts`     |
+| 创建实例     | `createConfiguredStorageProvider()` → `storageRegistry.create(pluginId, ctx)` |
+| 注册官方插件 | `registerGitHubProvider` · `registerGiteeProvider`（各包 `/register` 子路径） |
+| 契约定义     | `@pixuli/core/plugins` — `StorageProvider`、`StoragePluginRegistry`           |
+
+详细设计：[docs/02-system-design/04-Plugin-System.md](docs/02-system-design/04-Plugin-System.md)
+
+### Gitee 代理子路径（易踩坑）
+
+Renderer **仅**使用 `@pixuli/provider-gitee/proxy/client` 与 `/proxy/url`。
+**禁止**在 Renderer 或 Vite 客户端 bundle 引入
+`/proxy`、`/proxy/node`、`/proxy/server`（会拉入 `node:http`）。
+
+| 子路径             | 用途                                                           |
+| ------------------ | -------------------------------------------------------------- |
+| `/proxy/client`    | `getGiteeProviderContextFields()` — 读 `window.giteeProxyBase` |
+| `/proxy/url`       | 构建代理图片 URL                                               |
+| `/proxy/server`    | Vite dev 中间件、`api/gitee-proxy.entry.ts` 打包源             |
+| `/proxy/node`      | Electron main：`startGiteeProxyServer`                         |
+| `/proxy/constants` | `GITEE_PROXY_PATH`（登记 `.js` 例外）                          |
+
+Host 胶水：`apps/pixuli/plugins/viteGiteeProxyPlugin.ts`（动态
+`ssrLoadModule`）· `apps/pixuli/api/gitee-proxy.entry.ts` · `electron/main` +
+preload `giteeProxyBase`。
+
+## 代码约束
+
+- **默认 TypeScript**；登记 JS 例外见
+  [05-TypeScript-JavaScript-Policy.md](docs/02-system-design/05-TypeScript-JavaScript-Policy.md)
+- **包边界**：`core` ↛ `ui`；`provider-*` ↛ `ui`（REF-209 ESLint）
+- **Vercel API**：改代理逻辑后运行 `pnpm build:vercel-api`，提交生成的
+  `api/gitee-proxy.js`
+- **范围控制**：只改 Issue/PR 相关文件；勿顺手重构无关代码
+
+## 开 PR 与 Issue 同步
+
+1. 分支名或 PR 标题含计划编号，如 `REF-414` 或 `Fixes #129`
+2. 合并意图用 `Fixes #n` / `Closes #n`（仅当本 PR 完整关闭 Issue）
+3. Issue 关闭或部分完成时，更新 [REFACTOR_PLAN.md](REFACTOR_PLAN.md) 对应行
+   **GitHub #** / **状态**
+4. 文档变更：用户向 → `docs/01-product` / Wiki 源稿；技术向 →
+   `docs/02-system-design`；Agent 向 → 本文 + `.cursor/`
+
+## Cursor 资产
+
+### Rules（`.cursor/rules/`）
+
+| 文件                   | 作用                                   |
+| ---------------------- | -------------------------------------- |
+| `pixuli-monorepo.mdc`  | 全局：三端底线、包边界、TS 策略、测试  |
+| `storage-plugin.mdc`   | 编辑 provider / registry / storage 时  |
+| `electron-desktop.mdc` | 编辑 Electron / Vite 插件 / preload 时 |
+
+### Skills（`.cursor/skills/`）
+
+| Skill                      | 触发场景                                       | 路径                                                                                             |
+| -------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| **storage-provider**       | 新增或修改 StorageProvider、register、manifest | [.cursor/skills/storage-provider/SKILL.md](.cursor/skills/storage-provider/SKILL.md)             |
+| **gitee-host-integration** | Gitee 图片代理、Vite/Electron/Vercel Host 集成 | [.cursor/skills/gitee-host-integration/SKILL.md](.cursor/skills/gitee-host-integration/SKILL.md) |
+| **ref-issue-pr**           | 处理 REF-\* Issue、开 PR、同步 REFACTOR_PLAN   | [.cursor/skills/ref-issue-pr/SKILL.md](.cursor/skills/ref-issue-pr/SKILL.md)                     |
+
+### 何时更新 Agent/Skill
+
+- 架构或包边界变更（M 里程碑合并后）
+- 新增官方 provider 或 Host 集成模式（REF-411 等）
+- 登记新的 TS/JS 例外或 ESLint 边界规则
+- **不必**随每次功能 PR 更新；与 [docs/README.md](docs/README.md)
+  用户文档职责分离
+
+## 延伸阅读
+
+| 主题       | 文档                                                                                           |
+| ---------- | ---------------------------------------------------------------------------------------------- |
+| 系统架构   | [00-System-Design.md](docs/02-system-design/00-System-Design.md)                               |
+| 三端设计   | [02-Three-Platform-Design.md](docs/02-system-design/02-Three-Platform-Design.md)               |
+| TS/JS 策略 | [05-TypeScript-JavaScript-Policy.md](docs/02-system-design/05-TypeScript-JavaScript-Policy.md) |
+| 版本发布   | [03-Release-Versioning.md](docs/01-product/03-Release-Versioning.md)                           |
+| Backlog    | [docs/backlog.md](docs/backlog.md)                                                             |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ understand how to contribute to the project development.
 - [Code Standards](#code-standards)
 - [Commit Standards](#commit-standards)
 - [Workflow](#workflow)
+- [AI-Assisted Development](#ai-assisted-development)
 - [Feedback](#feedback)
 
 ## 🔧 Requirements
@@ -265,6 +266,22 @@ Create a Pull Request on GitHub with a detailed description of your changes.
 
 Wait for maintainers to review the code and make modifications based on
 feedback.
+
+## 🤖 AI-Assisted Development
+
+When using **Cursor**, **Copilot**, or similar tools on this repo:
+
+- Read [AGENTS.md](AGENTS.md) first — monorepo layout, storage plugins, Gitee
+  proxy rules, PR conventions
+- Cursor **Rules** live in `.cursor/rules/`; **Skills** in `.cursor/skills/`
+  (see skill table in AGENTS.md)
+- Refactor issues use `REF-xxx` IDs — track them in
+  [REFACTOR_PLAN.md](REFACTOR_PLAN.md); PR titles should include the ID
+- Update Agent/Skill files when **architecture boundaries** change (new
+  provider, Host integration, TS/JS exceptions) — not on every feature PR
+- User-facing docs stay in `docs/` and
+  [Wiki](https://github.com/trueLoving/Pixuli/wiki); see
+  [docs/README.md](docs/README.md) §AI 编程辅助 (REF-414)
 
 ## 📚 Related Resources
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ commit conventions.
 | **Removed / deferred** | [docs/backlog.md](docs/backlog.md)                                                               |
 | **Developers**         | [docs/README.md](docs/README.md) — full doc index                                                |
 | **Contributing**       | [CONTRIBUTING.md](./CONTRIBUTING.md)                                                             |
+| **AI agents**          | [AGENTS.md](./AGENTS.md) — Cursor Rules/Skills, monorepo context (REF-414)                       |
 | **Refactor plan**      | [REFACTOR_PLAN.md](./REFACTOR_PLAN.md)                                                           |
 | **Changelog**          | [CHANGELOG.md](./CHANGELOG.md)                                                                   |
 | **App (Web/Desktop)**  | [apps/pixuli/README.md](./apps/pixuli/README.md)                                                 |

--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -843,7 +843,7 @@ P0，见 [#102](https://github.com/trueLoving/Pixuli/issues/102)（#70 / #76 /
 | REF-411 | [M4] 插件体系：Host 运行时集成层设计（dev / 打包 / Serverless） | refactor, m4, area:plugin, priority:P1 | P1     | #70, #123  | [#126](https://github.com/trueLoving/Pixuli/issues/126) | ⬜   |
 | REF-412 | [M4] 集成测试体系设计与落地（基线版本稳定后）                   | refactor, m4, priority:P2              | P2     | #113, #79  | [#127](https://github.com/trueLoving/Pixuli/issues/127) | ⬜   |
 | REF-413 | [M4] 冒烟测试矩阵与 CI 门禁（基线版本稳定后）                   | refactor, m4, priority:P2              | P2     | #113, #125 | [#128](https://github.com/trueLoving/Pixuli/issues/128) | ⬜   |
-| REF-414 | [M4] AI 编程辅助：Agent 规则与 Skill 文件体系                   | refactor, m4, type:docs, priority:P2   | P2     | #111       | [#129](https://github.com/trueLoving/Pixuli/issues/129) | ⬜   |
+| REF-414 | [M4] AI 编程辅助：Agent 规则与 Skill 文件体系                   | refactor, m4, type:docs, priority:P2   | P2     | #111       | [#129](https://github.com/trueLoving/Pixuli/issues/129) | ✅   |
 | REF-415 | [M4] 文档国际化（中/英）策略与目录设计                          | refactor, m4, type:docs, priority:P2   | P2     | #111, #112 | [#138](https://github.com/trueLoving/Pixuli/issues/138) | ⬜   |
 
 REF-407 / REF-408 / REF-409 / REF-415 范围说明（点击展开）
@@ -1131,13 +1131,15 @@ PoC 通过则优先 **#118/#120**，否则继续 **#117/#119**（方案 C 过渡
 `index.mjs`、Gitee `proxy/client|url|node`
 子路径、禁止 Renderer 引入 Node 模块等）。
 
-**REF-414 交付物（建议）**：
+**REF-414 交付物**（✅
+[#129](https://github.com/trueLoving/Pixuli/issues/129)）：
 
-| 资产       | 路径（建议）                       | 内容要点                                           |
-| ---------- | ---------------------------------- | -------------------------------------------------- |
-| Agent 总览 | `AGENTS.md` 或 `.cursor/AGENTS.md` | 三端底线、目录结构、开 PR 流程、REFACTOR_PLAN 同步 |
-| Rules      | `.cursor/rules/*.mdc`              | monorepo、storage-plugin、electron-desktop         |
-| Skills     | `.cursor/skills/*/SKILL.md`        | 实现 provider、Gitee Host 集成、REF Issue→PR       |
+| 资产       | 路径                                                                              | 内容要点                                     |
+| ---------- | --------------------------------------------------------------------------------- | -------------------------------------------- |
+| Agent 总览 | [AGENTS.md](AGENTS.md)                                                            | 三端底线、目录结构、Skill 清单、开 PR 流程   |
+| Rules      | `.cursor/rules/pixuli-monorepo.mdc`、`storage-plugin.mdc`、`electron-desktop.mdc` | monorepo、storage-plugin、electron-desktop   |
+| Skills     | `.cursor/skills/storage-provider/`、`gitee-host-integration/`、`ref-issue-pr/`    | 实现 provider、Gitee Host 集成、REF Issue→PR |
+| 索引       | [docs/README.md](docs/README.md) §AI 编程辅助、`CONTRIBUTING.md`                  | 何时更新 Agent/Skill；与用户向 docs 职责分离 |
 
 与 **REF-407**（`docs/` 梳理）协同：用户向文档、协作者向 Agent/Skill，职责分离。
 
@@ -1349,10 +1351,10 @@ flowchart LR
 | M1       | 12       | 7      | 58%     |
 | M2       | 10       | 0      | 0%      |
 | M3       | 12       | 9      | 75%     |
-| M4       | 15       | 10     | 67%     |
+| M4       | 15       | 11     | 73%     |
 | M5       | 11       | 0      | 0%      |
 | M6       | 7        | 0      | 0%      |
-| **合计** | **67**   | **20** | **30%** |
+| **合计** | **67**   | **21** | **31%** |
 
 ---
 
@@ -1369,7 +1371,7 @@ flowchart LR
 | TS/JS 策略                    | [05-TypeScript-JavaScript-Policy.md](docs/02-system-design/05-TypeScript-JavaScript-Policy.md)（REF-410） |
 | 插件 Host 集成（计划）        | REF-411 → 扩展 [04-Plugin-System.md](docs/02-system-design/04-Plugin-System.md) §第二部分                 |
 | M3 存储回归清单               | [04-Plugin-System.md §第三部分](docs/02-system-design/04-Plugin-System.md#第三部分-m3-存储插件回归清单)   |
-| AI Agent / Skill（计划）      | REF-414 → `AGENTS.md`、`.cursor/rules/`、`.cursor/skills/`                                                |
+| AI Agent / Skill              | [AGENTS.md](AGENTS.md)（REF-414）、`.cursor/rules/`、`.cursor/skills/`                                    |
 | 产品 Backlog（已移除/延后）   | [docs/backlog.md](docs/backlog.md)（REF-402）                                                             |
 | 文档国际化策略（计划）        | REF-415 → §1.7、`docs/en/` 镜像与 `13-documentation-i18n.md`                                              |
 | 三端交互规范（计划）          | REF-601 → `docs/01-product/`                                                                              |

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@
 | **产品 / 测试**     | [产品需求规格说明书](01-product/01-Product-Requirements-Specification.md) → [backlog](backlog.md)（已移除项）                                                                                                                                             |
 | **前端 / 多端开发** | [00-System-Design](02-system-design/00-System-Design.md) → [三端能力共享](02-system-design/01-Three-Platform-Capability-Sharing.md) → [三端设计](02-system-design/02-Three-Platform-Design.md) → [04-Plugin-System](02-system-design/04-Plugin-System.md) |
 | **插件作者**        | [04-Plugin-System](02-system-design/04-Plugin-System.md)（§第二部分 开发指南）                                                                                                                                                                            |
-| **协作者 / Issue**  | 仓库根 [REFACTOR_PLAN.md](../REFACTOR_PLAN.md)                                                                                                                                                                                                            |
+| **协作者 / Issue**  | [REFACTOR_PLAN.md](../REFACTOR_PLAN.md) · AI 辅助 [AGENTS.md](../AGENTS.md)（REF-414）                                                                                                                                                                    |
 
 ---
 
@@ -78,6 +78,22 @@
 
 ---
 
+## AI 编程辅助（REF-414）
+
+面向 **Cursor / Copilot 等 AI 助手**与协作者，与用户向 `docs/`、Wiki
+**职责分离**：
+
+| 资产          | 路径                        | 何时更新                                              |
+| ------------- | --------------------------- | ----------------------------------------------------- |
+| Agent 总览    | [AGENTS.md](../AGENTS.md)   | 三端底线、包结构、PR 流程、Skill 清单                 |
+| Cursor Rules  | `.cursor/rules/*.mdc`       | monorepo / storage-plugin / electron-desktop 边界变更 |
+| Cursor Skills | `.cursor/skills/*/SKILL.md` | 新增 provider、Host 集成模式、REF 工作流变化          |
+
+**不必**随每个功能 PR 改 Agent 文件；架构里程碑（M1～M4 合并）或插件 Host 契约变更时再同步。详见
+[AGENTS.md §何时更新](../AGENTS.md#何时更新-agentskill)。
+
+---
+
 ## 修订
 
 | 日期       | 变更                                                                                 |
@@ -87,3 +103,4 @@
 | 2026-06-06 | REF-407：角色索引、架构摘要                                                          |
 | 2026-05-27 | REF-401/402：PRD v2.0、backlog 索引                                                  |
 | 2026-05-27 | REF-409：`03-Release-Versioning.md` 版本发布策略与历史盘点                           |
+| 2026-05-27 | REF-414：`AGENTS.md`、`.cursor/rules/`、`.cursor/skills/` AI 编程辅助资产            |


### PR DESCRIPTION
## Summary

- 新增 `AGENTS.md`：三端底线、monorepo 结构、存储插件与 Gitee 代理子路径约定、Skill 清单
- 新增 Cursor Rules：`.cursor/rules/pixuli-monorepo.mdc`、`storage-plugin.mdc`、`electron-desktop.mdc`
- 新增 Cursor Skills：`storage-provider`、`gitee-host-integration`、`ref-issue-pr`
- 更新 `docs/README.md`、`CONTRIBUTING.md`、`README.md` 索引；`REFACTOR_PLAN.md` 标记 REF-414 ✅

## Test plan

- [x] 文档与规则文件已提交，无代码逻辑变更
- [x] 在 Cursor 中确认 Rules 可被加载
- [x] 新协作者/AI 读 `AGENTS.md` 可定位 `registerGiteeProvider` 与 `proxy/*` 子路径

Fixes #129

Made with [Cursor](https://cursor.com)