### PR TITLE
feat(core): REF-607-P1 本地工作区 vault 契约 (#156)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,11 @@
       "development": "./src/sources/index.ts",
       "types": "./dist/sources/index.d.ts",
       "import": "./dist/sources/index.js"
+    },
+    "./vault": {
+      "development": "./src/vault/index.ts",
+      "types": "./dist/vault/index.d.ts",
+      "import": "./dist/vault/index.js"
     }
   },
   "scripts": {

--- a/packages/core/src/plugins/__tests__/syncTypes.test.ts
+++ b/packages/core/src/plugins/__tests__/syncTypes.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import type { StorageProvider } from '../types';
+import { hasStorageProviderPublicUrl, hasStorageProviderSync } from '../types';
+
+describe('StorageProvider sync type guards', () => {
+  const baseProvider = {
+    manifest: {
+      id: 'test',
+      name: 'Test',
+      version: '1',
+      capabilities: {
+        list: true,
+        upload: true,
+        delete: true,
+        updateMetadata: true,
+      },
+    },
+    configure: () => {},
+    listImages: async () => [],
+    uploadImage: async () => {
+      throw new Error('not implemented');
+    },
+    deleteImage: async () => {},
+    getRawUrl: () => '',
+  } satisfies StorageProvider;
+
+  it('hasStorageProviderSync is false for base provider', () => {
+    expect(hasStorageProviderSync(baseProvider)).toBe(false);
+  });
+
+  it('hasStorageProviderSync is true when sync methods exist', () => {
+    const withSync = {
+      ...baseProvider,
+      syncPull: async () => ({ items: [] }),
+      syncPush: async () => {},
+      getSyncCursor: async () => null,
+    };
+    expect(hasStorageProviderSync(withSync)).toBe(true);
+  });
+
+  it('hasStorageProviderPublicUrl detects buildPublicUrl', () => {
+    expect(hasStorageProviderPublicUrl(baseProvider)).toBe(false);
+    const withUrl = {
+      ...baseProvider,
+      buildPublicUrl: (path: string) => `https://example.com/${path}`,
+      resolveLinkKind: () => 'remote-raw' as const,
+    };
+    expect(hasStorageProviderPublicUrl(withUrl)).toBe(true);
+  });
+});

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -1,4 +1,4 @@
-import type { ImageItem, ImageUploadData } from '../types/image';
+import type { ImageItem, ImageUploadData, LinkKind } from '../types/image';
 import type { PlatformAdapter } from '../platform/platformAdapter';
 
 export interface StorageCapabilities {
@@ -8,6 +8,10 @@ export interface StorageCapabilities {
   updateMetadata: boolean;
   needsProxy?: boolean;
   maxUploadBytes?: number;
+  /** REF-607：支持 syncPull / syncPush */
+  sync?: boolean;
+  /** REF-607：支持 buildPublicUrl / resolveLinkKind */
+  publicUrl?: boolean;
 }
 
 /** 插件需在宿主环境挂载的集成点（REF-411） */
@@ -84,6 +88,69 @@ export interface StorageProviderWithMetadata extends StorageProvider {
     images: ImageItem[],
     options?: ImageMetadataLoadOptions,
   ): Promise<ImageItem[]>;
+}
+
+/** REF-607：远端同步拉取 */
+export interface SyncPullOptions {
+  since?: string;
+  pathPrefix?: string;
+}
+
+export interface SyncPullResult {
+  items: Array<{
+    remotePath: string;
+    action: 'add' | 'update' | 'delete';
+    contentHash?: string;
+    metadata?: Partial<ImageItem>;
+  }>;
+  nextCursor?: string;
+}
+
+export interface SyncPushItem {
+  localRelativePath: string;
+  remotePath: string;
+  action: 'upload' | 'delete' | 'metadata';
+  file?: Uint8Array;
+  metadata?: Partial<ImageItem>;
+}
+
+export interface StorageProviderSync {
+  syncPull(options?: SyncPullOptions): Promise<SyncPullResult>;
+  syncPush(items: SyncPushItem[]): Promise<void>;
+  getSyncCursor(): Promise<string | null>;
+}
+
+export type { LinkKind };
+
+export interface StorageProviderPublicUrl {
+  buildPublicUrl(remotePath: string): string;
+  resolveLinkKind(url: string): LinkKind;
+}
+
+export interface StorageProviderWithSync
+  extends StorageProvider,
+    StorageProviderSync,
+    StorageProviderPublicUrl {}
+
+export function hasStorageProviderSync(
+  provider: StorageProvider,
+): provider is StorageProvider & StorageProviderSync {
+  const candidate = provider as Partial<StorageProviderSync>;
+  return (
+    typeof candidate.syncPull === 'function' &&
+    typeof candidate.syncPush === 'function' &&
+    typeof candidate.getSyncCursor === 'function'
+  );
+}
+
+export function hasStorageProviderPublicUrl(
+  provider: StorageProvider,
+): provider is StorageProvider & StorageProviderPublicUrl {
+  const candidate = provider as Partial<StorageProviderPublicUrl>;
+  return (
+    typeof candidate.buildPublicUrl === 'function' &&
+    typeof candidate.resolveLinkKind === 'function'
+  );
 }
 
 /** M3 后期（REF-306）持久化的单条仓库源 */

--- a/packages/core/src/types/image.ts
+++ b/packages/core/src/types/image.ts
@@ -1,7 +1,13 @@
+/** REF-607：与 `StorageProviderPublicUrl.resolveLinkKind` 一致 */
+export type LinkKind = 'local' | 'remote-raw' | 'remote-proxy';
+
 export interface ImageItem {
   id: string;
   name: string;
   url: string;
+  /**
+   * @deprecated 使用 `publicUrl`；保留以兼容现有 GitHub raw 字段与远端列表。
+   */
   githubUrl: string;
   size: number;
   width: number;
@@ -11,6 +17,12 @@ export interface ImageItem {
   description?: string;
   createdAt: string;
   updatedAt: string;
+  /** REF-607：工作区内相对路径 */
+  localPath?: string;
+  /** REF-607：链接形态（本地预览 vs 远端公网） */
+  linkKind?: LinkKind;
+  /** REF-607：当前绑定远端下的公网 URL */
+  publicUrl?: string;
 }
 
 export interface ImageUploadData {

--- a/packages/core/src/vault/__tests__/localVault.test.ts
+++ b/packages/core/src/vault/__tests__/localVault.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { WORKSPACE_PATHS } from '../paths';
+import { createLocalVault } from '../localVault';
+import { MemoryWorkspaceAdapter } from '../memoryAdapter';
+import { decodeJson } from '../utils';
+
+describe('MemoryWorkspaceAdapter', () => {
+  it('reads and writes files after pickRoot', async () => {
+    const adapter = new MemoryWorkspaceAdapter('desktop');
+    expect(adapter.isReady()).toBe(false);
+    await adapter.pickRoot();
+    await adapter.writeFile('images/a.jpg', new Uint8Array([1, 2, 3]));
+    const data = await adapter.readFile('images/a.jpg');
+    expect(data).toEqual(new Uint8Array([1, 2, 3]));
+    expect(await adapter.listFiles('images')).toEqual(['images/a.jpg']);
+  });
+});
+
+describe('createLocalVault', () => {
+  it('open initializes config and index', async () => {
+    const adapter = new MemoryWorkspaceAdapter();
+    const vault = createLocalVault(adapter);
+    await vault.open();
+
+    const config = vault.getConfig();
+    expect(config.schemaVersion).toBe(1);
+    expect(config.workspaceId).toBeTruthy();
+    expect(await adapter.exists(WORKSPACE_PATHS.config)).toBe(true);
+    expect(await adapter.exists(WORKSPACE_PATHS.index)).toBe(true);
+  });
+
+  it('importFile adds entry and persists index', async () => {
+    const adapter = new MemoryWorkspaceAdapter();
+    const vault = createLocalVault(adapter);
+    await vault.open();
+
+    const file = new File([new Uint8Array([9, 9, 9])], 'photo.jpg', {
+      type: 'image/jpeg',
+    });
+    const entry = await vault.importFile(file, 'images/photo.jpg', {
+      tags: ['test'],
+      width: 100,
+      height: 80,
+    });
+
+    expect(entry.relativePath).toBe('images/photo.jpg');
+    expect(entry.tags).toEqual(['test']);
+    expect(entry.syncState).toBe('local-only');
+
+    const listed = await vault.list();
+    expect(listed).toHaveLength(1);
+    expect(listed[0].name).toBe('photo.jpg');
+
+    const raw = await adapter.readFile(WORKSPACE_PATHS.index);
+    const persisted = decodeJson<{ entries: unknown[] }>(raw);
+    expect(persisted.entries).toHaveLength(1);
+  });
+
+  it('updateMetadata and softDelete update index', async () => {
+    const adapter = new MemoryWorkspaceAdapter();
+    const vault = createLocalVault(adapter);
+    await vault.open();
+
+    adapter.seedFile('images/x.png', new Uint8Array(10));
+    await vault.importFile('images/x.png', 'images/x.png');
+
+    const updated = await vault.updateMetadata('images/x.png', {
+      description: 'hello',
+      tags: ['a'],
+    });
+    expect(updated.description).toBe('hello');
+
+    await vault.softDelete('images/x.png');
+    expect(await vault.list()).toHaveLength(0);
+    const deleted = await vault.getByPath('images/x.png');
+    expect(deleted?.deletedAt).toBeTruthy();
+    expect((await vault.list({ includeDeleted: true })).length).toBe(1);
+  });
+
+  it('scan discovers files under images/', async () => {
+    const adapter = new MemoryWorkspaceAdapter();
+    const vault = createLocalVault(adapter);
+    await vault.open();
+
+    adapter.seedFile('images/new/shot.webp', new Uint8Array(4));
+    const added = await vault.scan();
+    expect(added).toBe(1);
+    expect(await vault.list()).toHaveLength(1);
+    expect((await vault.list())[0].mimeType).toBe('image/webp');
+  });
+});

--- a/packages/core/src/vault/__tests__/syncEngine.test.ts
+++ b/packages/core/src/vault/__tests__/syncEngine.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSyncEngine } from '../syncEngine';
+
+describe('createSyncEngine', () => {
+  it('tracks enqueuePush in status', async () => {
+    const onEnqueue = vi.fn();
+    const engine = createSyncEngine({ onEnqueue });
+
+    await engine.enqueuePush({ type: 'upload', relativePath: 'images/a.jpg' });
+    expect(onEnqueue).toHaveBeenCalledOnce();
+
+    const status = await engine.getStatus();
+    expect(status.pendingPush).toBe(1);
+    expect(status.conflicts).toBe(0);
+  });
+
+  it('run clears push queue and updates lastSyncAt', async () => {
+    const engine = createSyncEngine();
+    await engine.enqueuePush({ type: 'upload', relativePath: 'images/a.jpg' });
+    await engine.enqueuePush({
+      type: 'metadata',
+      relativePath: 'images/b.jpg',
+    });
+
+    const result = await engine.run({ direction: 'push' });
+    expect(result.pushed).toBe(2);
+    expect(result.pulled).toBe(0);
+
+    const status = await engine.getStatus();
+    expect(status.pendingPush).toBe(0);
+    expect(status.lastSyncAt).toBeTruthy();
+  });
+});

--- a/packages/core/src/vault/index.ts
+++ b/packages/core/src/vault/index.ts
@@ -1,0 +1,12 @@
+export * from './types';
+export * from './paths';
+export { MemoryWorkspaceAdapter } from './memoryAdapter';
+export { createLocalVault } from './localVault';
+export { createSyncEngine } from './syncEngine';
+export type { CreateSyncEngineOptions } from './syncEngine';
+export {
+  basename,
+  createIndexEntry,
+  stablePathId,
+  guessMimeType,
+} from './utils';

--- a/packages/core/src/vault/localVault.ts
+++ b/packages/core/src/vault/localVault.ts
@@ -1,0 +1,217 @@
+import { WORKSPACE_PATHS, WORKSPACE_SCHEMA_VERSION } from './paths';
+import type {
+  LocalImageIndexEntry,
+  LocalListOptions,
+  LocalVault,
+  WorkspaceAdapter,
+  WorkspaceConfig,
+} from './types';
+import {
+  basename,
+  createIndexEntry,
+  decodeJson,
+  encodeJson,
+  isImageFilePath,
+  nowIso,
+} from './utils';
+
+type IndexFile = {
+  schemaVersion: number;
+  entries: LocalImageIndexEntry[];
+};
+
+export function createLocalVault(adapter: WorkspaceAdapter): LocalVault {
+  let config: WorkspaceConfig | null = null;
+  let index: LocalImageIndexEntry[] = [];
+
+  const persistConfig = async () => {
+    if (!config) {
+      throw new Error('Workspace config is not initialized');
+    }
+    await adapter.writeFile(WORKSPACE_PATHS.config, encodeJson(config));
+  };
+
+  const persistIndex = async () => {
+    const payload: IndexFile = {
+      schemaVersion: WORKSPACE_SCHEMA_VERSION,
+      entries: index,
+    };
+    await adapter.writeFile(WORKSPACE_PATHS.index, encodeJson(payload));
+  };
+
+  const loadOrInitConfig = async (): Promise<WorkspaceConfig> => {
+    if (await adapter.exists(WORKSPACE_PATHS.config)) {
+      const raw = await adapter.readFile(WORKSPACE_PATHS.config);
+      const parsed = decodeJson<WorkspaceConfig>(raw);
+      if (parsed.schemaVersion !== WORKSPACE_SCHEMA_VERSION) {
+        throw new Error(
+          `Unsupported workspace schema: ${parsed.schemaVersion}`,
+        );
+      }
+      return parsed;
+    }
+
+    const initial: WorkspaceConfig = {
+      schemaVersion: WORKSPACE_SCHEMA_VERSION,
+      workspaceId: crypto.randomUUID(),
+      displayName: 'Pixuli Library',
+      createdAt: nowIso(),
+      bindings: [],
+    };
+    await adapter.writeFile(WORKSPACE_PATHS.config, encodeJson(initial));
+    return initial;
+  };
+
+  const loadOrInitIndex = async (): Promise<LocalImageIndexEntry[]> => {
+    if (await adapter.exists(WORKSPACE_PATHS.index)) {
+      const raw = await adapter.readFile(WORKSPACE_PATHS.index);
+      const parsed = decodeJson<IndexFile>(raw);
+      return parsed.entries ?? [];
+    }
+
+    const empty: IndexFile = {
+      schemaVersion: WORKSPACE_SCHEMA_VERSION,
+      entries: [],
+    };
+    await adapter.writeFile(WORKSPACE_PATHS.index, encodeJson(empty));
+    return [];
+  };
+
+  const vault: LocalVault = {
+    adapter,
+
+    async open() {
+      if (!adapter.isReady()) {
+        await adapter.pickRoot();
+      }
+      config = await loadOrInitConfig();
+      index = await loadOrInitIndex();
+    },
+
+    getConfig() {
+      if (!config) {
+        throw new Error('LocalVault is not open; call open() first');
+      }
+      return config;
+    },
+
+    async list(options?: LocalListOptions) {
+      let entries = index.filter(entry => {
+        if (!options?.includeDeleted && entry.deletedAt) {
+          return false;
+        }
+        if (options?.bindingId && entry.bindingId !== options.bindingId) {
+          return false;
+        }
+        if (options?.search) {
+          const q = options.search.toLowerCase();
+          const haystack = [
+            entry.name,
+            entry.description ?? '',
+            entry.tags.join(' '),
+          ]
+            .join(' ')
+            .toLowerCase();
+          if (!haystack.includes(q)) {
+            return false;
+          }
+        }
+        return true;
+      });
+      return entries.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    },
+
+    async getByPath(relativePath) {
+      return index.find(entry => entry.relativePath === relativePath) ?? null;
+    },
+
+    async importFile(source, targetRelativePath, meta) {
+      const data = await readSourceBytes(adapter, source);
+      await adapter.writeFile(targetRelativePath, data);
+      const entry = createIndexEntry(targetRelativePath, data.byteLength, meta);
+      const existingIdx = index.findIndex(
+        item => item.relativePath === targetRelativePath,
+      );
+      if (existingIdx >= 0) {
+        index[existingIdx] = {
+          ...index[existingIdx],
+          ...entry,
+          id: index[existingIdx].id,
+          createdAt: index[existingIdx].createdAt,
+          updatedAt: nowIso(),
+        };
+      } else {
+        index.push(entry);
+      }
+      await persistIndex();
+      return (
+        index.find(item => item.relativePath === targetRelativePath) ?? entry
+      );
+    },
+
+    async updateMetadata(relativePath, patch) {
+      const entry = index.find(item => item.relativePath === relativePath);
+      if (!entry || entry.deletedAt) {
+        throw new Error(`Image not found: ${relativePath}`);
+      }
+      Object.assign(entry, patch, { updatedAt: nowIso() });
+      await persistIndex();
+      return { ...entry };
+    },
+
+    async softDelete(relativePath) {
+      const entry = index.find(item => item.relativePath === relativePath);
+      if (!entry || entry.deletedAt) {
+        throw new Error(`Image not found: ${relativePath}`);
+      }
+      entry.deletedAt = nowIso();
+      entry.updatedAt = entry.deletedAt;
+      entry.syncState = 'pending-push';
+      await persistIndex();
+    },
+
+    async scan() {
+      const files = await adapter.listFiles(WORKSPACE_PATHS.imagesDir, {
+        recursive: true,
+      });
+      let count = 0;
+      for (const relativePath of files) {
+        if (!isImageFilePath(relativePath)) {
+          continue;
+        }
+        const existsInIndex = index.some(
+          entry => entry.relativePath === relativePath && !entry.deletedAt,
+        );
+        if (existsInIndex) {
+          continue;
+        }
+        const data = await adapter.readFile(relativePath);
+        index.push(
+          createIndexEntry(relativePath, data.byteLength, {
+            name: basename(relativePath),
+          }),
+        );
+        count += 1;
+      }
+      if (count > 0) {
+        await persistIndex();
+      }
+      return count;
+    },
+  };
+
+  return vault;
+}
+
+async function readSourceBytes(
+  adapter: WorkspaceAdapter,
+  source: File | string,
+): Promise<Uint8Array> {
+  if (typeof source === 'string') {
+    return adapter.readFile(source);
+  }
+  if (typeof source.arrayBuffer === 'function') {
+    return new Uint8Array(await source.arrayBuffer());
+  }
+  return new Uint8Array(await new Response(source).arrayBuffer());
+}

--- a/packages/core/src/vault/memoryAdapter.ts
+++ b/packages/core/src/vault/memoryAdapter.ts
@@ -1,0 +1,98 @@
+import type { WorkspaceAdapter, WorkspaceAdapterKind } from './types';
+
+/**
+ * 内存工作区适配器，供单测与 P1 契约验证；不依赖真实 FS。
+ */
+export class MemoryWorkspaceAdapter implements WorkspaceAdapter {
+  readonly kind: WorkspaceAdapterKind;
+  private root: string | null = null;
+  private readonly files = new Map<string, Uint8Array>();
+
+  constructor(kind: WorkspaceAdapterKind = 'web') {
+    this.kind = kind;
+  }
+
+  isReady(): boolean {
+    return this.root !== null;
+  }
+
+  getRootPath(): string | null {
+    return this.root;
+  }
+
+  async pickRoot(): Promise<boolean> {
+    this.root = `memory://${crypto.randomUUID()}`;
+    return true;
+  }
+
+  async readFile(relativePath: string): Promise<Uint8Array> {
+    const normalized = normalizeRelativePath(relativePath);
+    const data = this.files.get(normalized);
+    if (!data) {
+      throw new Error(`File not found: ${normalized}`);
+    }
+    return data;
+  }
+
+  async writeFile(relativePath: string, data: Uint8Array): Promise<void> {
+    this.files.set(normalizeRelativePath(relativePath), data);
+  }
+
+  async deleteFile(relativePath: string): Promise<void> {
+    this.files.delete(normalizeRelativePath(relativePath));
+  }
+
+  async listFiles(
+    relativeDir: string,
+    options?: { recursive?: boolean },
+  ): Promise<string[]> {
+    const prefix = normalizeDirPrefix(relativeDir);
+    const paths = new Set<string>();
+
+    for (const key of this.files.keys()) {
+      if (!key.startsWith(prefix)) {
+        continue;
+      }
+      const rest = key.slice(prefix.length);
+      if (!rest) {
+        continue;
+      }
+      if (options?.recursive) {
+        paths.add(key);
+        continue;
+      }
+      const segment = rest.split('/').filter(Boolean)[0];
+      if (segment) {
+        paths.add(prefix ? `${prefix}${segment}` : segment);
+      }
+    }
+
+    return [...paths].sort();
+  }
+
+  async exists(relativePath: string): Promise<boolean> {
+    return this.files.has(normalizeRelativePath(relativePath));
+  }
+
+  /** 测试辅助：直接写入文件 */
+  seedFile(relativePath: string, data: Uint8Array): void {
+    this.files.set(normalizeRelativePath(relativePath), data);
+  }
+
+  /** 测试辅助：列出全部路径 */
+  listAllPaths(): string[] {
+    return [...this.files.keys()].sort();
+  }
+}
+
+function normalizeRelativePath(path: string): string {
+  return path.replace(/^\/+/, '').replace(/\\/g, '/');
+}
+
+function normalizeDirPrefix(dir: string): string {
+  const normalized = normalizeRelativePath(dir);
+  if (!normalized) {
+    return '';
+  }
+  return normalized.endsWith('/') ? normalized : `${normalized}/`;
+}

--- a/packages/core/src/vault/paths.ts
+++ b/packages/core/src/vault/paths.ts
@@ -1,0 +1,12 @@
+/** 工作区内约定路径（相对 workspace 根） */
+export const WORKSPACE_PATHS = {
+  config: '.pixuli/config.json',
+  index: '.pixuli/index.json',
+  syncState: '.pixuli/sync/state.json',
+  syncQueue: '.pixuli/sync/queue.jsonl',
+  syncConflicts: '.pixuli/sync/conflicts.json',
+  trashDir: '.pixuli/trash',
+  imagesDir: 'images',
+} as const;
+
+export const WORKSPACE_SCHEMA_VERSION = 1;

--- a/packages/core/src/vault/syncEngine.ts
+++ b/packages/core/src/vault/syncEngine.ts
@@ -1,0 +1,57 @@
+import type {
+  SyncEngine,
+  SyncPushOperation,
+  SyncRunOptions,
+  SyncRunResult,
+  SyncStatusSummary,
+} from './types';
+import { nowIso } from './utils';
+
+export interface CreateSyncEngineOptions {
+  /** P3：绑定 LocalVault 与 Provider 后实现 push/pull */
+  onEnqueue?: (op: SyncPushOperation) => void | Promise<void>;
+}
+
+/**
+ * SyncEngine MVP 骨架（REF-607 P1）：内存队列 + 状态汇总；push/pull 在 P3 实现。
+ */
+export function createSyncEngine(
+  options: CreateSyncEngineOptions = {},
+): SyncEngine {
+  const queue: SyncPushOperation[] = [];
+  let lastSyncAt: string | null = null;
+
+  return {
+    async enqueuePush(op) {
+      queue.push(op);
+      await options.onEnqueue?.(op);
+    },
+
+    async getStatus(): Promise<SyncStatusSummary> {
+      return {
+        lastSyncAt,
+        pendingPush: queue.length,
+        conflicts: 0,
+        bindings: {},
+      };
+    },
+
+    async run(runOptions?: SyncRunOptions): Promise<SyncRunResult> {
+      const direction = runOptions?.direction ?? 'both';
+      const result: SyncRunResult = {
+        pushed: 0,
+        pulled: 0,
+        conflicts: [],
+        errors: [],
+      };
+
+      if (direction === 'push' || direction === 'both') {
+        result.pushed = queue.length;
+        queue.length = 0;
+      }
+
+      lastSyncAt = nowIso();
+      return result;
+    },
+  };
+}

--- a/packages/core/src/vault/types.ts
+++ b/packages/core/src/vault/types.ts
@@ -1,0 +1,136 @@
+import type { StorageProviderConfig } from '../plugins/types';
+
+export type WorkspaceAdapterKind = 'desktop' | 'web' | 'mobile';
+
+/** 读写工作区文件的端口；由各端实现（Desktop FS / Web OPFS / Mobile SAF） */
+export interface WorkspaceAdapter {
+  readonly kind: WorkspaceAdapterKind;
+  isReady(): boolean;
+  /** Desktop 绝对路径；Web/Mobile 为虚拟根 id */
+  getRootPath(): string | null;
+  pickRoot(): Promise<boolean>;
+  readFile(relativePath: string): Promise<Uint8Array>;
+  writeFile(relativePath: string, data: Uint8Array): Promise<void>;
+  deleteFile(relativePath: string): Promise<void>;
+  listFiles(
+    relativeDir: string,
+    options?: { recursive?: boolean },
+  ): Promise<string[]>;
+  exists(relativePath: string): Promise<boolean>;
+}
+
+export interface WorkspaceBinding {
+  id: string;
+  label: string;
+  pluginId: string;
+  remotePathPrefix: string;
+  localPathPrefix: string;
+  config: StorageProviderConfig;
+}
+
+export interface WorkspaceConfig {
+  schemaVersion: number;
+  workspaceId: string;
+  displayName: string;
+  createdAt: string;
+  bindings: WorkspaceBinding[];
+}
+
+export type LocalImageSyncState =
+  | 'local-only'
+  | 'synced'
+  | 'pending-push'
+  | 'conflict';
+
+export interface LocalImageIndexEntry {
+  id: string;
+  relativePath: string;
+  name: string;
+  size: number;
+  width: number;
+  height: number;
+  mimeType: string;
+  tags: string[];
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt?: string;
+  bindingId?: string;
+  remotePath?: string;
+  syncState?: LocalImageSyncState;
+}
+
+export interface LocalListOptions {
+  bindingId?: string;
+  includeDeleted?: boolean;
+  search?: string;
+}
+
+export interface LocalVault {
+  readonly adapter: WorkspaceAdapter;
+  open(): Promise<void>;
+  getConfig(): WorkspaceConfig;
+  list(options?: LocalListOptions): Promise<LocalImageIndexEntry[]>;
+  getByPath(relativePath: string): Promise<LocalImageIndexEntry | null>;
+  importFile(
+    source: File | string,
+    targetRelativePath: string,
+    meta?: Partial<LocalImageIndexEntry>,
+  ): Promise<LocalImageIndexEntry>;
+  updateMetadata(
+    relativePath: string,
+    patch: Partial<Pick<LocalImageIndexEntry, 'name' | 'tags' | 'description'>>,
+  ): Promise<LocalImageIndexEntry>;
+  softDelete(relativePath: string): Promise<void>;
+  scan(): Promise<number>;
+}
+
+export type SyncDirection = 'push' | 'pull' | 'both';
+
+export type SyncPushOperation =
+  | { type: 'upload'; relativePath: string }
+  | { type: 'delete'; relativePath: string; remotePath?: string }
+  | { type: 'metadata'; relativePath: string };
+
+export interface SyncConflict {
+  relativePath: string;
+  bindingId?: string;
+  localRev?: string;
+  remoteRev?: string;
+  strategy?: 'lww' | 'manual';
+  message?: string;
+  recordedAt: string;
+}
+
+export interface SyncBindingStatus {
+  cursor: string | null;
+  lastSyncAt: string | null;
+  pendingPush: number;
+}
+
+export interface SyncStatusSummary {
+  lastSyncAt: string | null;
+  pendingPush: number;
+  conflicts: number;
+  bindings: Record<string, SyncBindingStatus>;
+}
+
+export interface SyncRunOptions {
+  bindingId?: string;
+  direction?: SyncDirection;
+}
+
+export interface SyncRunResult {
+  pushed: number;
+  pulled: number;
+  conflicts: SyncConflict[];
+  errors: Array<{ path: string; message: string }>;
+}
+
+export interface SyncEngine {
+  enqueuePush(op: SyncPushOperation): Promise<void>;
+  getStatus(): Promise<SyncStatusSummary>;
+  run(options?: SyncRunOptions): Promise<SyncRunResult>;
+}
+
+export type WorkspaceMode = 'unset' | 'local' | 'remote-only';

--- a/packages/core/src/vault/utils.ts
+++ b/packages/core/src/vault/utils.ts
@@ -1,0 +1,69 @@
+import type { LocalImageIndexEntry } from './types';
+
+const TEXT_ENCODER = new TextEncoder();
+
+export function stablePathId(relativePath: string): string {
+  const normalized = relativePath.replace(/^\/+/, '').replace(/\\/g, '/');
+  let hash = 0;
+  for (let i = 0; i < normalized.length; i += 1) {
+    hash = (hash << 5) - hash + normalized.charCodeAt(i);
+    hash |= 0;
+  }
+  return `img_${Math.abs(hash).toString(36)}`;
+}
+
+export function basename(relativePath: string): string {
+  const parts = relativePath.replace(/\\/g, '/').split('/');
+  return parts[parts.length - 1] || relativePath;
+}
+
+export function guessMimeType(name: string): string {
+  const lower = name.toLowerCase();
+  if (lower.endsWith('.png')) return 'image/png';
+  if (lower.endsWith('.webp')) return 'image/webp';
+  if (lower.endsWith('.gif')) return 'image/gif';
+  if (lower.endsWith('.svg')) return 'image/svg+xml';
+  return 'image/jpeg';
+}
+
+export function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function encodeJson(value: unknown): Uint8Array {
+  return TEXT_ENCODER.encode(JSON.stringify(value, null, 2));
+}
+
+export function decodeJson<T>(data: Uint8Array): T {
+  return JSON.parse(new TextDecoder().decode(data)) as T;
+}
+
+export function createIndexEntry(
+  relativePath: string,
+  size: number,
+  meta?: Partial<LocalImageIndexEntry>,
+): LocalImageIndexEntry {
+  const name = meta?.name ?? basename(relativePath);
+  const timestamp = nowIso();
+  return {
+    id: meta?.id ?? stablePathId(relativePath),
+    relativePath,
+    name,
+    size,
+    width: meta?.width ?? 0,
+    height: meta?.height ?? 0,
+    mimeType: meta?.mimeType ?? guessMimeType(name),
+    tags: meta?.tags ?? [],
+    description: meta?.description,
+    createdAt: meta?.createdAt ?? timestamp,
+    updatedAt: meta?.updatedAt ?? timestamp,
+    deletedAt: meta?.deletedAt,
+    bindingId: meta?.bindingId,
+    remotePath: meta?.remotePath,
+    syncState: meta?.syncState ?? 'local-only',
+  };
+}
+
+export function isImageFilePath(relativePath: string): boolean {
+  return /\.(jpe?g|png|gif|webp|svg)$/i.test(relativePath);
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     'locales/index': 'src/locales/index.ts',
     'operation-log/index': 'src/operation-log/index.ts',
     'sources/index': 'src/sources/index.ts',
+    'vault/index': 'src/vault/index.ts',
   },
   format: ['esm'],
   dts: true,


### PR DESCRIPTION
## Summary

Closes #156

- 新增 `@pixuli/core/vault`：`WorkspaceAdapter`、`LocalVault`、`SyncEngine` 类型与实现骨架
- `MemoryWorkspaceAdapter` + `createLocalVault`：config/index 持久化、import/scan/软删
- `createSyncEngine`：内存 push 队列（P3 再接 Provider）
- `StorageProviderSync` / `StorageProviderPublicUrl` / `capabilities.sync|publicUrl`
- `ImageItem` 演进：`localPath`、`linkKind`、`publicUrl`；`githubUrl` 标记 deprecated

## Test plan

- [x] `pnpm --filter @pixuli/core test`
- [x] `pnpm --filter @pixuli/core build`
- [ ] P2 可 `import { createLocalVault } from '@pixuli/core/vault'`


Made with [Cursor](https://cursor.com)