### PR TITLE
feat(desktop): REF-607-P2 本地工作区 PoC (#157)

### DIFF
--- a/apps/pixuli/electron/main/services/index.ts
+++ b/apps/pixuli/electron/main/services/index.ts
@@ -1,7 +1,9 @@
 import { registerAiHandlers } from './aiService';
 import { registerFileHandlers } from './fileService';
+import { registerWorkspaceHandlers } from './workspaceService';
 
 export function registerServiceHandlers() {
   registerAiHandlers();
   registerFileHandlers();
+  registerWorkspaceHandlers();
 }

--- a/apps/pixuli/electron/main/services/workspaceService.ts
+++ b/apps/pixuli/electron/main/services/workspaceService.ts
@@ -1,0 +1,134 @@
+import { dialog, ipcMain } from 'electron';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+function resolveSafePath(root: string, relativePath: string): string {
+  const normalized = relativePath.replace(/^[/\\]+/, '').replace(/\\/g, '/');
+  const resolved = path.resolve(root, normalized);
+  const rootResolved = path.resolve(root);
+  if (
+    resolved !== rootResolved &&
+    !resolved.startsWith(`${rootResolved}${path.sep}`)
+  ) {
+    throw new Error(`Invalid workspace path: ${relativePath}`);
+  }
+  return resolved;
+}
+
+function listRelativeFiles(
+  root: string,
+  relativeDir: string,
+  recursive: boolean,
+): string[] {
+  const absDir = resolveSafePath(root, relativeDir);
+  if (!fs.existsSync(absDir)) {
+    return [];
+  }
+
+  const results: string[] = [];
+  const walk = (currentAbs: string, currentRel: string) => {
+    const entries = fs.readdirSync(currentAbs, { withFileTypes: true });
+    for (const entry of entries) {
+      const rel = currentRel ? `${currentRel}/${entry.name}` : entry.name;
+      const abs = path.join(currentAbs, entry.name);
+      if (entry.isDirectory()) {
+        if (recursive) {
+          walk(abs, rel);
+        } else {
+          results.push(rel.replace(/\\/g, '/'));
+        }
+      } else if (entry.isFile()) {
+        results.push(rel.replace(/\\/g, '/'));
+      }
+    }
+  };
+
+  const stat = fs.statSync(absDir);
+  if (stat.isDirectory()) {
+    walk(absDir, relativeDir.replace(/\\/g, '/').replace(/\/$/, ''));
+  }
+  return results.sort();
+}
+
+let workspaceRoot: string | null = null;
+
+export function registerWorkspaceHandlers() {
+  ipcMain.handle('workspace:getRoot', () => ({
+    rootPath: workspaceRoot,
+  }));
+
+  ipcMain.handle('workspace:pickRoot', async () => {
+    const result = await dialog.showOpenDialog({
+      properties: ['openDirectory', 'createDirectory'],
+      title: '选择 Pixuli 本地工作区',
+    });
+    if (result.canceled || result.filePaths.length === 0) {
+      return { ok: false, rootPath: null as string | null };
+    }
+    workspaceRoot = result.filePaths[0];
+    return { ok: true, rootPath: workspaceRoot };
+  });
+
+  ipcMain.handle('workspace:setRoot', (_event, rootPath: string) => {
+    if (!rootPath || !fs.existsSync(rootPath)) {
+      return { ok: false };
+    }
+    workspaceRoot = rootPath;
+    return { ok: true, rootPath: workspaceRoot };
+  });
+
+  ipcMain.handle('workspace:readFile', (_event, relativePath: string) => {
+    if (!workspaceRoot) {
+      throw new Error('Workspace root is not set');
+    }
+    const abs = resolveSafePath(workspaceRoot, relativePath);
+    const buffer = fs.readFileSync(abs);
+    return Uint8Array.from(buffer);
+  });
+
+  ipcMain.handle(
+    'workspace:writeFile',
+    (_event, relativePath: string, data: Uint8Array) => {
+      if (!workspaceRoot) {
+        throw new Error('Workspace root is not set');
+      }
+      const abs = resolveSafePath(workspaceRoot, relativePath);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, Buffer.from(data));
+      return { ok: true };
+    },
+  );
+
+  ipcMain.handle('workspace:deleteFile', (_event, relativePath: string) => {
+    if (!workspaceRoot) {
+      throw new Error('Workspace root is not set');
+    }
+    const abs = resolveSafePath(workspaceRoot, relativePath);
+    if (fs.existsSync(abs)) {
+      fs.unlinkSync(abs);
+    }
+    return { ok: true };
+  });
+
+  ipcMain.handle(
+    'workspace:listFiles',
+    (_event, relativeDir: string, recursive?: boolean) => {
+      if (!workspaceRoot) {
+        throw new Error('Workspace root is not set');
+      }
+      return listRelativeFiles(workspaceRoot, relativeDir, recursive ?? false);
+    },
+  );
+
+  ipcMain.handle('workspace:exists', (_event, relativePath: string) => {
+    if (!workspaceRoot) {
+      return false;
+    }
+    try {
+      const abs = resolveSafePath(workspaceRoot, relativePath);
+      return fs.existsSync(abs);
+    } catch {
+      return false;
+    }
+  });
+}

--- a/apps/pixuli/electron/preload/index.ts
+++ b/apps/pixuli/electron/preload/index.ts
@@ -68,6 +68,24 @@ contextBridge.exposeInMainWorld('fileAPI', {
     ipcRenderer.invoke('file:save', fileName, content, mimeType),
 });
 
+// --------- Expose Workspace API (REF-607 Desktop) -------------------------
+contextBridge.exposeInMainWorld('workspaceAPI', {
+  getRoot: () => ipcRenderer.invoke('workspace:getRoot'),
+  pickRoot: () => ipcRenderer.invoke('workspace:pickRoot'),
+  setRoot: (rootPath: string) =>
+    ipcRenderer.invoke('workspace:setRoot', rootPath),
+  readFile: (relativePath: string) =>
+    ipcRenderer.invoke('workspace:readFile', relativePath),
+  writeFile: (relativePath: string, data: Uint8Array) =>
+    ipcRenderer.invoke('workspace:writeFile', relativePath, data),
+  deleteFile: (relativePath: string) =>
+    ipcRenderer.invoke('workspace:deleteFile', relativePath),
+  listFiles: (relativeDir: string, recursive?: boolean) =>
+    ipcRenderer.invoke('workspace:listFiles', relativeDir, recursive),
+  exists: (relativePath: string) =>
+    ipcRenderer.invoke('workspace:exists', relativePath),
+});
+
 // --------- Expose Electron API to the Renderer process ---------
 contextBridge.exposeInMainWorld('electronAPI', {
   onReceiveMessage: (callback: (message: string) => void) => {

--- a/apps/pixuli/src/App.tsx
+++ b/apps/pixuli/src/App.tsx
@@ -1,5 +1,5 @@
 import { useDemoMode } from '@pixuli/ui';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import './App.css';
 import { SearchProvider } from './contexts/SearchContext';
 import {
@@ -11,15 +11,29 @@ import {
 } from './hooks';
 import { useI18n } from './i18n/useI18n';
 import { MainLayout } from './layouts/MainLayout';
+import { isDesktopWorkspaceAvailable } from './platforms/desktop/workspaceAdapter';
 import { AppRoutes } from './router/routes';
 import { useImageStore } from './stores/imageStore';
 import { useSourceStore } from './stores/sourceStore';
 import { useUIStore } from './stores/uiStore';
+import { useWorkspaceStore } from './stores/workspaceStore';
 
 // 主应用组件（统一 Web 和 Desktop）
 function App() {
   const { t } = useI18n();
   const { loadImages, uploadImage, uploadMultipleImages } = useImageStore();
+  const initializeWorkspace = useWorkspaceStore(state => state.initialize);
+  const isLocalActive = useWorkspaceStore(state => state.isLocalActive);
+  const importLocalImage = useWorkspaceStore(state => state.importLocalImage);
+  const refreshLocalImages = useWorkspaceStore(
+    state => state.refreshLocalImages,
+  );
+
+  useEffect(() => {
+    if (isDesktopWorkspaceAvailable()) {
+      void initializeWorkspace();
+    }
+  }, [initializeWorkspace]);
 
   const { sources, selectedSourceId } = useSourceStore();
 
@@ -60,17 +74,52 @@ function App() {
   // 配置管理
   const { handleSaveConfig, handleClearConfig } = useConfigManagement();
 
-  // 判断是否有配置
-  const hasConfig = sources.length > 0;
+  const workspaceMode = useWorkspaceStore(state => state.mode);
 
-  // 加载图片
+  const hasConfig =
+    sources.length > 0 ||
+    (isDesktopWorkspaceAvailable() && workspaceMode === 'local');
+
   const handleLoadImages = useCallback(async () => {
     try {
+      if (isLocalActive()) {
+        await refreshLocalImages();
+        return;
+      }
       await loadImages();
     } catch (error) {
       console.error('Failed to load images:', error);
     }
-  }, [loadImages]);
+  }, [isLocalActive, refreshLocalImages, loadImages]);
+
+  const handleUploadImage = useCallback(
+    async (data: Parameters<typeof uploadImage>[0]) => {
+      if (isLocalActive()) {
+        await importLocalImage(data);
+        return;
+      }
+      await uploadImage(data);
+    },
+    [isLocalActive, importLocalImage, uploadImage],
+  );
+
+  const handleUploadMultipleImages = useCallback(
+    async (data: Parameters<typeof uploadMultipleImages>[0]) => {
+      if (isLocalActive()) {
+        for (const file of data.files) {
+          await importLocalImage({
+            file,
+            name: data.name,
+            description: data.description,
+            tags: data.tags,
+          });
+        }
+        return;
+      }
+      await uploadMultipleImages(data);
+    },
+    [isLocalActive, importLocalImage, uploadMultipleImages],
+  );
 
   // 保存配置（包装以包含 editingSourceId）
   const handleSaveConfigWithId = useMemo(
@@ -108,6 +157,9 @@ function App() {
 
   // 同步选中源到配置，并在同步后加载图片
   useSelectedSourceSync(selectedSource ?? null, () => {
+    if (isLocalActive()) {
+      return;
+    }
     if (sources.length > 0 && selectedSource) {
       handleLoadImages();
     }
@@ -162,8 +214,8 @@ function App() {
         hasConfig={hasConfig}
         onAddSource={addSource}
         onLoadImages={handleLoadImages}
-        onUploadImage={uploadImage}
-        onUploadMultipleImages={uploadMultipleImages}
+        onUploadImage={handleUploadImage}
+        onUploadMultipleImages={handleUploadMultipleImages}
         onSaveConfig={handleSaveConfigWithId}
         onClearConfig={handleClearConfigWithId}
         onSelectSourceType={handleSelectSourceType}

--- a/apps/pixuli/src/features/index.ts
+++ b/apps/pixuli/src/features/index.ts
@@ -6,3 +6,4 @@ export { pwaLocales } from './pwa/locales';
 export { OfflineIndicator } from './pwa/OfflineIndicator';
 export { PWAInstallPrompt } from './pwa/PWAInstallPrompt';
 export { SourceTypeMenu } from './source-type-menu/SourceTypeMenu';
+export { WorkspaceSetupPanel, WorkspaceToolbar } from './workspace';

--- a/apps/pixuli/src/features/workspace/WorkspacePanel.tsx
+++ b/apps/pixuli/src/features/workspace/WorkspacePanel.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { FolderOpen, UploadCloud } from 'lucide-react';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { useSourceStore } from '@/stores/sourceStore';
+import { useI18n } from '@/i18n/useI18n';
+
+export const WorkspaceSetupPanel: React.FC = () => {
+  const { t } = useI18n();
+  const { pickWorkspace, loading, error } = useWorkspaceStore();
+
+  return (
+    <div className="w-full px-4 sm:px-6 lg:px-8 py-8">
+      <div className="max-w-lg mx-auto rounded-xl border border-dashed border-blue-300 bg-blue-50/60 p-8 text-center">
+        <FolderOpen className="mx-auto mb-4 text-blue-600" size={40} />
+        <h2 className="text-lg font-semibold text-gray-900 mb-2">
+          {t('workspace.setupTitle')}
+        </h2>
+        <p className="text-sm text-gray-600 mb-6">{t('workspace.setupHint')}</p>
+        <button
+          type="button"
+          onClick={() => void pickWorkspace()}
+          disabled={loading}
+          className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+        >
+          <FolderOpen size={16} />
+          {loading ? t('workspace.picking') : t('workspace.pickFolder')}
+        </button>
+        {error && (
+          <p className="mt-4 text-sm text-red-600" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const WorkspaceToolbar: React.FC = () => {
+  const { t } = useI18n();
+  const {
+    displayName,
+    rootPath,
+    pushing,
+    syncMessage,
+    error,
+    pushPendingToRemote,
+    clearError,
+  } = useWorkspaceStore();
+  const sources = useSourceStore(state => state.sources);
+  const hasRemote = sources.length > 0;
+
+  return (
+    <div className="mb-4 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-gray-900">
+            {t('workspace.current')}: {displayName || t('workspace.unnamed')}
+          </p>
+          {rootPath && (
+            <p className="text-xs text-gray-500 truncate" title={rootPath}>
+              {rootPath}
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => void pushPendingToRemote()}
+          disabled={pushing || !hasRemote}
+          title={hasRemote ? undefined : t('workspace.pushNeedsRemote')}
+          className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-800 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <UploadCloud size={16} />
+          {pushing ? t('workspace.pushing') : t('workspace.pushManual')}
+        </button>
+      </div>
+      {syncMessage && (
+        <p className="mt-2 text-xs text-green-700">{syncMessage}</p>
+      )}
+      {error && (
+        <div className="mt-2 flex items-center justify-between gap-2">
+          <p className="text-xs text-red-600">{error}</p>
+          <button
+            type="button"
+            className="text-xs text-red-700 hover:underline"
+            onClick={clearError}
+          >
+            {t('workspace.dismiss')}
+          </button>
+        </div>
+      )}
+      {!hasRemote && (
+        <p className="mt-2 text-xs text-amber-700">
+          {t('workspace.pushNeedsRemote')}
+        </p>
+      )}
+    </div>
+  );
+};

--- a/apps/pixuli/src/features/workspace/index.ts
+++ b/apps/pixuli/src/features/workspace/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceSetupPanel, WorkspaceToolbar } from './WorkspacePanel';

--- a/apps/pixuli/src/features/workspace/localImageMapper.ts
+++ b/apps/pixuli/src/features/workspace/localImageMapper.ts
@@ -1,0 +1,75 @@
+import type { ImageItem, LinkKind } from '@pixuli/core/types';
+import type { LocalImageIndexEntry } from '@pixuli/core/vault';
+
+const previewUrlCache = new Map<string, string>();
+
+export function clearLocalPreviewCache(): void {
+  for (const url of previewUrlCache.values()) {
+    URL.revokeObjectURL(url);
+  }
+  previewUrlCache.clear();
+}
+
+export async function resolveLocalPreviewUrl(
+  relativePath: string,
+  mimeType: string,
+): Promise<string> {
+  const cached = previewUrlCache.get(relativePath);
+  if (cached) {
+    return cached;
+  }
+  if (!window.workspaceAPI) {
+    throw new Error('workspaceAPI unavailable');
+  }
+  const bytes = await window.workspaceAPI.readFile(relativePath);
+  const blob = new Blob([Uint8Array.from(bytes)], {
+    type: mimeType || 'image/jpeg',
+  });
+  const url = URL.createObjectURL(blob);
+  previewUrlCache.set(relativePath, url);
+  return url;
+}
+
+export function localEntryToImageItem(
+  entry: LocalImageIndexEntry,
+  previewUrl: string,
+  publicUrl?: string,
+): ImageItem {
+  const linkKind: LinkKind | undefined = publicUrl ? 'remote-raw' : 'local';
+  return {
+    id: entry.id,
+    name: entry.name,
+    url: previewUrl,
+    githubUrl: publicUrl ?? '',
+    publicUrl,
+    localPath: entry.relativePath,
+    linkKind,
+    size: entry.size,
+    width: entry.width,
+    height: entry.height,
+    type: entry.mimeType,
+    tags: entry.tags,
+    description: entry.description,
+    createdAt: entry.createdAt,
+    updatedAt: entry.updatedAt,
+  };
+}
+
+export async function mapEntriesToImageItems(
+  entries: LocalImageIndexEntry[],
+  provider?: { getRawUrl: (path: string) => string } | null,
+): Promise<ImageItem[]> {
+  const items: ImageItem[] = [];
+  for (const entry of entries) {
+    const previewUrl = await resolveLocalPreviewUrl(
+      entry.relativePath,
+      entry.mimeType,
+    );
+    const publicUrl =
+      entry.remotePath && provider
+        ? provider.getRawUrl(entry.remotePath)
+        : undefined;
+    items.push(localEntryToImageItem(entry, previewUrl, publicUrl));
+  }
+  return items;
+}

--- a/apps/pixuli/src/hooks/useAppInitialization.ts
+++ b/apps/pixuli/src/hooks/useAppInitialization.ts
@@ -1,7 +1,9 @@
 import { useEffect } from 'react';
 import { getDemoGitHubConfig, getDemoGiteeConfig } from '@pixuli/ui';
+import { isDesktopWorkspaceAvailable } from '../platforms/desktop/workspaceAdapter';
 import { useImageStore } from '../stores/imageStore';
 import { useSourceStore } from '../stores/sourceStore';
+import { useWorkspaceStore } from '../stores/workspaceStore';
 
 /**
  * 应用初始化相关的 hooks
@@ -64,6 +66,14 @@ export function useAppInitialization(
   useEffect(() => {
     // Demo 模式下不自动加载图片
     if (isDemoMode) {
+      return;
+    }
+
+    // 本地工作区模式由 workspaceStore.initialize 负责加载
+    if (
+      isDesktopWorkspaceAvailable() &&
+      useWorkspaceStore.getState().mode === 'local'
+    ) {
       return;
     }
 

--- a/apps/pixuli/src/i18n/locales/en-US.json
+++ b/apps/pixuli/src/i18n/locales/en-US.json
@@ -68,5 +68,17 @@
     "noFiles": "Select images to convert first",
     "clear": "Clear",
     "keepAspectRatio": "Keep aspect ratio"
+  },
+  "workspace": {
+    "setupTitle": "Choose a local workspace",
+    "setupHint": "Pick a folder as your Pixuli local image workspace. Images are stored under images/ in that directory.",
+    "pickFolder": "Choose folder",
+    "picking": "Opening…",
+    "current": "Workspace",
+    "unnamed": "Unnamed workspace",
+    "pushManual": "Push to remote",
+    "pushing": "Pushing…",
+    "pushNeedsRemote": "Add a GitHub or Gitee remote source to push",
+    "dismiss": "Dismiss"
   }
 }

--- a/apps/pixuli/src/i18n/locales/zh-CN.json
+++ b/apps/pixuli/src/i18n/locales/zh-CN.json
@@ -68,5 +68,17 @@
     "noFiles": "请先选择要转换的图片",
     "clear": "清空",
     "keepAspectRatio": "保持宽高比"
+  },
+  "workspace": {
+    "setupTitle": "选择本地工作区",
+    "setupHint": "选择一个文件夹作为 Pixuli 本地图床工作区，图片将保存在该目录下的 images/ 中。",
+    "pickFolder": "选择文件夹",
+    "picking": "正在打开…",
+    "current": "当前工作区",
+    "unnamed": "未命名工作区",
+    "pushManual": "推送到远端",
+    "pushing": "推送中…",
+    "pushNeedsRemote": "请先添加 GitHub 或 Gitee 远端源以推送",
+    "dismiss": "关闭"
   }
 }

--- a/apps/pixuli/src/layouts/AppMain.tsx
+++ b/apps/pixuli/src/layouts/AppMain.tsx
@@ -20,9 +20,11 @@ import { ROUTES } from '../router/routes';
 import { useSearchContextSafe } from '../contexts/SearchContext';
 import { useMobileViewport } from '../hooks/useMobileViewport';
 import { useI18n } from '../i18n/useI18n';
+import { isDesktopWorkspaceAvailable } from '../platforms/desktop/workspaceAdapter';
 import { useImageStore } from '../stores/imageStore';
 import { useSourceStore } from '../stores/sourceStore';
 import { useUIStore } from '../stores/uiStore';
+import { useWorkspaceStore } from '../stores/workspaceStore';
 
 interface AppMainProps {
   children: React.ReactNode;
@@ -42,6 +44,13 @@ export const AppMain: React.FC<AppMainProps> = ({
   const { t, changeLanguage, getCurrentLanguage, getAvailableLanguages } =
     useI18n();
   const { loading, batchUploadProgress, images } = useImageStore();
+  const workspaceMode = useWorkspaceStore(state => state.mode);
+  const localImages = useWorkspaceStore(state => state.localImages);
+  const workspaceLoading = useWorkspaceStore(state => state.loading);
+  const localActive =
+    isDesktopWorkspaceAvailable() && workspaceMode === 'local';
+  const displayLoading = localActive ? workspaceLoading : loading;
+  const displayImages = localActive ? localImages : images;
   const { sources } = useSourceStore();
   const {
     isFullscreenMode,
@@ -78,7 +87,7 @@ export const AppMain: React.FC<AppMainProps> = ({
           onSearchChange={searchContext.setSearchQuery}
           variant="header"
           hasConfig={hasConfig}
-          images={images}
+          images={displayImages}
           externalFilters={searchContext.filters}
           onFiltersChange={searchContext.setFilters}
           showFilter={true}
@@ -114,7 +123,7 @@ export const AppMain: React.FC<AppMainProps> = ({
                 <UploadButton
                   onUploadImage={onUploadImage}
                   onUploadMultipleImages={onUploadMultipleImages}
-                  loading={loading}
+                  loading={displayLoading}
                   batchUploadProgress={batchUploadProgress}
                   t={t}
                 />
@@ -122,7 +131,7 @@ export const AppMain: React.FC<AppMainProps> = ({
               {hasConfig && (
                 <RefreshButton
                   onRefresh={onLoadImages}
-                  loading={loading}
+                  loading={displayLoading}
                   disabled={!hasConfig}
                   t={t}
                 />

--- a/apps/pixuli/src/layouts/MainLayout.tsx
+++ b/apps/pixuli/src/layouts/MainLayout.tsx
@@ -33,6 +33,8 @@ import { useI18n } from '../i18n/useI18n';
 import { useImageStore } from '../stores/imageStore';
 import { useSourceStore } from '../stores/sourceStore';
 import { useUIStore } from '../stores/uiStore';
+import { useWorkspaceStore } from '../stores/workspaceStore';
+import { isDesktopWorkspaceAvailable } from '../platforms/desktop/workspaceAdapter';
 import { listStoragePluginManifests } from '../storage/registry';
 import { getPlatform, isNativeMobile } from '../utils/platform';
 import {
@@ -84,6 +86,11 @@ export const MainLayout: React.FC<MainLayoutProps> = ({
 }) => {
   const { t } = useI18n();
   const { loading, storageType, githubConfig, giteeConfig } = useImageStore();
+  const workspaceMode = useWorkspaceStore(state => state.mode);
+  const workspaceLoading = useWorkspaceStore(state => state.loading);
+  const localActive =
+    isDesktopWorkspaceAvailable() && workspaceMode === 'local';
+  const showGlobalLoading = localActive ? workspaceLoading : loading;
   const sources = useSourceStore(state => state.sources);
   const { isDemoMode } = useDemoMode();
   const platform = getPlatform();
@@ -234,8 +241,8 @@ export const MainLayout: React.FC<MainLayoutProps> = ({
       <Toaster />
 
       <FullScreenLoading
-        visible={loading}
-        text={loading ? t('app.loadingImages') : undefined}
+        visible={showGlobalLoading}
+        text={showGlobalLoading ? t('app.loadingImages') : undefined}
       />
 
       {typeof __IS_WEB__ !== 'undefined' && __IS_WEB__ && !isNativeMobile() && (

--- a/apps/pixuli/src/layouts/Sidebar.tsx
+++ b/apps/pixuli/src/layouts/Sidebar.tsx
@@ -8,7 +8,9 @@ import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMobileViewport } from '../hooks/useMobileViewport';
 import { ROUTES } from '../router/routes';
+import { isDesktopWorkspaceAvailable } from '../platforms/desktop/workspaceAdapter';
 import { useUIStore } from '../stores/uiStore';
+import { useWorkspaceStore } from '../stores/workspaceStore';
 
 interface SidebarProps {
   sidebarSources: any[];
@@ -33,6 +35,10 @@ export const Sidebar: React.FC<SidebarProps> = ({
 }) => {
   const navigate = useNavigate();
   const isMobile = useMobileViewport();
+  const workspaceMode = useWorkspaceStore(state => state.mode);
+  const displayName = useWorkspaceStore(state => state.displayName);
+  const showWorkspaceHint =
+    isDesktopWorkspaceAvailable() && workspaceMode === 'local';
   const {
     activeMenu,
     sidebarCollapsed,
@@ -108,21 +114,36 @@ export const Sidebar: React.FC<SidebarProps> = ({
   }
 
   return (
-    <CommonSidebar
-      onMenuClick={handleMenuClick}
-      activeMenu={activeMenu}
-      sources={sidebarSources}
-      selectedSourceId={selectedSourceId}
-      onSourceSelect={handleSourceSelect}
-      onSourceEdit={onSourceEdit}
-      onSourceDelete={onSourceDelete}
-      hasConfig={hasConfig}
-      onAddSource={handleAddSource}
-      collapsed={isMobile ? false : sidebarCollapsed}
-      onToggleCollapse={isMobile ? undefined : toggleSidebar}
-      mobileOpen={isMobile && mobileSidebarOpen}
-      onMobileClose={closeMobileSidebar}
-      t={t}
-    />
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <CommonSidebar
+          onMenuClick={handleMenuClick}
+          activeMenu={activeMenu}
+          sources={sidebarSources}
+          selectedSourceId={selectedSourceId}
+          onSourceSelect={handleSourceSelect}
+          onSourceEdit={onSourceEdit}
+          onSourceDelete={onSourceDelete}
+          hasConfig={hasConfig}
+          onAddSource={handleAddSource}
+          collapsed={isMobile ? false : sidebarCollapsed}
+          onToggleCollapse={isMobile ? undefined : toggleSidebar}
+          mobileOpen={isMobile && mobileSidebarOpen}
+          onMobileClose={closeMobileSidebar}
+          t={t}
+        />
+      </div>
+      {showWorkspaceHint && (
+        <div
+          className="border-t border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400"
+          title={displayName ?? undefined}
+        >
+          <span className="font-medium">{t('workspace.current')}:</span>{' '}
+          <span className="truncate">
+            {displayName || t('workspace.unnamed')}
+          </span>
+        </div>
+      )}
+    </div>
   );
 };

--- a/apps/pixuli/src/pages/photos/index.tsx
+++ b/apps/pixuli/src/pages/photos/index.tsx
@@ -1,9 +1,12 @@
 import { useSearchContextSafe } from '@/contexts/SearchContext';
 import { ImageContent } from '@/features/image-content/ImageContent';
+import { WorkspaceSetupPanel, WorkspaceToolbar } from '@/features/workspace';
 import { useImageOperations } from '@/hooks/useImageOperations';
 import { useI18n } from '@/i18n/useI18n';
+import { isDesktopWorkspaceAvailable } from '@/platforms/desktop/workspaceAdapter';
 import { useImageStore } from '@/stores/imageStore';
 import { useSourceStore } from '@/stores/sourceStore';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { createDefaultFilters, filterImages } from '@pixuli/core/utils';
 import React, { useEffect, useMemo, useRef } from 'react';
 
@@ -15,21 +18,36 @@ export const PhotosPage: React.FC<PhotosPageProps> = ({
   onOpenConfigModal,
 }) => {
   const { t } = useI18n();
-  const { images, loading, error, clearError } = useImageStore();
+  const remoteImages = useImageStore(state => state.images);
+  const remoteLoading = useImageStore(state => state.loading);
+  const remoteError = useImageStore(state => state.error);
+  const clearRemoteError = useImageStore(state => state.clearError);
   const { sources } = useSourceStore();
+  const workspaceMode = useWorkspaceStore(state => state.mode);
+  const localImages = useWorkspaceStore(state => state.localImages);
+  const workspaceLoading = useWorkspaceStore(state => state.loading);
+  const workspaceError = useWorkspaceStore(state => state.error);
+  const clearWorkspaceError = useWorkspaceStore(state => state.clearError);
+  const softDeleteLocal = useWorkspaceStore(state => state.softDeleteLocal);
   const { handleDeleteImage, handleDeleteMultipleImages, handleUpdateImage } =
     useImageOperations();
   const searchContext = useSearchContextSafe();
   const searchContextRef = useRef(searchContext);
 
-  // 更新 ref 以保持最新值
+  const desktopWorkspace = isDesktopWorkspaceAvailable();
+  const localActive = desktopWorkspace && workspaceMode === 'local';
+  const needsSetup = desktopWorkspace && workspaceMode === 'unset';
+
+  const images = localActive ? localImages : remoteImages;
+  const loading = localActive ? workspaceLoading : remoteLoading;
+  const error = localActive ? workspaceError : remoteError;
+  const clearError = localActive ? clearWorkspaceError : clearRemoteError;
+  const hasConfig = localActive ? true : sources.length > 0;
+
   useEffect(() => {
     searchContextRef.current = searchContext;
   }, [searchContext]);
 
-  const hasConfig = sources.length > 0;
-
-  // 页面加载时显示搜索框
   useEffect(() => {
     if (searchContextRef.current) {
       searchContextRef.current.setShowSearch(true);
@@ -41,7 +59,6 @@ export const PhotosPage: React.FC<PhotosPageProps> = ({
     }
   }, []);
 
-  // 同步搜索查询到筛选条件
   const searchQuery = searchContext?.searchQuery ?? '';
   const setFiltersRef = useRef(searchContext?.setFilters);
 
@@ -54,7 +71,6 @@ export const PhotosPage: React.FC<PhotosPageProps> = ({
 
     const currentQuery = searchQuery;
     setFiltersRef.current(prev => {
-      // 只有当 searchTerm 不同时才更新，避免无限循环
       if (prev.searchTerm === currentQuery) {
         return prev;
       }
@@ -65,7 +81,6 @@ export const PhotosPage: React.FC<PhotosPageProps> = ({
     });
   }, [searchQuery]);
 
-  // 计算筛选后的图片
   const filteredImages = useMemo(() => {
     if (!searchContext) {
       return filterImages(images, createDefaultFilters());
@@ -73,18 +88,57 @@ export const PhotosPage: React.FC<PhotosPageProps> = ({
     return filterImages(images, searchContext.filters);
   }, [images, searchContext]);
 
+  const onDeleteImage = async (imageId: string, fileName: string) => {
+    if (localActive) {
+      const target = images.find(img => img.id === imageId);
+      if (target?.localPath) {
+        await softDeleteLocal(target.localPath);
+      }
+      return;
+    }
+    await handleDeleteImage(imageId, fileName);
+  };
+
+  const onDeleteMultipleImages = async (
+    imageIds: string[],
+    fileNames: string[],
+  ) => {
+    if (localActive) {
+      for (const id of imageIds) {
+        const target = images.find(img => img.id === id);
+        if (target?.localPath) {
+          await softDeleteLocal(target.localPath);
+        }
+      }
+      return;
+    }
+    await handleDeleteMultipleImages(imageIds, fileNames);
+  };
+
+  if (needsSetup) {
+    return (
+      <div className="photos-page h-full flex flex-col overflow-hidden">
+        <WorkspaceSetupPanel />
+      </div>
+    );
+  }
+
   return (
     <div className="photos-page h-full flex flex-col overflow-hidden">
-      {/* 图片内容 */}
       <div className="flex-1 overflow-y-auto">
+        {localActive && (
+          <div className="px-4 pt-4 sm:px-6 lg:px-8">
+            <WorkspaceToolbar />
+          </div>
+        )}
         <ImageContent
           hasConfig={hasConfig}
           error={error}
           onClearError={clearError}
           images={filteredImages}
           loading={loading}
-          onDeleteImage={handleDeleteImage}
-          onDeleteMultipleImages={handleDeleteMultipleImages}
+          onDeleteImage={onDeleteImage}
+          onDeleteMultipleImages={onDeleteMultipleImages}
           onUpdateImage={handleUpdateImage}
           onOpenConfigModal={onOpenConfigModal}
           t={t}

--- a/apps/pixuli/src/platforms/desktop/workspaceAdapter.ts
+++ b/apps/pixuli/src/platforms/desktop/workspaceAdapter.ts
@@ -1,0 +1,69 @@
+import type { WorkspaceAdapter } from '@pixuli/core/vault';
+
+function assertWorkspaceAPI(): WorkspaceAPI {
+  if (typeof window === 'undefined' || !window.workspaceAPI) {
+    throw new Error('workspaceAPI is only available in Electron Desktop');
+  }
+  return window.workspaceAPI;
+}
+
+export class DesktopWorkspaceAdapter implements WorkspaceAdapter {
+  readonly kind = 'desktop' as const;
+  private rootPath: string | null = null;
+
+  isReady(): boolean {
+    return Boolean(this.rootPath);
+  }
+
+  getRootPath(): string | null {
+    return this.rootPath;
+  }
+
+  setRootPath(rootPath: string | null): void {
+    this.rootPath = rootPath;
+  }
+
+  async pickRoot(): Promise<boolean> {
+    const api = assertWorkspaceAPI();
+    const result = await api.pickRoot();
+    if (result.ok && result.rootPath) {
+      this.rootPath = result.rootPath;
+      return true;
+    }
+    return false;
+  }
+
+  async readFile(relativePath: string): Promise<Uint8Array> {
+    return assertWorkspaceAPI().readFile(relativePath);
+  }
+
+  async writeFile(relativePath: string, data: Uint8Array): Promise<void> {
+    await assertWorkspaceAPI().writeFile(relativePath, data);
+  }
+
+  async deleteFile(relativePath: string): Promise<void> {
+    await assertWorkspaceAPI().deleteFile(relativePath);
+  }
+
+  async listFiles(
+    relativeDir: string,
+    options?: { recursive?: boolean },
+  ): Promise<string[]> {
+    return assertWorkspaceAPI().listFiles(
+      relativeDir,
+      options?.recursive ?? false,
+    );
+  }
+
+  async exists(relativePath: string): Promise<boolean> {
+    return assertWorkspaceAPI().exists(relativePath);
+  }
+}
+
+export function createDesktopWorkspaceAdapter(): DesktopWorkspaceAdapter {
+  return new DesktopWorkspaceAdapter();
+}
+
+export function isDesktopWorkspaceAvailable(): boolean {
+  return typeof window !== 'undefined' && Boolean(window.workspaceAPI);
+}

--- a/apps/pixuli/src/stores/workspaceStore.ts
+++ b/apps/pixuli/src/stores/workspaceStore.ts
@@ -1,0 +1,352 @@
+import {
+  createConfiguredStorageProvider,
+  type StoragePluginId,
+} from '@/storage/createProvider';
+import { useSourceStore } from '@/stores/sourceStore';
+import { DefaultPlatformAdapter } from '@pixuli/core/platform';
+import type { ImageItem, ImageUploadData } from '@pixuli/core/types';
+import {
+  createLocalVault,
+  type LocalVault,
+  type WorkspaceMode,
+} from '@pixuli/core/vault';
+import { getUploadFileName } from '@pixuli/core/types';
+import { create } from 'zustand';
+import {
+  clearLocalPreviewCache,
+  mapEntriesToImageItems,
+} from '../features/workspace/localImageMapper';
+import {
+  createDesktopWorkspaceAdapter,
+  DesktopWorkspaceAdapter,
+  isDesktopWorkspaceAvailable,
+} from '../platforms/desktop/workspaceAdapter';
+
+const WORKSPACE_STORAGE_KEY = 'pixuli.workspace.v1';
+
+interface WorkspacePersist {
+  rootPath: string;
+  workspaceId: string;
+}
+
+interface WorkspaceState {
+  mode: WorkspaceMode;
+  rootPath: string | null;
+  displayName: string | null;
+  localImages: ImageItem[];
+  loading: boolean;
+  pushing: boolean;
+  error: string | null;
+  syncMessage: string | null;
+  isLocalActive: () => boolean;
+  initialize: () => Promise<void>;
+  pickWorkspace: () => Promise<boolean>;
+  refreshLocalImages: () => Promise<void>;
+  importLocalImage: (uploadData: ImageUploadData) => Promise<void>;
+  pushPendingToRemote: () => Promise<void>;
+  softDeleteLocal: (relativePath: string) => Promise<void>;
+  clearError: () => void;
+}
+
+let vaultInstance: LocalVault | null = null;
+let adapterInstance: DesktopWorkspaceAdapter | null = null;
+
+function getAdapter(): DesktopWorkspaceAdapter {
+  if (!adapterInstance) {
+    adapterInstance = createDesktopWorkspaceAdapter();
+  }
+  return adapterInstance;
+}
+
+function getVault(): LocalVault {
+  if (!vaultInstance) {
+    vaultInstance = createLocalVault(getAdapter());
+  }
+  return vaultInstance;
+}
+
+function loadPersistedWorkspace(): WorkspacePersist | null {
+  try {
+    const raw = localStorage.getItem(WORKSPACE_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as WorkspacePersist;
+    if (parsed?.rootPath) {
+      return parsed;
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+function savePersistedWorkspace(rootPath: string, workspaceId: string): void {
+  try {
+    localStorage.setItem(
+      WORKSPACE_STORAGE_KEY,
+      JSON.stringify({ rootPath, workspaceId }),
+    );
+  } catch {
+    // ignore
+  }
+}
+
+function sanitizeFileName(name: string): string {
+  return name.replace(/[/\\?%*:|"<>]/g, '_');
+}
+
+async function openVaultWithRoot(rootPath: string): Promise<LocalVault> {
+  const adapter = getAdapter();
+  adapter.setRootPath(rootPath);
+  if (window.workspaceAPI) {
+    await window.workspaceAPI.setRoot(rootPath);
+  }
+  const vault = getVault();
+  await vault.open();
+  return vault;
+}
+
+export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
+  mode: 'unset',
+  rootPath: null,
+  displayName: null,
+  localImages: [],
+  loading: false,
+  pushing: false,
+  error: null,
+  syncMessage: null,
+
+  isLocalActive: () => {
+    return isDesktopWorkspaceAvailable() && get().mode === 'local';
+  },
+
+  initialize: async () => {
+    if (!isDesktopWorkspaceAvailable()) {
+      set({ mode: 'remote-only' });
+      return;
+    }
+
+    const persisted = loadPersistedWorkspace();
+    if (!persisted?.rootPath) {
+      set({ mode: 'unset' });
+      return;
+    }
+
+    set({ loading: true, error: null });
+    try {
+      const vault = await openVaultWithRoot(persisted.rootPath);
+      const config = vault.getConfig();
+      savePersistedWorkspace(persisted.rootPath, config.workspaceId);
+      set({
+        mode: 'local',
+        rootPath: persisted.rootPath,
+        displayName: config.displayName,
+        loading: false,
+      });
+      await get().refreshLocalImages();
+    } catch (error) {
+      set({
+        mode: 'unset',
+        loading: false,
+        error: error instanceof Error ? error.message : '工作区初始化失败',
+      });
+    }
+  },
+
+  pickWorkspace: async () => {
+    if (!isDesktopWorkspaceAvailable()) {
+      return false;
+    }
+
+    set({ loading: true, error: null });
+    try {
+      clearLocalPreviewCache();
+      vaultInstance = null;
+      const adapter = getAdapter();
+      const picked = await adapter.pickRoot();
+      if (!picked || !adapter.getRootPath()) {
+        set({ loading: false });
+        return false;
+      }
+
+      const rootPath = adapter.getRootPath()!;
+      const vault = await openVaultWithRoot(rootPath);
+      const config = vault.getConfig();
+      savePersistedWorkspace(rootPath, config.workspaceId);
+
+      set({
+        mode: 'local',
+        rootPath,
+        displayName: config.displayName,
+        loading: false,
+        syncMessage: null,
+      });
+      await get().refreshLocalImages();
+      return true;
+    } catch (error) {
+      set({
+        loading: false,
+        error: error instanceof Error ? error.message : '选择工作区失败',
+      });
+      return false;
+    }
+  },
+
+  refreshLocalImages: async () => {
+    if (get().mode !== 'local') {
+      return;
+    }
+
+    set({ loading: true, error: null });
+    try {
+      const vault = getVault();
+      const entries = await vault.list();
+      const provider = resolveSelectedProvider();
+      const images = await mapEntriesToImageItems(entries, provider);
+      set({ localImages: images, loading: false });
+    } catch (error) {
+      set({
+        loading: false,
+        error: error instanceof Error ? error.message : '加载本地图片失败',
+      });
+    }
+  },
+
+  importLocalImage: async uploadData => {
+    if (get().mode !== 'local') {
+      set({ error: '请先选择本地工作区' });
+      return;
+    }
+
+    set({ loading: true, error: null });
+    try {
+      const fileName = sanitizeFileName(
+        getUploadFileName(uploadData.file, uploadData.name),
+      );
+      const targetPath = `images/${Date.now()}-${fileName}`;
+      const platform = new DefaultPlatformAdapter();
+      const dimensions = await platform.getImageDimensions(uploadData.file);
+
+      const vault = getVault();
+      await vault.importFile(uploadData.file, targetPath, {
+        name: uploadData.name ?? fileName,
+        tags: uploadData.tags ?? [],
+        description: uploadData.description,
+        width: dimensions.width,
+        height: dimensions.height,
+        syncState: 'local-only',
+      });
+
+      await get().refreshLocalImages();
+      set({ loading: false, syncMessage: '已保存到本地工作区' });
+    } catch (error) {
+      set({
+        loading: false,
+        error: error instanceof Error ? error.message : '保存到本地工作区失败',
+      });
+    }
+  },
+
+  pushPendingToRemote: async () => {
+    if (get().mode !== 'local') {
+      set({ error: '请先选择本地工作区' });
+      return;
+    }
+
+    const provider = resolveSelectedProvider();
+    if (!provider) {
+      set({ error: '请先添加并选择 GitHub/Gitee 远端源' });
+      return;
+    }
+
+    set({ pushing: true, error: null, syncMessage: null });
+    try {
+      const vault = getVault();
+      const entries = await vault.list();
+      const pending = entries.filter(
+        e => e.syncState === 'local-only' || e.syncState === 'pending-push',
+      );
+
+      if (pending.length === 0) {
+        set({ pushing: false, syncMessage: '没有待推送的本地图片' });
+        return;
+      }
+
+      let pushed = 0;
+      const source = resolveSelectedSource();
+      for (const entry of pending) {
+        const bytes = await getAdapter().readFile(entry.relativePath);
+        const file = new File([Uint8Array.from(bytes)], entry.name, {
+          type: entry.mimeType,
+        });
+
+        await provider.uploadImage({
+          file,
+          name: entry.name,
+          tags: entry.tags,
+          description: entry.description,
+        });
+
+        await vault.updateSyncMeta(entry.relativePath, {
+          syncState: 'synced',
+          remotePath: entry.name,
+          bindingId: source?.id,
+        });
+        pushed += 1;
+      }
+
+      await get().refreshLocalImages();
+      set({
+        pushing: false,
+        syncMessage: `已推送 ${pushed} 张图片到远端`,
+      });
+    } catch (error) {
+      set({
+        pushing: false,
+        error: error instanceof Error ? error.message : '推送到远端失败',
+      });
+    }
+  },
+
+  softDeleteLocal: async relativePath => {
+    if (get().mode !== 'local') {
+      return;
+    }
+    set({ loading: true, error: null });
+    try {
+      await getVault().softDelete(relativePath);
+      await get().refreshLocalImages();
+      set({ loading: false });
+    } catch (error) {
+      set({
+        loading: false,
+        error: error instanceof Error ? error.message : '删除失败',
+      });
+    }
+  },
+
+  clearError: () => set({ error: null }),
+}));
+
+function resolveSelectedSource() {
+  const { selectedSourceId, sources, getSourceById } =
+    useSourceStore.getState();
+  if (selectedSourceId) {
+    return getSourceById(selectedSourceId) ?? null;
+  }
+  return sources[0] ?? null;
+}
+
+function resolveSelectedProvider() {
+  const source = resolveSelectedSource();
+  if (!source) {
+    return null;
+  }
+  try {
+    return createConfiguredStorageProvider(
+      source.pluginId as StoragePluginId,
+      source.config as never,
+    );
+  } catch {
+    return null;
+  }
+}

--- a/apps/pixuli/src/types/workspace-api.d.ts
+++ b/apps/pixuli/src/types/workspace-api.d.ts
@@ -1,0 +1,22 @@
+interface WorkspacePickResult {
+  ok: boolean;
+  rootPath: string | null;
+}
+
+interface WorkspaceAPI {
+  getRoot: () => Promise<{ rootPath: string | null }>;
+  pickRoot: () => Promise<WorkspacePickResult>;
+  setRoot: (rootPath: string) => Promise<{ ok: boolean; rootPath?: string }>;
+  readFile: (relativePath: string) => Promise<Uint8Array>;
+  writeFile: (relativePath: string, data: Uint8Array) => Promise<{ ok: boolean }>;
+  deleteFile: (relativePath: string) => Promise<{ ok: boolean }>;
+  listFiles: (
+    relativeDir: string,
+    recursive?: boolean,
+  ) => Promise<string[]>;
+  exists: (relativePath: string) => Promise<boolean>;
+}
+
+interface Window {
+  workspaceAPI?: WorkspaceAPI;
+}

--- a/packages/core/src/vault/__tests__/localVault.test.ts
+++ b/packages/core/src/vault/__tests__/localVault.test.ts
@@ -77,6 +77,31 @@ describe('createLocalVault', () => {
     expect((await vault.list({ includeDeleted: true })).length).toBe(1);
   });
 
+  it('updateSyncMeta updates sync fields', async () => {
+    const adapter = new MemoryWorkspaceAdapter();
+    const vault = createLocalVault(adapter);
+    await vault.open();
+
+    const file = new File([new Uint8Array([1])], 'a.jpg', {
+      type: 'image/jpeg',
+    });
+    await vault.importFile(file, 'images/a.jpg');
+
+    const updated = await vault.updateSyncMeta('images/a.jpg', {
+      syncState: 'synced',
+      remotePath: 'a.jpg',
+      bindingId: 'source-1',
+    });
+
+    expect(updated.syncState).toBe('synced');
+    expect(updated.remotePath).toBe('a.jpg');
+    expect(updated.bindingId).toBe('source-1');
+
+    const listed = await vault.list();
+    expect(listed[0].syncState).toBe('synced');
+    expect(listed[0].remotePath).toBe('a.jpg');
+  });
+
   it('scan discovers files under images/', async () => {
     const adapter = new MemoryWorkspaceAdapter();
     const vault = createLocalVault(adapter);

--- a/packages/core/src/vault/localVault.ts
+++ b/packages/core/src/vault/localVault.ts
@@ -198,6 +198,16 @@ export function createLocalVault(adapter: WorkspaceAdapter): LocalVault {
       }
       return count;
     },
+
+    async updateSyncMeta(relativePath, patch) {
+      const entry = index.find(item => item.relativePath === relativePath);
+      if (!entry || entry.deletedAt) {
+        throw new Error(`Image not found: ${relativePath}`);
+      }
+      Object.assign(entry, patch, { updatedAt: nowIso() });
+      await persistIndex();
+      return { ...entry };
+    },
   };
 
   return vault;

--- a/packages/core/src/vault/types.ts
+++ b/packages/core/src/vault/types.ts
@@ -83,6 +83,12 @@ export interface LocalVault {
   ): Promise<LocalImageIndexEntry>;
   softDelete(relativePath: string): Promise<void>;
   scan(): Promise<number>;
+  updateSyncMeta(
+    relativePath: string,
+    patch: Partial<
+      Pick<LocalImageIndexEntry, 'syncState' | 'remotePath' | 'bindingId'>
+    >,
+  ): Promise<LocalImageIndexEntry>;
 }
 
 export type SyncDirection = 'push' | 'pull' | 'both';


### PR DESCRIPTION
## Summary

- 在 Electron Desktop 落地 `workspaceIpc`（选目录、read/write/list），Renderer 通过 `window.workspaceAPI` 访问本地文件，不直接操作 `fs`
- 新增 `DesktopWorkspaceAdapter`、`workspaceStore` 与薄 UI：首次选目录、`LocalVault.list()` 本地列表、blob 预览、手动 `syncPush` 到 GitHub/Gitee
- Core 补充 `LocalVault.updateSyncMeta` 及单测，供推送后更新同步元数据

Closes #157

## Test plan

- [ ] `pnpm --filter @pixuli/core test` 通过
- [ ] `pnpm dev:desktop` 启动 Desktop
- [ ] 照片页选择本地工作区目录，确认 `images/` 与索引初始化
- [ ] 上传单张图片，列表以 blob 预览显示
- [ ] 配置 GitHub/Gitee 远端源后，点击「推送到远端」，远端仓库可见该图片
- [ ] 侧栏底部显示当前工作区名称


Made with [Cursor](https://cursor.com)