### PR TITLE
feat(sync): REF-607-P3 索引与 pull SyncEngine MVP (#158)

### DIFF
--- a/apps/pixuli/src/features/workspace/WorkspacePanel.tsx
+++ b/apps/pixuli/src/features/workspace/WorkspacePanel.tsx
@@ -1,8 +1,28 @@
 import React from 'react';
-import { FolderOpen, UploadCloud } from 'lucide-react';
+import {
+  DownloadCloud,
+  FolderOpen,
+  RefreshCw,
+  ScanSearch,
+  UploadCloud,
+} from 'lucide-react';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useSourceStore } from '@/stores/sourceStore';
 import { useI18n } from '@/i18n/useI18n';
+
+function formatSyncTime(
+  iso: string | null | undefined,
+  t: (key: string) => string,
+) {
+  if (!iso) {
+    return t('workspace.syncNever');
+  }
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
 
 export const WorkspaceSetupPanel: React.FC = () => {
   const { t } = useI18n();
@@ -41,13 +61,19 @@ export const WorkspaceToolbar: React.FC = () => {
     displayName,
     rootPath,
     pushing,
+    syncing,
+    syncStatus,
     syncMessage,
     error,
     pushPendingToRemote,
+    pullFromRemote,
+    runSync,
+    scanWorkspace,
     clearError,
   } = useWorkspaceStore();
   const sources = useSourceStore(state => state.sources);
   const hasRemote = sources.length > 0;
+  const busy = pushing || syncing;
 
   return (
     <div className="mb-4 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
@@ -61,17 +87,68 @@ export const WorkspaceToolbar: React.FC = () => {
               {rootPath}
             </p>
           )}
+          <div className="mt-2 flex flex-wrap gap-2">
+            <span className="inline-flex items-center rounded-full bg-white px-2 py-0.5 text-xs text-gray-700 border border-gray-200">
+              {t('workspace.lastSync')}:{' '}
+              {formatSyncTime(syncStatus?.lastSyncAt, t)}
+            </span>
+            {(syncStatus?.pendingPush ?? 0) > 0 && (
+              <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-800">
+                {t('workspace.pendingPush', {
+                  count: syncStatus?.pendingPush ?? 0,
+                })}
+              </span>
+            )}
+            {(syncStatus?.conflicts ?? 0) > 0 && (
+              <span className="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-xs text-red-800">
+                {t('workspace.conflicts', {
+                  count: syncStatus?.conflicts ?? 0,
+                })}
+              </span>
+            )}
+          </div>
         </div>
-        <button
-          type="button"
-          onClick={() => void pushPendingToRemote()}
-          disabled={pushing || !hasRemote}
-          title={hasRemote ? undefined : t('workspace.pushNeedsRemote')}
-          className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-800 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          <UploadCloud size={16} />
-          {pushing ? t('workspace.pushing') : t('workspace.pushManual')}
-        </button>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void scanWorkspace()}
+            disabled={busy}
+            className="inline-flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50"
+          >
+            <ScanSearch size={16} />
+            {t('workspace.scan')}
+          </button>
+          <button
+            type="button"
+            onClick={() => void pullFromRemote()}
+            disabled={busy || !hasRemote}
+            title={hasRemote ? undefined : t('workspace.pullNeedsRemote')}
+            className="inline-flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-800 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <DownloadCloud size={16} />
+            {syncing ? t('workspace.pulling') : t('workspace.pullManual')}
+          </button>
+          <button
+            type="button"
+            onClick={() => void pushPendingToRemote()}
+            disabled={busy || !hasRemote}
+            title={hasRemote ? undefined : t('workspace.pushNeedsRemote')}
+            className="inline-flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-800 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <UploadCloud size={16} />
+            {pushing ? t('workspace.pushing') : t('workspace.pushManual')}
+          </button>
+          <button
+            type="button"
+            onClick={() => void runSync('both')}
+            disabled={busy || !hasRemote}
+            title={hasRemote ? undefined : t('workspace.syncNeedsRemote')}
+            className="inline-flex items-center gap-1.5 rounded-md border border-blue-300 bg-blue-50 px-3 py-1.5 text-sm text-blue-800 hover:bg-blue-100 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <RefreshCw size={16} />
+            {syncing ? t('workspace.syncing') : t('workspace.syncBoth')}
+          </button>
+        </div>
       </div>
       {syncMessage && (
         <p className="mt-2 text-xs text-green-700">{syncMessage}</p>

--- a/apps/pixuli/src/i18n/locales/en-US.json
+++ b/apps/pixuli/src/i18n/locales/en-US.json
@@ -79,6 +79,17 @@
     "pushManual": "Push to remote",
     "pushing": "Pushing…",
     "pushNeedsRemote": "Add a GitHub or Gitee remote source to push",
+    "pullNeedsRemote": "Add a GitHub or Gitee remote source to pull",
+    "syncNeedsRemote": "Add a GitHub or Gitee remote source to sync",
+    "pullManual": "Pull from remote",
+    "pulling": "Pulling…",
+    "syncBoth": "Sync both ways",
+    "syncing": "Syncing…",
+    "scan": "Scan index",
+    "lastSync": "Last sync",
+    "syncNever": "Never synced",
+    "pendingPush": "Pending push {{count}}",
+    "conflicts": "Conflicts {{count}}",
     "dismiss": "Dismiss"
   }
 }

--- a/apps/pixuli/src/i18n/locales/zh-CN.json
+++ b/apps/pixuli/src/i18n/locales/zh-CN.json
@@ -79,6 +79,17 @@
     "pushManual": "推送到远端",
     "pushing": "推送中…",
     "pushNeedsRemote": "请先添加 GitHub 或 Gitee 远端源以推送",
+    "pullNeedsRemote": "请先添加 GitHub 或 Gitee 远端源以拉取",
+    "syncNeedsRemote": "请先添加 GitHub 或 Gitee 远端源以同步",
+    "pullManual": "从远端拉取",
+    "pulling": "拉取中…",
+    "syncBoth": "双向同步",
+    "syncing": "同步中…",
+    "scan": "扫描索引",
+    "lastSync": "上次同步",
+    "syncNever": "从未同步",
+    "pendingPush": "待推送 {{count}}",
+    "conflicts": "冲突 {{count}}",
     "dismiss": "关闭"
   }
 }

--- a/apps/pixuli/src/stores/workspaceStore.ts
+++ b/apps/pixuli/src/stores/workspaceStore.ts
@@ -7,7 +7,11 @@ import { DefaultPlatformAdapter } from '@pixuli/core/platform';
 import type { ImageItem, ImageUploadData } from '@pixuli/core/types';
 import {
   createLocalVault,
+  createSyncEngine,
+  providerSupportsSync,
   type LocalVault,
+  type SyncEngine,
+  type SyncStatusSummary,
   type WorkspaceMode,
 } from '@pixuli/core/vault';
 import { getUploadFileName } from '@pixuli/core/types';
@@ -36,19 +40,26 @@ interface WorkspaceState {
   localImages: ImageItem[];
   loading: boolean;
   pushing: boolean;
+  syncing: boolean;
+  syncStatus: SyncStatusSummary | null;
   error: string | null;
   syncMessage: string | null;
   isLocalActive: () => boolean;
   initialize: () => Promise<void>;
   pickWorkspace: () => Promise<boolean>;
   refreshLocalImages: () => Promise<void>;
+  refreshSyncStatus: () => Promise<void>;
+  scanWorkspace: () => Promise<void>;
   importLocalImage: (uploadData: ImageUploadData) => Promise<void>;
   pushPendingToRemote: () => Promise<void>;
+  pullFromRemote: () => Promise<void>;
+  runSync: (direction?: 'push' | 'pull' | 'both') => Promise<void>;
   softDeleteLocal: (relativePath: string) => Promise<void>;
   clearError: () => void;
 }
 
 let vaultInstance: LocalVault | null = null;
+let syncEngineInstance: SyncEngine | null = null;
 let adapterInstance: DesktopWorkspaceAdapter | null = null;
 
 function getAdapter(): DesktopWorkspaceAdapter {
@@ -63,6 +74,30 @@ function getVault(): LocalVault {
     vaultInstance = createLocalVault(getAdapter());
   }
   return vaultInstance;
+}
+
+function getSyncEngine(): SyncEngine {
+  if (!syncEngineInstance) {
+    syncEngineInstance = createSyncEngine({
+      vault: getVault(),
+      getBindings: () => {
+        const source = resolveSelectedSource();
+        const provider = resolveSelectedProvider();
+        if (!source || !provider || !providerSupportsSync(provider)) {
+          return [];
+        }
+        return [{ bindingId: source.id, provider }];
+      },
+      readFileBytes: relativePath => getAdapter().readFile(relativePath),
+    });
+  }
+  return syncEngineInstance;
+}
+
+function resetWorkspaceRuntime(): void {
+  clearLocalPreviewCache();
+  vaultInstance = null;
+  syncEngineInstance = null;
 }
 
 function loadPersistedWorkspace(): WorkspacePersist | null {
@@ -112,6 +147,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   localImages: [],
   loading: false,
   pushing: false,
+  syncing: false,
+  syncStatus: null,
   error: null,
   syncMessage: null,
 
@@ -143,6 +180,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         loading: false,
       });
       await get().refreshLocalImages();
+      await get().refreshSyncStatus();
     } catch (error) {
       set({
         mode: 'unset',
@@ -159,8 +197,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
 
     set({ loading: true, error: null });
     try {
-      clearLocalPreviewCache();
-      vaultInstance = null;
+      resetWorkspaceRuntime();
       const adapter = getAdapter();
       const picked = await adapter.pickRoot();
       if (!picked || !adapter.getRootPath()) {
@@ -181,6 +218,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         syncMessage: null,
       });
       await get().refreshLocalImages();
+      await get().refreshSyncStatus();
       return true;
     } catch (error) {
       set({
@@ -211,6 +249,40 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
   },
 
+  refreshSyncStatus: async () => {
+    if (get().mode !== 'local') {
+      return;
+    }
+    try {
+      const status = await getSyncEngine().getStatus();
+      set({ syncStatus: status });
+    } catch {
+      // ignore status refresh errors
+    }
+  },
+
+  scanWorkspace: async () => {
+    if (get().mode !== 'local') {
+      return;
+    }
+    set({ loading: true, error: null });
+    try {
+      const added = await getVault().scan();
+      await get().refreshLocalImages();
+      await get().refreshSyncStatus();
+      set({
+        loading: false,
+        syncMessage:
+          added > 0 ? `扫描完成，新增 ${added} 张图片` : '扫描完成，索引已更新',
+      });
+    } catch (error) {
+      set({
+        loading: false,
+        error: error instanceof Error ? error.message : '扫描工作区失败',
+      });
+    }
+  },
+
   importLocalImage: async uploadData => {
     if (get().mode !== 'local') {
       set({ error: '请先选择本地工作区' });
@@ -236,7 +308,13 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         syncState: 'local-only',
       });
 
+      await getSyncEngine().enqueuePush({
+        type: 'upload',
+        relativePath: targetPath,
+      });
+
       await get().refreshLocalImages();
+      await get().refreshSyncStatus();
       set({ loading: false, syncMessage: '已保存到本地工作区' });
     } catch (error) {
       set({
@@ -247,62 +325,84 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   },
 
   pushPendingToRemote: async () => {
+    await get().runSync('push');
+  },
+
+  pullFromRemote: async () => {
+    await get().runSync('pull');
+  },
+
+  runSync: async (direction = 'both') => {
     if (get().mode !== 'local') {
       set({ error: '请先选择本地工作区' });
       return;
     }
 
-    const provider = resolveSelectedProvider();
-    if (!provider) {
+    if (resolveSelectedProvider() === null) {
       set({ error: '请先添加并选择 GitHub/Gitee 远端源' });
       return;
     }
 
-    set({ pushing: true, error: null, syncMessage: null });
-    try {
-      const vault = getVault();
-      const entries = await vault.list();
-      const pending = entries.filter(
-        e => e.syncState === 'local-only' || e.syncState === 'pending-push',
+    if (direction === 'push') {
+      const entries = await getVault().list();
+      const hasPending = entries.some(
+        entry =>
+          !entry.deletedAt &&
+          (entry.syncState === 'local-only' ||
+            entry.syncState === 'pending-push'),
       );
+      const status = await getSyncEngine().getStatus();
+      if (!hasPending && status.pendingPush === 0) {
+        set({ syncMessage: '没有待推送的本地图片' });
+        return;
+      }
+    }
 
-      if (pending.length === 0) {
-        set({ pushing: false, syncMessage: '没有待推送的本地图片' });
+    set({
+      syncing: true,
+      pushing: direction === 'push' || direction === 'both',
+      error: null,
+      syncMessage: null,
+    });
+
+    try {
+      const result = await getSyncEngine().run({ direction });
+      await get().refreshLocalImages();
+      await get().refreshSyncStatus();
+
+      if (result.errors.length > 0) {
+        set({
+          syncing: false,
+          pushing: false,
+          error: result.errors.map(item => item.message).join('；'),
+        });
         return;
       }
 
-      let pushed = 0;
-      const source = resolveSelectedSource();
-      for (const entry of pending) {
-        const bytes = await getAdapter().readFile(entry.relativePath);
-        const file = new File([Uint8Array.from(bytes)], entry.name, {
-          type: entry.mimeType,
-        });
-
-        await provider.uploadImage({
-          file,
-          name: entry.name,
-          tags: entry.tags,
-          description: entry.description,
-        });
-
-        await vault.updateSyncMeta(entry.relativePath, {
-          syncState: 'synced',
-          remotePath: entry.name,
-          bindingId: source?.id,
-        });
-        pushed += 1;
+      const messages: string[] = [];
+      if (result.pushed > 0) {
+        messages.push(`已推送 ${result.pushed} 项`);
+      }
+      if (result.pulled > 0) {
+        messages.push(`已拉取 ${result.pulled} 项`);
+      }
+      if (result.conflicts.length > 0) {
+        messages.push(`${result.conflicts.length} 项冲突需手动处理`);
+      }
+      if (messages.length === 0) {
+        messages.push('同步完成，无变更');
       }
 
-      await get().refreshLocalImages();
       set({
+        syncing: false,
         pushing: false,
-        syncMessage: `已推送 ${pushed} 张图片到远端`,
+        syncMessage: messages.join('；'),
       });
     } catch (error) {
       set({
+        syncing: false,
         pushing: false,
-        error: error instanceof Error ? error.message : '推送到远端失败',
+        error: error instanceof Error ? error.message : '同步失败',
       });
     }
   },
@@ -314,7 +414,12 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     set({ loading: true, error: null });
     try {
       await getVault().softDelete(relativePath);
+      await getSyncEngine().enqueuePush({
+        type: 'delete',
+        relativePath,
+      });
       await get().refreshLocalImages();
+      await get().refreshSyncStatus();
       set({ loading: false });
     } catch (error) {
       set({

--- a/apps/pixuli/vite.config.ts
+++ b/apps/pixuli/vite.config.ts
@@ -141,6 +141,7 @@ export default defineConfig(({ command, mode }) => {
           input: 'electron/preload/index.ts',
           vite: {
             build: {
+              target: 'esnext',
               sourcemap: sourcemap ? 'inline' : undefined,
               minify: isBuild,
               outDir: 'dist-electron/preload',
@@ -148,6 +149,12 @@ export default defineConfig(({ command, mode }) => {
                 external: Object.keys(
                   'dependencies' in pkg ? pkg.dependencies : {},
                 ),
+                output: {
+                  // sandbox: false + nodeIntegration: false → ESM preload 可用 import / top-level await
+                  format: 'es',
+                  entryFileNames: 'index.mjs',
+                  inlineDynamicImports: true,
+                },
               },
             },
           },

--- a/packages/core/src/vault/__tests__/syncEngine.test.ts
+++ b/packages/core/src/vault/__tests__/syncEngine.test.ts
@@ -1,33 +1,157 @@
 import { describe, expect, it, vi } from 'vitest';
+import { createLocalVault } from '../localVault';
+import { MemoryWorkspaceAdapter } from '../memoryAdapter';
 import { createSyncEngine } from '../syncEngine';
+import type { StorageProvider } from '../../plugins/types';
+
+function createMockSyncProvider(
+  overrides: Partial<StorageProvider> = {},
+): StorageProvider {
+  return {
+    manifest: {
+      id: 'mock',
+      name: 'Mock',
+      version: '1.0.0',
+      capabilities: { list: true, upload: true, delete: true, sync: true },
+    },
+    configure: () => undefined,
+    listImages: async () => [],
+    uploadImage: async () => {
+      throw new Error('not used');
+    },
+    deleteImage: async () => undefined,
+    getRawUrl: (path: string) => `https://example.test/${path}`,
+    syncPull: async () => ({ items: [], nextCursor: 'cursor-1' }),
+    syncPush: async () => undefined,
+    getSyncCursor: async () => null,
+    ...overrides,
+  } as StorageProvider;
+}
+
+async function createTestContext() {
+  const adapter = new MemoryWorkspaceAdapter('desktop');
+  await adapter.pickRoot();
+  const vault = createLocalVault(adapter);
+  await vault.open();
+  const syncPush = vi.fn(async () => undefined);
+  const provider = createMockSyncProvider({ syncPush });
+  const engine = createSyncEngine({
+    vault,
+    getBindings: () => [{ bindingId: 'binding-1', provider }],
+  });
+  return { engine, vault, adapter, provider, syncPush };
+}
 
 describe('createSyncEngine', () => {
   it('tracks enqueuePush in status', async () => {
     const onEnqueue = vi.fn();
-    const engine = createSyncEngine({ onEnqueue });
+    const { engine } = await createTestContext();
+    const tracked = createSyncEngine({
+      vault: (await createTestContext()).vault,
+      getBindings: () => [
+        {
+          bindingId: 'binding-1',
+          provider: createMockSyncProvider(),
+        },
+      ],
+      onEnqueue,
+    });
 
-    await engine.enqueuePush({ type: 'upload', relativePath: 'images/a.jpg' });
+    await tracked.enqueuePush({
+      type: 'upload',
+      relativePath: 'images/a.jpg',
+    });
     expect(onEnqueue).toHaveBeenCalledOnce();
 
-    const status = await engine.getStatus();
-    expect(status.pendingPush).toBe(1);
+    const status = await tracked.getStatus();
+    expect(status.pendingPush).toBeGreaterThanOrEqual(1);
     expect(status.conflicts).toBe(0);
   });
 
-  it('run clears push queue and updates lastSyncAt', async () => {
-    const engine = createSyncEngine();
-    await engine.enqueuePush({ type: 'upload', relativePath: 'images/a.jpg' });
-    await engine.enqueuePush({
-      type: 'metadata',
-      relativePath: 'images/b.jpg',
+  it('run push flushes pending local entries', async () => {
+    const { engine, vault, syncPush } = await createTestContext();
+    const file = new File([new Uint8Array([1, 2, 3])], 'a.jpg', {
+      type: 'image/jpeg',
     });
+    await vault.importFile(file, 'images/a.jpg', { syncState: 'local-only' });
 
     const result = await engine.run({ direction: 'push' });
-    expect(result.pushed).toBe(2);
-    expect(result.pulled).toBe(0);
+    expect(result.pushed).toBe(1);
+    expect(syncPush).toHaveBeenCalledOnce();
+
+    const entry = await vault.getByPath('images/a.jpg');
+    expect(entry?.syncState).toBe('synced');
+  });
+
+  it('run pull applies remote items and updates cursor', async () => {
+    const adapter = new MemoryWorkspaceAdapter('desktop');
+    await adapter.pickRoot();
+    const vault = createLocalVault(adapter);
+    await vault.open();
+
+    const remoteBytes = new Uint8Array([9, 9, 9]);
+    const provider = createMockSyncProvider({
+      syncPull: async () => ({
+        items: [
+          {
+            remotePath: 'remote.jpg',
+            action: 'add',
+            contentHash: 'sha-remote',
+            metadata: {
+              name: 'remote.jpg',
+              updatedAt: new Date().toISOString(),
+              url: 'https://example.test/remote.jpg',
+            },
+          },
+        ],
+        nextCursor: 'cursor-2',
+      }),
+      getRawUrl: () => 'https://example.test/remote.jpg',
+    });
+
+    const fetchFn = vi.fn(async () => ({
+      ok: true,
+      arrayBuffer: async () => remoteBytes.buffer,
+    })) as unknown as typeof fetch;
+
+    const engine = createSyncEngine({
+      vault,
+      getBindings: () => [{ bindingId: 'binding-1', provider }],
+      fetch: fetchFn,
+    });
+
+    const result = await engine.run({ direction: 'pull' });
+    expect(result.pulled).toBe(1);
+    expect(result.errors).toHaveLength(0);
+
+    const listed = await vault.list();
+    expect(listed).toHaveLength(1);
+    expect(listed[0].remotePath).toBe('remote.jpg');
+    expect(listed[0].syncState).toBe('synced');
 
     const status = await engine.getStatus();
-    expect(status.pendingPush).toBe(0);
+    expect(status.bindings['binding-1']?.cursor).toBe('cursor-2');
     expect(status.lastSyncAt).toBeTruthy();
+  });
+
+  it('run reports pull errors without silent failure', async () => {
+    const { engine } = await createTestContext();
+    const failing = createSyncEngine({
+      vault: (await createTestContext()).vault,
+      getBindings: () => [
+        {
+          bindingId: 'binding-1',
+          provider: createMockSyncProvider({
+            syncPull: async () => {
+              throw new Error('network down');
+            },
+          }),
+        },
+      ],
+    });
+
+    const result = await failing.run({ direction: 'pull' });
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]?.message).toContain('network down');
   });
 });

--- a/packages/core/src/vault/index.ts
+++ b/packages/core/src/vault/index.ts
@@ -2,8 +2,8 @@ export * from './types';
 export * from './paths';
 export { MemoryWorkspaceAdapter } from './memoryAdapter';
 export { createLocalVault } from './localVault';
-export { createSyncEngine } from './syncEngine';
-export type { CreateSyncEngineOptions } from './syncEngine';
+export { createSyncEngine, providerSupportsSync } from './syncEngine';
+export type { CreateSyncEngineOptions, SyncEngineBinding } from './syncEngine';
 export {
   basename,
   createIndexEntry,

--- a/packages/core/src/vault/syncApply.ts
+++ b/packages/core/src/vault/syncApply.ts
@@ -1,0 +1,195 @@
+import type { ImageItem } from '../types/image';
+import type {
+  StorageProvider,
+  StorageProviderSync,
+  SyncPullResult,
+  SyncPushItem,
+} from '../plugins/types';
+import { hasStorageProviderSync } from '../plugins/types';
+import type { LocalVault, SyncConflict } from './types';
+import { appendConflict } from './syncPersistence';
+import { basename, nowIso } from './utils';
+
+export async function downloadRemoteBytes(
+  provider: StorageProvider,
+  remotePath: string,
+  downloadUrl?: string,
+  fetchFn: typeof fetch = globalThis.fetch,
+): Promise<Uint8Array> {
+  const url = downloadUrl || provider.getRawUrl(remotePath);
+  const response = await fetchFn(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download remote file ${remotePath}: ${response.status}`,
+    );
+  }
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+function pickImageMetadata(metadata?: Partial<ImageItem>): Partial<ImageItem> {
+  if (!metadata) {
+    return {};
+  }
+  return {
+    name: metadata.name,
+    tags: metadata.tags,
+    description: metadata.description,
+    width: metadata.width,
+    height: metadata.height,
+    size: metadata.size,
+    type: metadata.type,
+    createdAt: metadata.createdAt,
+    updatedAt: metadata.updatedAt,
+  };
+}
+
+export async function applySyncPull(
+  vault: LocalVault,
+  bindingId: string,
+  pullResult: SyncPullResult,
+  provider: StorageProvider,
+  options?: {
+    fetchFn?: typeof fetch;
+    onConflict?: (conflict: SyncConflict) => void | Promise<void>;
+  },
+): Promise<{ pulled: number; conflicts: SyncConflict[] }> {
+  const fetchFn = options?.fetchFn ?? globalThis.fetch;
+  const conflicts: SyncConflict[] = [];
+  let pulled = 0;
+
+  for (const item of pullResult.items) {
+    const localRelativePath = `images/${item.remotePath}`;
+    const existing = await vault.getByPath(localRelativePath);
+    const remoteUpdatedAt = item.metadata?.updatedAt ?? nowIso();
+
+    if (item.action === 'delete') {
+      if (existing && !existing.deletedAt) {
+        if (
+          existing.syncState === 'pending-push' ||
+          existing.syncState === 'local-only'
+        ) {
+          const conflict: SyncConflict = {
+            relativePath: localRelativePath,
+            bindingId,
+            localRev: existing.updatedAt,
+            remoteRev: remoteUpdatedAt,
+            strategy: 'lww',
+            message: '远端已删除，本地仍有未推送修改',
+            recordedAt: nowIso(),
+          };
+          conflicts.push(conflict);
+          await appendConflict(vault.adapter, conflict);
+          await options?.onConflict?.(conflict);
+          continue;
+        }
+        await vault.softDelete(localRelativePath);
+        pulled += 1;
+      }
+      continue;
+    }
+
+    if (existing && !existing.deletedAt) {
+      const sameRemote =
+        existing.remotePath === item.remotePath &&
+        item.contentHash &&
+        existing.id === item.contentHash;
+      if (sameRemote && existing.syncState === 'synced') {
+        continue;
+      }
+
+      if (
+        (existing.syncState === 'pending-push' ||
+          existing.syncState === 'local-only') &&
+        existing.updatedAt > remoteUpdatedAt
+      ) {
+        const conflict: SyncConflict = {
+          relativePath: localRelativePath,
+          bindingId,
+          localRev: existing.updatedAt,
+          remoteRev: remoteUpdatedAt,
+          strategy: 'lww',
+          message: '本地修改较新，跳过远端覆盖',
+          recordedAt: nowIso(),
+        };
+        conflicts.push(conflict);
+        await appendConflict(vault.adapter, conflict);
+        await options?.onConflict?.(conflict);
+        continue;
+      }
+    }
+
+    const bytes = await downloadRemoteBytes(
+      provider,
+      item.remotePath,
+      item.metadata?.url,
+      fetchFn,
+    );
+
+    const meta = pickImageMetadata(item.metadata);
+    await vault.adapter.writeFile(localRelativePath, bytes);
+    await vault.importFile(localRelativePath, localRelativePath, {
+      ...meta,
+      name: meta.name ?? basename(item.remotePath),
+      mimeType: meta.type,
+      syncState: 'synced',
+      remotePath: item.remotePath,
+      bindingId,
+    });
+    await vault.updateSyncMeta(localRelativePath, {
+      syncState: 'synced',
+      remotePath: item.remotePath,
+      bindingId,
+    });
+    pulled += 1;
+  }
+
+  return { pulled, conflicts };
+}
+
+export function buildSyncPushItems(
+  vault: LocalVault,
+  bindingId: string,
+  relativePaths: string[],
+  readBytes: (relativePath: string) => Promise<Uint8Array>,
+): Promise<SyncPushItem[]> {
+  return Promise.all(
+    relativePaths.map(async relativePath => {
+      const entry = await vault.getByPath(relativePath);
+      if (!entry) {
+        throw new Error(`Missing local entry: ${relativePath}`);
+      }
+      if (entry.deletedAt) {
+        return {
+          localRelativePath: relativePath,
+          remotePath: entry.remotePath ?? basename(relativePath),
+          action: 'delete' as const,
+        };
+      }
+      const bytes = await readBytes(relativePath);
+      return {
+        localRelativePath: relativePath,
+        remotePath: entry.remotePath ?? basename(relativePath),
+        action: 'upload' as const,
+        file: bytes,
+        metadata: {
+          name: entry.name,
+          tags: entry.tags,
+          description: entry.description,
+          width: entry.width,
+          height: entry.height,
+          size: entry.size,
+          type: entry.mimeType,
+        },
+      };
+    }),
+  );
+}
+
+export function assertSyncProvider(
+  provider: StorageProvider,
+): StorageProvider & StorageProviderSync {
+  if (!hasStorageProviderSync(provider)) {
+    throw new Error('Storage provider does not support sync');
+  }
+  return provider;
+}

--- a/packages/core/src/vault/syncEngine.ts
+++ b/packages/core/src/vault/syncEngine.ts
@@ -1,4 +1,21 @@
+import type { StorageProvider, StorageProviderSync } from '../plugins/types';
+import { hasStorageProviderSync } from '../plugins/types';
+import {
+  appendPushQueue,
+  getBindingSyncState,
+  readConflicts,
+  readPushQueue,
+  updateBindingSyncState,
+  writePushQueue,
+  type QueuedPushOperation,
+} from './syncPersistence';
+import {
+  applySyncPull,
+  assertSyncProvider,
+  buildSyncPushItems,
+} from './syncApply';
 import type {
+  LocalVault,
   SyncEngine,
   SyncPushOperation,
   SyncRunOptions,
@@ -7,37 +24,108 @@ import type {
 } from './types';
 import { nowIso } from './utils';
 
+export interface SyncEngineBinding {
+  bindingId: string;
+  provider: StorageProvider;
+}
+
 export interface CreateSyncEngineOptions {
-  /** P3：绑定 LocalVault 与 Provider 后实现 push/pull */
+  vault: LocalVault;
+  getBindings: () => SyncEngineBinding[];
+  readFileBytes?: (relativePath: string) => Promise<Uint8Array>;
+  fetch?: typeof fetch;
   onEnqueue?: (op: SyncPushOperation) => void | Promise<void>;
 }
 
 /**
- * SyncEngine MVP 骨架（REF-607 P1）：内存队列 + 状态汇总；push/pull 在 P3 实现。
+ * SyncEngine MVP（REF-607 P3）：持久化 push 队列、单向 pull、游标与冲突登记。
  */
-export function createSyncEngine(
-  options: CreateSyncEngineOptions = {},
-): SyncEngine {
-  const queue: SyncPushOperation[] = [];
-  let lastSyncAt: string | null = null;
+export function createSyncEngine(options: CreateSyncEngineOptions): SyncEngine {
+  const {
+    vault,
+    getBindings,
+    readFileBytes = relativePath => vault.adapter.readFile(relativePath),
+    fetch: fetchFn = globalThis.fetch,
+    onEnqueue,
+  } = options;
+
+  const memoryQueue: SyncPushOperation[] = [];
+
+  const resolveBinding = (bindingId?: string): SyncEngineBinding => {
+    const bindings = getBindings();
+    if (bindings.length === 0) {
+      throw new Error('No sync bindings configured');
+    }
+    if (bindingId) {
+      const found = bindings.find(item => item.bindingId === bindingId);
+      if (!found) {
+        throw new Error(`Sync binding not found: ${bindingId}`);
+      }
+      return found;
+    }
+    return bindings[0];
+  };
+
+  const countPendingPush = async (): Promise<number> => {
+    const persisted = await readPushQueue(vault.adapter);
+    const entries = await vault.list();
+    const pendingEntries = entries.filter(
+      entry =>
+        !entry.deletedAt &&
+        (entry.syncState === 'local-only' ||
+          entry.syncState === 'pending-push'),
+    ).length;
+    return persisted.length + memoryQueue.length + pendingEntries;
+  };
 
   return {
     async enqueuePush(op) {
-      queue.push(op);
-      await options.onEnqueue?.(op);
+      memoryQueue.push(op);
+      await appendPushQueue(vault.adapter, op);
+      await onEnqueue?.(op);
     },
 
     async getStatus(): Promise<SyncStatusSummary> {
+      const bindings = getBindings();
+      const stateBindings: SyncStatusSummary['bindings'] = {};
+      let lastSyncAt: string | null = null;
+
+      for (const binding of bindings) {
+        const record = await getBindingSyncState(
+          vault.adapter,
+          binding.bindingId,
+        );
+        const queue = await readPushQueue(vault.adapter);
+        const pendingForBinding = queue.filter(
+          item => !item.bindingId || item.bindingId === binding.bindingId,
+        ).length;
+        stateBindings[binding.bindingId] = {
+          cursor: record.cursor,
+          lastSyncAt: record.lastSyncAt,
+          pendingPush: pendingForBinding,
+        };
+        if (
+          record.lastSyncAt &&
+          (!lastSyncAt || record.lastSyncAt > lastSyncAt)
+        ) {
+          lastSyncAt = record.lastSyncAt;
+        }
+      }
+
+      const conflicts = await readConflicts(vault.adapter);
+
       return {
         lastSyncAt,
-        pendingPush: queue.length,
-        conflicts: 0,
-        bindings: {},
+        pendingPush: await countPendingPush(),
+        conflicts: conflicts.length,
+        bindings: stateBindings,
       };
     },
 
     async run(runOptions?: SyncRunOptions): Promise<SyncRunResult> {
       const direction = runOptions?.direction ?? 'both';
+      const binding = resolveBinding(runOptions?.bindingId);
+      const provider = assertSyncProvider(binding.provider);
       const result: SyncRunResult = {
         pushed: 0,
         pulled: 0,
@@ -46,12 +134,134 @@ export function createSyncEngine(
       };
 
       if (direction === 'push' || direction === 'both') {
-        result.pushed = queue.length;
-        queue.length = 0;
+        try {
+          result.pushed += await flushPushQueue(
+            vault,
+            binding,
+            provider,
+            readFileBytes,
+            memoryQueue,
+          );
+        } catch (error) {
+          result.errors.push({
+            path: 'push',
+            message: error instanceof Error ? error.message : 'Push failed',
+          });
+        }
       }
 
-      lastSyncAt = nowIso();
+      if (direction === 'pull' || direction === 'both') {
+        try {
+          const bindingState = await getBindingSyncState(
+            vault.adapter,
+            binding.bindingId,
+          );
+          const pullResult = await provider.syncPull({
+            since: bindingState.cursor ?? undefined,
+          });
+          const applied = await applySyncPull(
+            vault,
+            binding.bindingId,
+            pullResult,
+            provider,
+            { fetchFn },
+          );
+          result.pulled += applied.pulled;
+          result.conflicts.push(...applied.conflicts);
+
+          await updateBindingSyncState(vault.adapter, binding.bindingId, {
+            cursor: pullResult.nextCursor ?? nowIso(),
+            lastSyncAt: nowIso(),
+          });
+        } catch (error) {
+          result.errors.push({
+            path: 'pull',
+            message: error instanceof Error ? error.message : 'Pull failed',
+          });
+        }
+      }
+
+      if (result.errors.length === 0) {
+        await updateBindingSyncState(vault.adapter, binding.bindingId, {
+          lastSyncAt: nowIso(),
+        });
+      }
+
       return result;
     },
   };
+}
+
+async function flushPushQueue(
+  vault: LocalVault,
+  binding: SyncEngineBinding,
+  provider: StorageProvider & StorageProviderSync,
+  readFileBytes: (relativePath: string) => Promise<Uint8Array>,
+  memoryQueue: SyncPushOperation[],
+): Promise<number> {
+  const persisted = await readPushQueue(vault.adapter);
+  const queue = [...persisted, ...toQueued(memoryQueue, binding.bindingId)];
+
+  const entries = await vault.list();
+  const pendingPaths = new Set<string>();
+  for (const entry of entries) {
+    if (
+      !entry.deletedAt &&
+      (entry.syncState === 'local-only' || entry.syncState === 'pending-push')
+    ) {
+      pendingPaths.add(entry.relativePath);
+    }
+  }
+  for (const op of queue) {
+    pendingPaths.add(op.relativePath);
+  }
+
+  if (pendingPaths.size === 0) {
+    return 0;
+  }
+
+  const items = await buildSyncPushItems(
+    vault,
+    binding.bindingId,
+    [...pendingPaths],
+    readFileBytes,
+  );
+
+  await provider.syncPush(items);
+
+  let pushed = 0;
+  for (const item of items) {
+    if (item.action === 'delete') {
+      pushed += 1;
+      continue;
+    }
+
+    await vault.updateSyncMeta(item.localRelativePath, {
+      syncState: 'synced',
+      remotePath: item.remotePath,
+      bindingId: binding.bindingId,
+    });
+    pushed += 1;
+  }
+
+  await writePushQueue(vault.adapter, []);
+  memoryQueue.length = 0;
+  return pushed;
+}
+
+function toQueued(
+  ops: SyncPushOperation[],
+  bindingId: string,
+): QueuedPushOperation[] {
+  return ops.map(op => ({
+    ...op,
+    bindingId,
+    enqueuedAt: nowIso(),
+  }));
+}
+
+export function providerSupportsSync(
+  provider: StorageProvider,
+): provider is StorageProvider & StorageProviderSync {
+  return hasStorageProviderSync(provider);
 }

--- a/packages/core/src/vault/syncPersistence.ts
+++ b/packages/core/src/vault/syncPersistence.ts
@@ -1,0 +1,145 @@
+import { WORKSPACE_PATHS } from './paths';
+import type {
+  SyncConflict,
+  SyncPushOperation,
+  WorkspaceAdapter,
+} from './types';
+import { decodeJson, encodeJson, nowIso } from './utils';
+
+const SYNC_SCHEMA_VERSION = 1;
+
+export interface BindingSyncStateRecord {
+  cursor: string | null;
+  lastSyncAt: string | null;
+}
+
+export interface SyncStateFile {
+  schemaVersion: number;
+  bindings: Record<string, BindingSyncStateRecord>;
+}
+
+export interface SyncConflictsFile {
+  schemaVersion: number;
+  conflicts: SyncConflict[];
+}
+
+export type QueuedPushOperation = SyncPushOperation & {
+  bindingId?: string;
+  enqueuedAt: string;
+};
+
+export async function readSyncState(
+  adapter: WorkspaceAdapter,
+): Promise<SyncStateFile> {
+  if (!(await adapter.exists(WORKSPACE_PATHS.syncState))) {
+    return { schemaVersion: SYNC_SCHEMA_VERSION, bindings: {} };
+  }
+  const raw = await adapter.readFile(WORKSPACE_PATHS.syncState);
+  const parsed = decodeJson<SyncStateFile>(raw);
+  return {
+    schemaVersion: SYNC_SCHEMA_VERSION,
+    bindings: parsed.bindings ?? {},
+  };
+}
+
+export async function writeSyncState(
+  adapter: WorkspaceAdapter,
+  state: SyncStateFile,
+): Promise<void> {
+  await adapter.writeFile(
+    WORKSPACE_PATHS.syncState,
+    encodeJson({ ...state, schemaVersion: SYNC_SCHEMA_VERSION }),
+  );
+}
+
+export async function getBindingSyncState(
+  adapter: WorkspaceAdapter,
+  bindingId: string,
+): Promise<BindingSyncStateRecord> {
+  const state = await readSyncState(adapter);
+  return (
+    state.bindings[bindingId] ?? {
+      cursor: null,
+      lastSyncAt: null,
+    }
+  );
+}
+
+export async function updateBindingSyncState(
+  adapter: WorkspaceAdapter,
+  bindingId: string,
+  patch: Partial<BindingSyncStateRecord>,
+): Promise<void> {
+  const state = await readSyncState(adapter);
+  const current = state.bindings[bindingId] ?? {
+    cursor: null,
+    lastSyncAt: null,
+  };
+  state.bindings[bindingId] = { ...current, ...patch };
+  await writeSyncState(adapter, state);
+}
+
+export async function readPushQueue(
+  adapter: WorkspaceAdapter,
+): Promise<QueuedPushOperation[]> {
+  if (!(await adapter.exists(WORKSPACE_PATHS.syncQueue))) {
+    return [];
+  }
+  const raw = await adapter.readFile(WORKSPACE_PATHS.syncQueue);
+  const text = new TextDecoder().decode(raw);
+  return text
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => JSON.parse(line) as QueuedPushOperation);
+}
+
+export async function appendPushQueue(
+  adapter: WorkspaceAdapter,
+  op: SyncPushOperation,
+  bindingId?: string,
+): Promise<void> {
+  const existing = await readPushQueue(adapter);
+  const entry: QueuedPushOperation = {
+    ...op,
+    bindingId,
+    enqueuedAt: nowIso(),
+  };
+  existing.push(entry);
+  await writePushQueue(adapter, existing);
+}
+
+export async function writePushQueue(
+  adapter: WorkspaceAdapter,
+  queue: QueuedPushOperation[],
+): Promise<void> {
+  const lines = queue.map(entry => JSON.stringify(entry)).join('\n');
+  const payload = lines.length > 0 ? `${lines}\n` : '';
+  await adapter.writeFile(
+    WORKSPACE_PATHS.syncQueue,
+    new TextEncoder().encode(payload),
+  );
+}
+
+export async function readConflicts(
+  adapter: WorkspaceAdapter,
+): Promise<SyncConflict[]> {
+  if (!(await adapter.exists(WORKSPACE_PATHS.syncConflicts))) {
+    return [];
+  }
+  const raw = await adapter.readFile(WORKSPACE_PATHS.syncConflicts);
+  const parsed = decodeJson<SyncConflictsFile>(raw);
+  return parsed.conflicts ?? [];
+}
+
+export async function appendConflict(
+  adapter: WorkspaceAdapter,
+  conflict: SyncConflict,
+): Promise<void> {
+  const conflicts = await readConflicts(adapter);
+  conflicts.push(conflict);
+  await adapter.writeFile(
+    WORKSPACE_PATHS.syncConflicts,
+    encodeJson({ schemaVersion: SYNC_SCHEMA_VERSION, conflicts }),
+  );
+}

--- a/packages/plugin-provider-gitee/src/giteeStorageProvider.ts
+++ b/packages/plugin-provider-gitee/src/giteeStorageProvider.ts
@@ -9,6 +9,9 @@ import type {
   ProviderContext,
   StorageProviderConfig,
   StorageProviderWithMetadata,
+  SyncPullOptions,
+  SyncPullResult,
+  SyncPushItem,
 } from '@pixuli/core/plugins';
 import { giteeManifest } from './manifest';
 import { GITEE_PROXY_PATH } from './proxy/constants.js';
@@ -47,6 +50,7 @@ export class GiteeStorageProvider implements StorageProviderWithMetadata {
   private readonly logger: Pick<Console, 'log' | 'warn' | 'error'>;
   private readonly useProxy: boolean;
   private readonly proxyBaseUrl?: string;
+  private syncCursor: string | null = null;
 
   constructor(ctx: ProviderContext, options: GiteeStorageProviderOptions = {}) {
     this.platformAdapter = ctx.platformAdapter;
@@ -843,6 +847,62 @@ export class GiteeStorageProvider implements StorageProviderWithMetadata {
       this.logger.error('Load image metadata failed:', error);
       // 即使加载元数据失败，也返回原始图片列表
       return images;
+    }
+  }
+
+  async getSyncCursor(): Promise<string | null> {
+    return this.syncCursor;
+  }
+
+  async syncPull(options?: SyncPullOptions): Promise<SyncPullResult> {
+    const images = await this.listImages();
+    const since = options?.since;
+    const items = images
+      .map(img => ({
+        remotePath: img.name,
+        action: 'update' as const,
+        contentHash: img.id,
+        metadata: {
+          name: img.name,
+          tags: img.tags,
+          description: img.description,
+          width: img.width,
+          height: img.height,
+          size: img.size,
+          type: img.type,
+          createdAt: img.createdAt,
+          updatedAt: img.updatedAt,
+          url: img.url,
+        },
+      }))
+      .filter(item => !since || (item.metadata.updatedAt ?? '') > since);
+
+    this.syncCursor = new Date().toISOString();
+    return { items, nextCursor: this.syncCursor };
+  }
+
+  async syncPush(items: SyncPushItem[]): Promise<void> {
+    for (const item of items) {
+      if (item.action === 'delete') {
+        await this.deleteImage(item.remotePath);
+        continue;
+      }
+      if (item.action === 'metadata') {
+        await this.updateImageMetadata(item.remotePath, item.metadata ?? {});
+        continue;
+      }
+      if (!item.file) {
+        throw new Error(`Missing file bytes for ${item.remotePath}`);
+      }
+      const file = new File([Uint8Array.from(item.file)], item.remotePath, {
+        type: item.metadata?.type ?? this.getMimeType(item.remotePath),
+      });
+      await this.uploadImage({
+        file,
+        name: item.metadata?.name,
+        tags: item.metadata?.tags,
+        description: item.metadata?.description,
+      });
     }
   }
 

--- a/packages/plugin-provider-gitee/src/manifest.ts
+++ b/packages/plugin-provider-gitee/src/manifest.ts
@@ -11,6 +11,7 @@ export const giteeManifest: StoragePluginManifest = {
     delete: true,
     updateMetadata: true,
     needsProxy: true,
+    sync: true,
   },
   hostIntegrations: [
     {

--- a/packages/plugin-provider-github/src/githubStorageProvider.ts
+++ b/packages/plugin-provider-github/src/githubStorageProvider.ts
@@ -6,6 +6,9 @@ import type {
   ProviderContext,
   StorageProviderConfig,
   StorageProviderWithMetadata,
+  SyncPullOptions,
+  SyncPullResult,
+  SyncPushItem,
 } from '@pixuli/core/plugins';
 import { githubManifest } from './manifest';
 
@@ -35,6 +38,7 @@ export class GitHubStorageProvider implements StorageProviderWithMetadata {
   private readonly platformAdapter: ProviderContext['platformAdapter'];
   private readonly fetchFn: typeof fetch;
   private readonly logger: Pick<Console, 'log' | 'warn' | 'error'>;
+  private syncCursor: string | null = null;
 
   constructor(ctx: ProviderContext) {
     this.platformAdapter = ctx.platformAdapter;
@@ -659,6 +663,62 @@ export class GitHubStorageProvider implements StorageProviderWithMetadata {
       this.logger.error('Load image metadata failed:', error);
       // 即使加载元数据失败，也返回原始图片列表
       return images;
+    }
+  }
+
+  async getSyncCursor(): Promise<string | null> {
+    return this.syncCursor;
+  }
+
+  async syncPull(options?: SyncPullOptions): Promise<SyncPullResult> {
+    const images = await this.listImages();
+    const since = options?.since;
+    const items = images
+      .map(img => ({
+        remotePath: img.name,
+        action: 'update' as const,
+        contentHash: img.id,
+        metadata: {
+          name: img.name,
+          tags: img.tags,
+          description: img.description,
+          width: img.width,
+          height: img.height,
+          size: img.size,
+          type: img.type,
+          createdAt: img.createdAt,
+          updatedAt: img.updatedAt,
+          url: img.url,
+        },
+      }))
+      .filter(item => !since || (item.metadata.updatedAt ?? '') > since);
+
+    this.syncCursor = new Date().toISOString();
+    return { items, nextCursor: this.syncCursor };
+  }
+
+  async syncPush(items: SyncPushItem[]): Promise<void> {
+    for (const item of items) {
+      if (item.action === 'delete') {
+        await this.deleteImage(item.remotePath);
+        continue;
+      }
+      if (item.action === 'metadata') {
+        await this.updateImageMetadata(item.remotePath, item.metadata ?? {});
+        continue;
+      }
+      if (!item.file) {
+        throw new Error(`Missing file bytes for ${item.remotePath}`);
+      }
+      const file = new File([Uint8Array.from(item.file)], item.remotePath, {
+        type: item.metadata?.type ?? this.getMimeType(item.remotePath),
+      });
+      await this.uploadImage({
+        file,
+        name: item.metadata?.name,
+        tags: item.metadata?.tags,
+        description: item.metadata?.description,
+      });
     }
   }
 

--- a/packages/plugin-provider-github/src/manifest.ts
+++ b/packages/plugin-provider-github/src/manifest.ts
@@ -10,5 +10,6 @@ export const githubManifest: StoragePluginManifest = {
     upload: true,
     delete: true,
     updateMetadata: true,
+    sync: true,
   },
 };


### PR DESCRIPTION
## Summary

- 实现 `SyncEngine` MVP：`.pixuli/sync/` 游标与 `queue.jsonl` 推送队列、`conflicts.json` 冲突登记，支持 `push` / `pull` / `both`
- GitHub/Gitee Provider 补充 `syncPull`、`syncPush`、`getSyncCursor`，manifest 声明 `sync: true`
- Desktop `workspaceStore` 接入 SyncEngine，工具栏增加扫描索引、拉取、双向同步与状态徽章（上次同步 / 待推送 / 冲突）
- 修复 Electron preload 构建：输出 ESM（`index.mjs`）+ `esnext` target，解决 top-level await 报错

Closes #158

## Test plan

- [ ] `pnpm --filter @pixuli/core test` 通过（83 项）
- [ ] `pnpm exec vite build --mode desktop` preload 构建成功
- [ ] `pnpm dev:desktop`：选工作区 + 配置远端源
- [ ] 点击「从远端拉取」，远端图片出现在本地列表
- [ ] 上传本地图片后「推送到远端」，远端仓库可见
- [ ] 「双向同步」后状态徽章更新；失败时显示错误文案（非静默）
- [ ] 「扫描索引」可发现 `images/` 下未索引文件


Made with [Cursor](https://cursor.com)