### PR TITLE
feat(ui): REF-512 深化移动端 Web UI 适配

### DIFF
--- a/apps/pixuli/src/App.css
+++ b/apps/pixuli/src/App.css
@@ -449,6 +449,11 @@ body {
 
 /* 工具页窄屏排版（REF-512 #150） */
 @media (max-width: 767px) {
+  .photos-page {
+    padding-left: env(safe-area-inset-left, 0);
+    padding-right: env(safe-area-inset-right, 0);
+  }
+
   .utility-page {
     padding-left: max(1rem, env(safe-area-inset-left, 0));
     padding-right: max(1rem, env(safe-area-inset-right, 0));

--- a/apps/pixuli/src/features/source-type-menu/SourceTypeMenu.css
+++ b/apps/pixuli/src/features/source-type-menu/SourceTypeMenu.css
@@ -1,0 +1,44 @@
+/* 窄屏全屏源类型选择（REF-512 #150） */
+@media (max-width: 767px) {
+  .source-type-menu-overlay {
+    align-items: stretch;
+    padding: 0;
+  }
+
+  .source-type-menu-panel {
+    max-width: none;
+    width: 100%;
+    height: 100%;
+    height: 100dvh;
+    margin: 0;
+    border-radius: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .source-type-menu-header {
+    padding-top: max(1rem, env(safe-area-inset-top, 0));
+  }
+
+  .source-type-menu-body {
+    flex: 1;
+    overflow-y: auto;
+  }
+
+  .source-type-menu-footer {
+    padding-bottom: max(1rem, env(safe-area-inset-bottom, 0));
+  }
+
+  .source-type-menu-option,
+  .source-type-menu-cancel {
+    min-height: 2.75rem;
+  }
+
+  .source-type-menu-close {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+}

--- a/apps/pixuli/src/features/source-type-menu/SourceTypeMenu.tsx
+++ b/apps/pixuli/src/features/source-type-menu/SourceTypeMenu.tsx
@@ -5,6 +5,7 @@ import {
 } from '@pixuli/core/plugins';
 import { Github, X } from 'lucide-react';
 import React from 'react';
+import './SourceTypeMenu.css';
 
 interface SourceTypeMenuProps {
   isOpen: boolean;
@@ -63,21 +64,35 @@ export const SourceTypeMenu: React.FC<SourceTypeMenuProps> = ({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-      <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4">
-        <div className="flex items-center justify-between p-4 border-b border-gray-200">
-          <h3 className="text-lg font-semibold text-gray-900">
+    <div
+      className="source-type-menu-overlay fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        className="source-type-menu-panel bg-white rounded-lg shadow-xl max-w-md w-full mx-4"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="source-type-menu-title"
+      >
+        <div className="source-type-menu-header flex items-center justify-between p-4 border-b border-gray-200">
+          <h3
+            id="source-type-menu-title"
+            className="text-lg font-semibold text-gray-900"
+          >
             {t('sidebar.selectSourceType')}
           </h3>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 transition-colors"
+            className="source-type-menu-close text-gray-400 hover:text-gray-600 transition-colors"
             type="button"
+            aria-label={t('common.cancel')}
           >
             <X size={20} />
           </button>
         </div>
-        <div className="p-4 space-y-3">
+        <div className="source-type-menu-body p-4 space-y-3">
           {manifests.length === 0 ? (
             <p className="text-sm text-gray-500 text-center py-4">
               {t('sidebar.noStoragePlugins')}
@@ -94,7 +109,7 @@ export const SourceTypeMenu: React.FC<SourceTypeMenuProps> = ({
                   onSelect(manifest.id);
                 }}
                 disabled={!isKnownBuiltinPluginId(manifest.id)}
-                className={`w-full flex items-center gap-3 p-4 border border-gray-200 rounded-lg transition-all group disabled:opacity-50 disabled:cursor-not-allowed ${hoverClassForPlugin(manifest.id)}`}
+                className={`source-type-menu-option w-full flex items-center gap-3 p-4 border border-gray-200 rounded-lg transition-all group disabled:opacity-50 disabled:cursor-not-allowed ${hoverClassForPlugin(manifest.id)}`}
               >
                 <PluginTypeIcon pluginId={manifest.id} name={manifest.name} />
                 <div className="flex-1 text-left">
@@ -109,11 +124,11 @@ export const SourceTypeMenu: React.FC<SourceTypeMenuProps> = ({
             ))
           )}
         </div>
-        <div className="p-4 border-t border-gray-200">
+        <div className="source-type-menu-footer p-4 border-t border-gray-200">
           <button
             type="button"
             onClick={onClose}
-            className="w-full px-4 py-2 text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors"
+            className="source-type-menu-cancel w-full px-4 py-2 text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors"
           >
             {t('common.cancel')}
           </button>

--- a/apps/pixuli/src/layouts/AppMain.tsx
+++ b/apps/pixuli/src/layouts/AppMain.tsx
@@ -81,7 +81,13 @@ export const AppMain: React.FC<AppMainProps> = ({
 
   const searchAction =
     isPhotosPage && searchContext && searchContext.showSearch ? (
-      <div className="flex-1 min-w-0 max-w-2xl">
+      <div
+        className={
+          isMobile
+            ? 'header-search-slot header-search-slot--mobile'
+            : 'header-search-slot flex-1 min-w-0 max-w-2xl'
+        }
+      >
         <Search
           searchQuery={searchContext.searchQuery}
           onSearchChange={searchContext.setSearchQuery}
@@ -118,7 +124,11 @@ export const AppMain: React.FC<AppMainProps> = ({
           leftActions={leftActions}
           rightActions={
             <>
-              <DemoIcon t={t} isDemoMode={isDemoMode} />
+              <DemoIcon
+                t={t}
+                isDemoMode={isDemoMode}
+                className={isMobile ? 'demo-icon--hide-mobile' : undefined}
+              />
               {hasConfig && (
                 <UploadButton
                   onUploadImage={onUploadImage}

--- a/apps/pixuli/src/layouts/Sidebar.tsx
+++ b/apps/pixuli/src/layouts/Sidebar.tsx
@@ -3,7 +3,12 @@
  * 处理侧边栏的显示和交互逻辑
  */
 
-import { Sidebar as CommonSidebar, type SidebarMenuItem } from '@pixuli/ui';
+import {
+  Sidebar as CommonSidebar,
+  DemoSidebarSection,
+  type SidebarMenuItem,
+  useDemoMode,
+} from '@pixuli/ui';
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMobileViewport } from '../hooks/useMobileViewport';
@@ -35,6 +40,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
 }) => {
   const navigate = useNavigate();
   const isMobile = useMobileViewport();
+  const { isDemoMode } = useDemoMode();
   const workspaceMode = useWorkspaceStore(state => state.mode);
   const displayName = useWorkspaceStore(state => state.displayName);
   const showWorkspaceHint =
@@ -130,6 +136,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
           onToggleCollapse={isMobile ? undefined : toggleSidebar}
           mobileOpen={isMobile && mobileSidebarOpen}
           onMobileClose={closeMobileSidebar}
+          footerExtra={isDemoMode ? <DemoSidebarSection t={t} /> : undefined}
           t={t}
         />
       </div>

--- a/packages/ui/src/dev/demo/web/DemoIcon.css
+++ b/packages/ui/src/dev/demo/web/DemoIcon.css
@@ -224,3 +224,53 @@
   color: #6b7280; /* gray-500 */
   line-height: 1.4;
 }
+
+/* 窄屏：Header 内隐藏（侧栏 Demo 区块替代）；下拉改全宽 sheet（REF-512） */
+@media (max-width: 767px) {
+  .demo-icon--hide-mobile {
+    display: none;
+  }
+
+  .demo-icon-text {
+    display: none;
+  }
+
+  .demo-icon-button {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+    padding: 0 0.5rem;
+  }
+
+  .demo-icon-dropdown {
+    position: fixed;
+    top: auto;
+    left: 0.75rem;
+    right: 0.75rem;
+    bottom: max(0.75rem, env(safe-area-inset-bottom, 0));
+    width: auto;
+    max-height: min(72vh, 24rem);
+    overflow-y: auto;
+    border-radius: 1rem;
+    animation: demo-icon-sheet-up 0.22s ease-out;
+  }
+
+  .demo-icon-dropdown-item {
+    min-height: 2.75rem;
+  }
+
+  .demo-icon-dropdown-close {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+  }
+}
+
+@keyframes demo-icon-sheet-up {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/packages/ui/src/dev/demo/web/DemoIcon.tsx
+++ b/packages/ui/src/dev/demo/web/DemoIcon.tsx
@@ -14,10 +14,16 @@ interface DemoIconProps {
   t?: (key: string) => string;
   /** 是否处于 Demo 模式（可选，如果不提供则自动检测） */
   isDemoMode?: boolean;
+  /** 附加 class（如窄屏隐藏 Header 内入口） */
+  className?: string;
 }
 
 // Demo 图标组件（Web 版本）- 用于 Header 右上角
-export function DemoIcon({ t, isDemoMode: propIsDemoMode }: DemoIconProps) {
+export function DemoIcon({
+  t,
+  isDemoMode: propIsDemoMode,
+  className,
+}: DemoIconProps) {
   const translate =
     t || ((key: string) => defaultTranslate(key, demoLocales['zh-CN']));
   const [showDropdown, setShowDropdown] = useState(false);
@@ -90,7 +96,10 @@ export function DemoIcon({ t, isDemoMode: propIsDemoMode }: DemoIconProps) {
   }, [showDropdown, handleClickOutside]);
 
   return (
-    <div className="demo-icon-wrapper" ref={dropdownRef}>
+    <div
+      className={['demo-icon-wrapper', className].filter(Boolean).join(' ')}
+      ref={dropdownRef}
+    >
       <button
         onClick={() => setShowDropdown(!showDropdown)}
         className="demo-icon-button"

--- a/packages/ui/src/dev/demo/web/DemoSidebarSection.css
+++ b/packages/ui/src/dev/demo/web/DemoSidebarSection.css
@@ -1,0 +1,135 @@
+/* 侧栏演示模式（REF-512 移动端菜单） */
+.sidebar-demo-section {
+  margin: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid #e9d5ff;
+  background: linear-gradient(180deg, #faf5ff 0%, #f5f3ff 100%);
+  flex-shrink: 0;
+}
+
+.sidebar-demo-section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.sidebar-demo-section-icon {
+  color: #7c3aed;
+  flex-shrink: 0;
+}
+
+.sidebar-demo-section-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #4c1d95;
+}
+
+.sidebar-demo-section-badge {
+  margin-left: auto;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  background: #e9d5ff;
+  color: #6b21a8;
+}
+
+.sidebar-demo-section-desc {
+  margin: 0 0 0.75rem;
+  font-size: 0.75rem;
+  line-height: 1.45;
+  color: #5b21b6;
+}
+
+.sidebar-demo-section-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem 0.625rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.5rem;
+  background: #fffbeb;
+  border: 1px solid #fed7aa;
+  color: #9a3412;
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+.sidebar-demo-section-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.sidebar-demo-download-btn {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  width: 100%;
+  min-height: 2.75rem;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 0.15s ease;
+}
+
+.sidebar-demo-download-btn:hover {
+  background: #f9fafb;
+}
+
+.sidebar-demo-gitee-icon {
+  width: 2rem;
+  height: 2rem;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.5rem;
+  background: #dc2626;
+  color: #ffffff;
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.sidebar-demo-download-text {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.sidebar-demo-download-title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.sidebar-demo-download-desc {
+  font-size: 0.6875rem;
+  color: #6b7280;
+  line-height: 1.35;
+}
+
+.sidebar-demo-exit-btn {
+  width: 100%;
+  min-height: 2.75rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #fecaca;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #dc2626;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.sidebar-demo-exit-btn:hover {
+  background: #fef2f2;
+}

--- a/packages/ui/src/dev/demo/web/DemoSidebarSection.tsx
+++ b/packages/ui/src/dev/demo/web/DemoSidebarSection.tsx
@@ -1,0 +1,102 @@
+import { AlertCircle, Github, Sparkles } from 'lucide-react';
+import { useCallback } from 'react';
+import { defaultTranslate } from '@pixuli/ui/locales';
+import { demoLocales } from '@pixuli/ui/dev/demo/locales';
+import {
+  downloadDemoGitHubConfig,
+  downloadDemoGiteeConfig,
+  isEnvConfigured,
+  setDemoMode,
+} from './Demo';
+import './DemoSidebarSection.css';
+
+export interface DemoSidebarSectionProps {
+  t?: (key: string) => string;
+  onExitDemo?: () => void;
+}
+
+/** 侧栏演示模式区块：下载 Demo 配置、退出演示（REF-512 移动端菜单） */
+export function DemoSidebarSection({ t, onExitDemo }: DemoSidebarSectionProps) {
+  const translate =
+    t || ((key: string) => defaultTranslate(key, demoLocales['zh-CN']));
+  const envConfigured = isEnvConfigured();
+
+  const handleExitDemo = useCallback(async () => {
+    await setDemoMode(false);
+    onExitDemo?.();
+    if (typeof window !== 'undefined') {
+      window.location.reload();
+    }
+  }, [onExitDemo]);
+
+  return (
+    <section
+      className="sidebar-demo-section"
+      aria-label={translate('app.demoMode.title')}
+    >
+      <div className="sidebar-demo-section-header">
+        <Sparkles size={16} className="sidebar-demo-section-icon" />
+        <span className="sidebar-demo-section-title">
+          {translate('app.demoMode.title')}
+        </span>
+        <span className="sidebar-demo-section-badge">Demo</span>
+      </div>
+
+      <p className="sidebar-demo-section-desc">
+        {translate('app.demoMode.description')}
+      </p>
+
+      {!envConfigured && (
+        <div className="sidebar-demo-section-warning" role="status">
+          <AlertCircle size={14} />
+          <span>{translate('app.demoMode.missingConfig')}</span>
+        </div>
+      )}
+
+      {envConfigured && (
+        <div className="sidebar-demo-section-actions">
+          <button
+            type="button"
+            className="sidebar-demo-download-btn"
+            onClick={downloadDemoGitHubConfig}
+          >
+            <Github size={16} />
+            <span className="sidebar-demo-download-text">
+              <span className="sidebar-demo-download-title">
+                {translate('app.demoMode.downloadGitHub')}
+              </span>
+              <span className="sidebar-demo-download-desc">
+                {translate('app.demoMode.downloadGitHubDesc')}
+              </span>
+            </span>
+          </button>
+          <button
+            type="button"
+            className="sidebar-demo-download-btn"
+            onClick={downloadDemoGiteeConfig}
+          >
+            <span className="sidebar-demo-gitee-icon">码</span>
+            <span className="sidebar-demo-download-text">
+              <span className="sidebar-demo-download-title">
+                {translate('app.demoMode.downloadGitee')}
+              </span>
+              <span className="sidebar-demo-download-desc">
+                {translate('app.demoMode.downloadGiteeDesc')}
+              </span>
+            </span>
+          </button>
+        </div>
+      )}
+
+      <button
+        type="button"
+        className="sidebar-demo-exit-btn"
+        onClick={() => void handleExitDemo()}
+      >
+        {translate('app.demoMode.exitDemo')}
+      </button>
+    </section>
+  );
+}
+
+export default DemoSidebarSection;

--- a/packages/ui/src/dev/demo/web/index.ts
+++ b/packages/ui/src/dev/demo/web/index.ts
@@ -12,3 +12,7 @@ export {
   isEnvConfigured,
 } from './Demo';
 export { default as DemoIcon } from './DemoIcon';
+export {
+  default as DemoSidebarSection,
+  type DemoSidebarSectionProps,
+} from './DemoSidebarSection';

--- a/packages/ui/src/image/image-browser/web/ImageBrowser.css
+++ b/packages/ui/src/image/image-browser/web/ImageBrowser.css
@@ -43,6 +43,32 @@
   gap: 1rem;
 }
 
+.image-browser-batch-delete-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border: 1px solid #dc2626;
+  border-radius: 0.375rem;
+  background-color: #ffffff;
+  color: #dc2626;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  flex-shrink: 0;
+}
+
+.image-browser-batch-delete-btn:hover {
+  background-color: #fef2f2;
+}
+
+.image-browser-batch-delete-icon {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+}
+
 /* 筛选区域样式 */
 .image-browser-filter-section {
   margin-bottom: 1.5rem;
@@ -72,35 +98,70 @@
 }
 
 /* 响应式设计 */
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .image-browser-toolbar {
+    position: sticky;
+    top: 0;
+    z-index: 20;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.5rem;
     align-items: stretch;
+    margin-bottom: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    background: rgba(255, 255, 255, 0.96);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid #f3f4f6;
   }
 
   .image-browser-header {
-    justify-content: center;
-    text-align: center;
+    justify-content: space-between;
+    text-align: left;
+    gap: 0.5rem;
+  }
+
+  .image-browser-title {
+    font-size: 1rem;
+  }
+
+  .image-browser-count {
+    font-size: 0.8125rem;
+    white-space: nowrap;
   }
 
   .image-browser-controls {
-    justify-content: center;
-    flex-wrap: wrap;
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    gap: 0.5rem;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    padding-bottom: 0.125rem;
+    justify-content: flex-start;
+  }
+
+  .image-browser-controls::-webkit-scrollbar {
+    display: none;
+  }
+
+  .image-browser-controls > * {
+    flex-shrink: 0;
+  }
+
+  .image-browser-batch-delete-btn {
+    min-height: 2.75rem;
+    min-width: 2.75rem;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .image-browser-batch-delete-label {
+    display: none;
   }
 }
 
 @media (max-width: 640px) {
   .image-browser-toolbar {
-    padding: 0 0.5rem;
-  }
-
-  .image-browser-title {
-    font-size: 1.125rem;
-  }
-
-  .image-browser-controls {
-    gap: 0.5rem;
+    padding: 0.5rem;
   }
 }
 

--- a/packages/ui/src/image/image-browser/web/ImageBrowser.tsx
+++ b/packages/ui/src/image/image-browser/web/ImageBrowser.tsx
@@ -442,21 +442,12 @@ const ImageBrowser: React.FC<ImageBrowserProps> = ({
             <button
               type="button"
               onClick={handleOpenBatchDelete}
-              style={{
-                padding: '0.375rem 0.75rem',
-                fontSize: '0.875rem',
-                border: '1px solid #dc2626',
-                borderRadius: '0.375rem',
-                backgroundColor: '#ffffff',
-                color: '#dc2626',
-                cursor: 'pointer',
-                display: 'flex',
-                alignItems: 'center',
-                gap: '0.25rem',
-              }}
+              className="image-browser-batch-delete-btn"
             >
-              <Trash2 style={{ width: '1rem', height: '1rem' }} />
-              {t('image.batchDelete.button')}
+              <Trash2 className="image-browser-batch-delete-icon" />
+              <span className="image-browser-batch-delete-label">
+                {t('image.batchDelete.button')}
+              </span>
             </button>
           )}
 

--- a/packages/ui/src/image/image-browser/web/ImageGrid.css
+++ b/packages/ui/src/image/image-browser/web/ImageGrid.css
@@ -381,6 +381,36 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
+.image-action-button--danger .image-action-icon {
+  color: #dc2626;
+}
+
+/* 窄屏：缩略图下方操作栏（默认隐藏，见 @media） */
+.image-grid-actions-mobile {
+  display: none;
+}
+
+.image-grid-actions-mobile .image-action-button {
+  flex: 1;
+  min-height: 2.5rem;
+  border-radius: 0.375rem;
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+.image-grid-actions-mobile .image-action-button:hover {
+  transform: none;
+  background: #f3f4f6;
+  box-shadow: none;
+}
+
+.image-grid-actions-mobile .image-action-button--danger {
+  border-color: #fecaca;
+  background: #fff;
+}
+
 /* 图片信息区域样式（重复定义已合并到上方） */
 
 /* 文本截断样式 */
@@ -416,30 +446,69 @@
 @media (max-width: 767px) {
   .image-grid {
     grid-template-columns: repeat(2, 1fr);
-    gap: 0.75rem;
-    padding: 0.75rem;
+    gap: 0.625rem;
+    padding: 0.5rem;
   }
 
   .image-browser-item {
     min-height: 0;
   }
 
+  .image-grid-preview {
+    max-height: none;
+  }
+
+  /* 不遮挡缩略图：隐藏悬停层，改用下方操作栏 */
+  .image-grid-overlay {
+    display: none;
+  }
+
+  .image-grid-actions-mobile {
+    display: flex;
+    gap: 0.375rem;
+    padding: 0.375rem 0.5rem 0;
+    background: #ffffff;
+    border-bottom: 1px solid #f3f4f6;
+  }
+
   .image-info-section {
-    min-height: 100px;
-    max-height: 120px;
+    min-height: 0;
+    max-height: none;
     padding: 0.5rem;
   }
 
-  .image-grid-actions button,
-  .image-grid-overlay button {
-    min-width: 2.75rem;
-    min-height: 2.75rem;
-    padding: 0.5rem;
+  .image-grid-title {
+    font-size: 0.8125rem;
+    -webkit-line-clamp: 1;
+  }
+
+  .image-grid-description {
+    display: none;
+  }
+
+  .image-info-footer {
+    padding-top: 0.25rem;
+    gap: 0.125rem;
+  }
+
+  .image-grid-tags {
+    max-height: 1.25rem;
+    overflow: hidden;
+  }
+
+  .image-grid-meta,
+  .image-grid-date {
+    font-size: 0.6875rem;
   }
 
   .image-grid-selected-indicator {
-    width: 1.75rem;
-    height: 1.75rem;
+    width: 1.5rem;
+    height: 1.5rem;
+    font-size: 0.6875rem;
+  }
+
+  .image-browser-item.selected {
+    outline-offset: -2px;
   }
 }
 

--- a/packages/ui/src/image/image-browser/web/ImageGrid.tsx
+++ b/packages/ui/src/image/image-browser/web/ImageGrid.tsx
@@ -37,6 +37,65 @@ interface ImageGridProps {
   t: (key: string) => string;
 }
 
+interface ImageGridActionsProps {
+  image: ImageItem;
+  translate: (key: string) => string;
+  onPreview: (image: ImageItem) => void;
+  onViewUrl: (image: ImageItem) => void;
+  onEdit: (image: ImageItem) => void;
+  onDelete: (image: ImageItem) => void;
+}
+
+function ImageGridActions({
+  image,
+  translate,
+  onPreview,
+  onViewUrl,
+  onEdit,
+  onDelete,
+}: ImageGridActionsProps) {
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => onPreview(image)}
+        className="image-action-button"
+        title={translate('image.grid.preview')}
+        aria-label={translate('image.grid.preview')}
+      >
+        <Eye className="image-action-icon" />
+      </button>
+      <button
+        type="button"
+        onClick={() => onViewUrl(image)}
+        className="image-action-button"
+        title={translate('image.grid.viewUrl')}
+        aria-label={translate('image.grid.viewUrl')}
+      >
+        <Link className="image-action-icon" />
+      </button>
+      <button
+        type="button"
+        onClick={() => onEdit(image)}
+        className="image-action-button"
+        title={translate('image.grid.edit')}
+        aria-label={translate('image.grid.edit')}
+      >
+        <Edit className="image-action-icon" />
+      </button>
+      <button
+        type="button"
+        onClick={() => onDelete(image)}
+        className="image-action-button image-action-button--danger"
+        title={translate('image.grid.delete')}
+        aria-label={translate('image.grid.delete')}
+      >
+        <Trash2 className="image-action-icon" />
+      </button>
+    </>
+  );
+}
+
 const ImageGridComponent: React.FC<ImageGridProps> = ({
   images,
   className = '',
@@ -352,42 +411,37 @@ const ImageGridComponent: React.FC<ImageGridProps> = ({
               }}
             />
 
-            {/* 操作按钮 */}
+            {/* 桌面端：悬停操作层 */}
             <div
               className="image-grid-overlay"
               onClick={e => e.stopPropagation()}
             >
               <div className="image-grid-actions">
-                <button
-                  onClick={() => handlePreview(image)}
-                  className="image-action-button"
-                  title={translate('image.grid.preview')}
-                >
-                  <Eye className="image-action-icon" />
-                </button>
-                <button
-                  onClick={() => handleViewUrl(image)}
-                  className="image-action-button"
-                  title={translate('image.grid.viewUrl')}
-                >
-                  <Link className="image-action-icon" />
-                </button>
-                <button
-                  onClick={() => handleEdit(image)}
-                  className="image-action-button"
-                  title={translate('image.grid.edit')}
-                >
-                  <Edit className="image-action-icon" />
-                </button>
-                <button
-                  onClick={() => handleDelete(image)}
-                  className="image-action-button"
-                  title={translate('image.grid.delete')}
-                >
-                  <Trash2 className="image-action-icon" />
-                </button>
+                <ImageGridActions
+                  image={image}
+                  translate={translate}
+                  onPreview={handlePreview}
+                  onViewUrl={handleViewUrl}
+                  onEdit={handleEdit}
+                  onDelete={handleDelete}
+                />
               </div>
             </div>
+          </div>
+
+          {/* 窄屏：缩略图下方操作栏（不遮挡图片） */}
+          <div
+            className="image-grid-actions-mobile"
+            onClick={e => e.stopPropagation()}
+          >
+            <ImageGridActions
+              image={image}
+              translate={translate}
+              onPreview={handlePreview}
+              onViewUrl={handleViewUrl}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+            />
           </div>
 
           {/* 图片信息 */}

--- a/packages/ui/src/image/image-browser/web/ImageList.css
+++ b/packages/ui/src/image/image-browser/web/ImageList.css
@@ -399,24 +399,118 @@
   overflow: hidden;
 }
 
-/* 响应式设计 */
-@media (max-width: 768px) {
+/* 响应式设计 — 平板过渡 */
+@media (min-width: 768px) and (max-width: 1023px) {
   .image-list-item .px-6 {
     padding-left: 1rem;
     padding-right: 1rem;
   }
+}
 
-  .image-list-item .w-16 {
-    width: 3rem;
+/* 窄屏触控优化（REF-512 #150） */
+@media (max-width: 767px) {
+  .image-list-header {
+    padding: 0.5rem 0.75rem;
   }
 
-  .image-list-item .h-16 {
-    height: 3rem;
+  .image-list-header-title {
+    font-size: 1rem;
   }
 
-  .image-list-header .px-6 {
-    padding-left: 1rem;
-    padding-right: 1rem;
+  .image-list-item .px-6 {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
+
+  .image-list-main-row {
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 0.625rem;
+  }
+
+  .image-list-thumbnail {
+    width: 3.5rem;
+    height: 3.5rem;
+  }
+
+  .image-list-main-content {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .image-list-info-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.375rem;
+    margin-bottom: 0.375rem;
+  }
+
+  .image-list-title {
+    white-space: normal;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .image-list-description {
+    font-size: 0.8125rem;
+    margin-bottom: 0.375rem;
+    -webkit-line-clamp: 1;
+  }
+
+  .image-list-meta {
+    flex-wrap: wrap;
+    gap: 0.5rem 0.75rem;
+  }
+
+  .image-list-actions {
+    flex-basis: 100%;
+    width: 100%;
+    justify-content: stretch;
+    gap: 0.375rem;
+    padding-top: 0.5rem;
+    margin-top: 0.125rem;
+    border-top: 1px solid #f3f4f6;
+  }
+
+  .image-list-action-button {
+    flex: 1;
+    min-height: 2.75rem;
+    min-width: 2.75rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #f9fafb;
+    border: 1px solid #e5e7eb;
+  }
+
+  .image-list-action-icon {
+    width: 1.125rem;
+    height: 1.125rem;
+  }
+
+  .image-list-expanded {
+    padding: 0.75rem;
+  }
+
+  .image-list-expanded-actions {
+    flex-direction: column;
+    width: 100%;
+    gap: 0.5rem;
+  }
+
+  .image-list-secondary-button {
+    width: 100%;
+    min-height: 2.75rem;
+    justify-content: center;
+  }
+
+  .image-list-load-more-button {
+    width: 100%;
+    min-height: 2.75rem;
   }
 }
 

--- a/packages/ui/src/image/image-browser/web/ImageSorter.css
+++ b/packages/ui/src/image/image-browser/web/ImageSorter.css
@@ -63,32 +63,35 @@
 }
 
 /* 响应式设计 */
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .image-sorter-container {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.75rem;
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: nowrap;
+    gap: 0.375rem;
+  }
+
+  .image-sorter-label {
+    display: none;
   }
 
   .sort-button {
-    width: 100%;
+    width: auto;
+    min-height: 2.75rem;
+    min-width: 2.75rem;
+    padding: 0.5rem 0.625rem;
+    white-space: nowrap;
     justify-content: center;
   }
-}
 
-@media (max-width: 640px) {
-  .image-sorter-container {
-    margin-top: 0.5rem;
+  .sort-label {
+    display: none;
   }
 
-  .sort-button {
-    padding: 0.375rem 0.5rem;
-    font-size: 0.75rem;
-  }
-
-  .sort-icon {
-    width: 0.875rem;
-    height: 0.875rem;
+  .sort-icon,
+  .image-sorter-icon {
+    width: 1.125rem;
+    height: 1.125rem;
   }
 }
 

--- a/packages/ui/src/image/image-browser/web/ImageViewToggle.css
+++ b/packages/ui/src/image/image-browser/web/ImageViewToggle.css
@@ -45,3 +45,26 @@
   font-size: 0.875rem;
   font-weight: 500;
 }
+
+/* 窄屏：仅图标 + 触控热区（REF-512 #150） */
+@media (max-width: 767px) {
+  .image-view-toggle-container {
+    flex-shrink: 0;
+  }
+
+  .image-view-toggle-button {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+    padding: 0.5rem;
+    justify-content: center;
+  }
+
+  .image-view-toggle-text {
+    display: none;
+  }
+
+  .image-view-toggle-icon {
+    width: 1.125rem;
+    height: 1.125rem;
+  }
+}

--- a/packages/ui/src/image/image-preview-modal/web/ImagePreviewModal.css
+++ b/packages/ui/src/image/image-preview-modal/web/ImagePreviewModal.css
@@ -12,6 +12,7 @@
 .image-preview-modal-container {
   width: 100vw;
   height: 100vh;
+  height: 100dvh;
   padding: 0;
   display: flex;
   flex-direction: column;
@@ -192,7 +193,7 @@
 @media (max-width: 768px) {
   .image-preview-modal-container {
     width: 100vw;
-    height: 100vh;
+    height: 100dvh;
     padding: 0;
   }
 
@@ -202,13 +203,17 @@
   }
 
   .image-preview-modal-close {
-    top: 1rem;
-    right: 1rem;
+    top: max(1rem, env(safe-area-inset-top, 0));
+    right: max(1rem, env(safe-area-inset-right, 0));
+    min-width: 2.75rem;
+    min-height: 2.75rem;
     padding: 0.5rem;
   }
 
   .image-preview-modal-nav {
     padding: 0.75rem;
+    min-width: 2.75rem;
+    min-height: 2.75rem;
   }
 
   .image-preview-modal-nav-left {

--- a/packages/ui/src/image/image-upload/web/ImageUploadModal.css
+++ b/packages/ui/src/image/image-upload/web/ImageUploadModal.css
@@ -99,21 +99,25 @@
   background: #ffffff;
 }
 
-/* 响应式设计 */
-@media (max-width: 640px) {
+/* 窄屏全屏弹层（REF-512 #150） */
+@media (max-width: 767px) {
   .image-upload-modal-overlay {
     padding: 0;
+    align-items: stretch;
   }
 
   .image-upload-modal-content {
-    max-width: 100%;
-    max-height: 100vh;
+    max-width: none;
+    width: 100%;
+    max-height: none;
+    height: 100%;
+    height: 100dvh;
     border-radius: 0;
-    height: 100vh;
   }
 
   .image-upload-modal-header {
-    padding: 1.25rem 1rem;
+    padding: 1rem;
+    padding-top: max(1rem, env(safe-area-inset-top, 0));
   }
 
   .image-upload-modal-title {
@@ -121,16 +125,12 @@
   }
 
   .image-upload-modal-body {
-    padding: 1.5rem 1rem;
-  }
-}
-
-@media (max-width: 480px) {
-  .image-upload-modal-header {
     padding: 1rem;
+    padding-bottom: max(1rem, env(safe-area-inset-bottom, 0));
   }
 
-  .image-upload-modal-body {
-    padding: 1rem;
+  .image-upload-modal-close {
+    width: 2.75rem;
+    height: 2.75rem;
   }
 }

--- a/packages/ui/src/layout/header/web/Header.css
+++ b/packages/ui/src/layout/header/web/Header.css
@@ -300,16 +300,37 @@
   flex-shrink: 0;
 }
 
+.header-search-slot {
+  flex: 1;
+  min-width: 0;
+}
+
+.header-search-slot--mobile {
+  max-width: none;
+}
+
+.header-search-slot .search-wrapper--header {
+  width: 100%;
+}
+
 /* 响应式设计 */
 @media (max-width: 768px) {
   .app-header {
     padding: 0 1rem;
+    padding-left: max(1rem, env(safe-area-inset-left, 0));
+    padding-right: max(1rem, env(safe-area-inset-right, 0));
     gap: 1rem;
+  }
+
+  .header-button.icon-only {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
   }
 
   .header-left {
     flex: 1;
     min-width: 0;
+    gap: 0.5rem;
   }
 
   .header-left .search-bar {

--- a/packages/ui/src/layout/sidebar/web/Sidebar.css
+++ b/packages/ui/src/layout/sidebar/web/Sidebar.css
@@ -813,6 +813,8 @@
     max-width: min(85vw, 280px);
     height: 100%;
     height: 100dvh;
+    padding-top: env(safe-area-inset-top, 0);
+    padding-bottom: env(safe-area-inset-bottom, 0);
     transform: translateX(-100%);
     transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
     box-shadow: none;

--- a/packages/ui/src/layout/sidebar/web/Sidebar.tsx
+++ b/packages/ui/src/layout/sidebar/web/Sidebar.tsx
@@ -65,6 +65,8 @@ interface SidebarProps {
   mobileOpen?: boolean;
   /** 点击遮罩或完成导航后关闭抽屉 */
   onMobileClose?: () => void;
+  /** 侧栏底部区域上方插槽（如演示模式区块） */
+  footerExtra?: React.ReactNode;
   t?: (key: string) => string;
 }
 
@@ -137,6 +139,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   onToggleCollapse,
   mobileOpen = false,
   onMobileClose,
+  footerExtra,
   t,
 }) => {
   const translate = t || defaultTranslate;
@@ -627,6 +630,8 @@ const Sidebar: React.FC<SidebarProps> = ({
             </div>
           )}
         </div>
+
+        {footerExtra}
 
         {/* 底部操作 */}
         <div className="sidebar-footer">

--- a/packages/ui/src/primitives/search/web/Search.css
+++ b/packages/ui/src/primitives/search/web/Search.css
@@ -265,11 +265,38 @@
   }
 }
 
+.search-filter-backdrop {
+  display: none;
+}
+
 /* 窄屏：筛选面板底部 sheet（REF-512 #150） */
 @media (max-width: 767px) {
+  .search-filter-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 999;
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: rgba(0, 0, 0, 0.4);
+    cursor: pointer;
+  }
+
   .search-wrapper--header {
-    flex-wrap: wrap;
-    gap: 0.5rem;
+    flex: 1;
+    flex-wrap: nowrap;
+    gap: 0.375rem;
+    min-width: 0;
+  }
+
+  .search-wrapper--header .search-bar-wrapper {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .search-filter-wrapper {
+    flex-shrink: 0;
   }
 
   .search-filter-button {
@@ -290,6 +317,7 @@
     padding-bottom: env(safe-area-inset-bottom, 0);
     box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.12);
     animation: search-filter-sheet-up 0.22s ease-out;
+    z-index: 1000;
   }
 
   .search-filter-option {

--- a/packages/ui/src/primitives/search/web/Search.tsx
+++ b/packages/ui/src/primitives/search/web/Search.tsx
@@ -201,6 +201,19 @@ const Search: React.FC<SearchProps> = ({
       window.removeEventListener('pixuli:closeFilterPanel', onCloseFilter);
   }, []);
 
+  // 窄屏筛选 sheet：锁定背景滚动（REF-512 #150）
+  useEffect(() => {
+    if (!showFilterPanel) return;
+    if (typeof window.matchMedia !== 'function') return;
+    const mq = window.matchMedia('(max-width: 767px)');
+    if (!mq.matches) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [showFilterPanel]);
+
   // 检查是否有活动的筛选条件
   const hasActiveFilters =
     externalFilters &&
@@ -266,69 +279,77 @@ const Search: React.FC<SearchProps> = ({
               {hasActiveFilters && <span className="search-filter-badge" />}
             </button>
             {showFilterPanel && (
-              <div className="search-filter-panel">
-                <div className="search-filter-panel-header">
-                  <span className="search-filter-panel-title">
-                    {translate('search.header.filter') || '筛选'}
-                  </span>
-                  {hasActiveFilters && (
-                    <button
-                      onClick={handleClearAll}
-                      className="search-filter-clear"
-                    >
-                      {translate('search.header.clearFilters') || '清除'}
-                    </button>
+              <>
+                <button
+                  type="button"
+                  className="search-filter-backdrop"
+                  aria-label={translate('common.cancel') || '关闭'}
+                  onClick={() => setShowFilterPanel(false)}
+                />
+                <div className="search-filter-panel">
+                  <div className="search-filter-panel-header">
+                    <span className="search-filter-panel-title">
+                      {translate('search.header.filter') || '筛选'}
+                    </span>
+                    {hasActiveFilters && (
+                      <button
+                        onClick={handleClearAll}
+                        className="search-filter-clear"
+                      >
+                        {translate('search.header.clearFilters') || '清除'}
+                      </button>
+                    )}
+                  </div>
+                  {availableTypes.length > 0 && (
+                    <div className="search-filter-section">
+                      <label className="search-filter-label">
+                        {translate('image.filter.imageType') || '图片类型'}
+                      </label>
+                      <div className="search-filter-options">
+                        {availableTypes.map(type => (
+                          <label key={type} className="search-filter-option">
+                            <input
+                              type="checkbox"
+                              checked={
+                                externalFilters?.selectedTypes.includes(type) ||
+                                false
+                              }
+                              onChange={e =>
+                                handleTypeChange(type, e.target.checked)
+                              }
+                            />
+                            <span>{type}</span>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {availableTags.length > 0 && (
+                    <div className="search-filter-section">
+                      <label className="search-filter-label">
+                        {translate('image.filter.tags') || '标签'}
+                      </label>
+                      <div className="search-filter-options">
+                        {availableTags.map(tag => (
+                          <label key={tag} className="search-filter-option">
+                            <input
+                              type="checkbox"
+                              checked={
+                                externalFilters?.selectedTags.includes(tag) ||
+                                false
+                              }
+                              onChange={e =>
+                                handleTagChange(tag, e.target.checked)
+                              }
+                            />
+                            <span>{tag}</span>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
                   )}
                 </div>
-                {availableTypes.length > 0 && (
-                  <div className="search-filter-section">
-                    <label className="search-filter-label">
-                      {translate('image.filter.imageType') || '图片类型'}
-                    </label>
-                    <div className="search-filter-options">
-                      {availableTypes.map(type => (
-                        <label key={type} className="search-filter-option">
-                          <input
-                            type="checkbox"
-                            checked={
-                              externalFilters?.selectedTypes.includes(type) ||
-                              false
-                            }
-                            onChange={e =>
-                              handleTypeChange(type, e.target.checked)
-                            }
-                          />
-                          <span>{type}</span>
-                        </label>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                {availableTags.length > 0 && (
-                  <div className="search-filter-section">
-                    <label className="search-filter-label">
-                      {translate('image.filter.tags') || '标签'}
-                    </label>
-                    <div className="search-filter-options">
-                      {availableTags.map(tag => (
-                        <label key={tag} className="search-filter-option">
-                          <input
-                            type="checkbox"
-                            checked={
-                              externalFilters?.selectedTags.includes(tag) ||
-                              false
-                            }
-                            onChange={e =>
-                              handleTagChange(tag, e.target.checked)
-                            }
-                          />
-                          <span>{tag}</span>
-                        </label>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
+              </>
             )}
           </div>
         )}

--- a/packages/ui/src/primitives/search/web/SearchBar.css
+++ b/packages/ui/src/primitives/search/web/SearchBar.css
@@ -194,3 +194,51 @@
   background: var(--error-bg, #fee2e2);
   color: var(--error-color, #dc2626);
 }
+
+/* 窄屏搜索框（REF-512 #150） */
+@media (max-width: 767px) {
+  .search-bar {
+    padding: 0.375rem 0.625rem;
+    min-height: 2.75rem;
+    max-width: none;
+    border-radius: 0.5rem;
+  }
+
+  .search-icon {
+    margin-right: 0.375rem;
+  }
+
+  .search-input {
+    font-size: 1rem;
+    min-width: 0;
+  }
+
+  .search-shortcut-hint {
+    display: none;
+  }
+
+  .search-clear {
+    min-width: 2.25rem;
+    min-height: 2.25rem;
+    margin-left: 0.25rem;
+  }
+
+  .search-history-panel {
+    position: fixed;
+    left: max(0.75rem, env(safe-area-inset-left, 0));
+    right: max(0.75rem, env(safe-area-inset-right, 0));
+    max-height: min(50vh, 20rem);
+    border-radius: 0.75rem;
+    box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.12);
+  }
+
+  .search-history-item {
+    min-height: 2.75rem;
+  }
+
+  .search-history-delete {
+    opacity: 1;
+    min-width: 2.25rem;
+    min-height: 2.25rem;
+  }
+}


### PR DESCRIPTION
## Summary

- **侧栏与 Demo**：窄屏抽屉 safe-area；演示模式区块（`DemoSidebarSection`）接入侧栏菜单，支持下载 Demo 配置与退出演示；Header 内 Demo 入口在移动端隐藏
- **搜索与弹层**：顶栏搜索框满宽布局、触控热区与历史/筛选 sheet；配置/上传/预览/源类型选择等弹层窄屏全屏 + safe-area
- **ImageBrowser**：工具栏 sticky + 横向滑动；排序/视图切换图标化；网格操作移至缩略图下方独立操作栏；列表模式操作钮整行等宽
- **Android 返回键**：延续 `useCapacitorBackButton` 关闭弹层/抽屉链路

本 PR 推进 **#150（REF-512）** 移动端体验，**不宣称完整关闭 Issue**。若合并后真机/窄屏仍发现布局或触控问题，请**新建独立 Issue** 跟踪修复（标题建议含 `REF-512`），避免与本 PR 范围纠缠。

## Test plan

- [x] `pnpm test`（513 passed）
- [ ] 窄屏浏览器：菜单 → 配置源 → 列表 → 上传
- [ ] 照片页：搜索 + 筛选 sheet、网格/列表切换、单张操作可点
- [ ] Demo 模式：侧栏演示区块下载 JSON；Capacitor 硬件返回键关闭弹层/抽屉
- [ ] Android 模拟器/真机冒烟（可选）


Made with [Cursor](https://cursor.com)