### PR TITLE
feat(pixuli): REF-607-P5 Web 本地工作区与 local-only UI 聚合

### DIFF
--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -290,8 +290,9 @@ Android 启动器与 splash 与 RN 一致（#167）。
 
 **建议顺序**：**#164** ✅ → **#150** → **#165** → **#119/#120/#141** →
 **#161**（REF-607 P1～P3 ✅ 后）→ **#166** → **#152/#153** →
-**#151**。REF-607 下一步：**#160**（Web OPFS）→ **#161**（Mobile SAF）→
-**P7**（Gitee 代理退役）；**#159** ✅（`imageStore` local 模式）。
+**#151**。REF-607 下一步：**#161**（Mobile SAF）→
+**P7**（Gitee 代理退役）；**#159** ✅（`imageStore` local 模式）；**#160**
+✅（Web OPFS/FSA）。
 
 **与 REF-507～515 关系**：REF-512～515 仍保留计划编号；追踪统一归入
 [里程碑 #8](https://github.com/trueLoving/Pixuli/milestone/8)，避免 M5 表与执行里程碑脱节。
@@ -1290,7 +1291,7 @@ Capacitor；[里程碑 #8](https://github.com/trueLoving/Pixuli/milestone/8)
 
 **建议顺序（REF-516）**：**#116** ✅ → **#118** ✅ → **#164** ✅ → **#150** →
 **#165** → **#119/#120/#141** → **#166** → **#152/#153** → **#151**。REF-607
-**#156→#158** ✅、**#159** ✅；下一步 **#160** → **#161** →
+**#156→#158** ✅、**#159** ✅、**#160** ✅；下一步 **#161** →
 **P7**（代理退役与 local-only 收官）。
 
 ---
@@ -1318,7 +1319,7 @@ Capacitor；[里程碑 #8](https://github.com/trueLoving/Pixuli/milestone/8)
 | P2      | Desktop PoC：选目录、本地列表、手动 push                            | [#157](https://github.com/trueLoving/Pixuli/issues/157) | ✅   |
 | P3      | 索引与 pull：`index.json`、`scan()`、SyncEngine MVP                 | [#158](https://github.com/trueLoving/Pixuli/issues/158) | ✅   |
 | P4      | 应用切换：`imageStore` local 模式与迁移向导                         | [#159](https://github.com/trueLoving/Pixuli/issues/159) | ✅   |
-| P5      | Web：OPFS/IDB 虚拟工作区适配器                                      | [#160](https://github.com/trueLoving/Pixuli/issues/160) | ⬜   |
+| P5      | Web：OPFS/IDB 虚拟工作区适配器                                      | [#160](https://github.com/trueLoving/Pixuli/issues/160) | ✅   |
 | P6      | Mobile：SAF / Capacitor 工作区适配器                                | [#161](https://github.com/trueLoving/Pixuli/issues/161) | ⬜   |
 | P7      | **收官**：Gitee 图片代理退役 + `remote-only` 移除 + local-only 锁死 | [#173](https://github.com/trueLoving/Pixuli/issues/173) | ⬜   |
 

--- a/apps/pixuli/src/App.tsx
+++ b/apps/pixuli/src/App.tsx
@@ -12,7 +12,7 @@ import {
 } from './hooks';
 import { useI18n } from './i18n/useI18n';
 import { MainLayout } from './layouts/MainLayout';
-import { isDesktopWorkspaceAvailable } from './platforms/desktop/workspaceAdapter';
+import { isWorkspaceAvailable } from './platforms/workspacePlatform';
 import { AppRoutes } from './router/routes';
 import { useImageStore } from './stores/imageStore';
 import { useSourceStore } from './stores/sourceStore';
@@ -22,17 +22,16 @@ import { useWorkspaceStore } from './stores/workspaceStore';
 // 主应用组件（统一 Web 和 Desktop）
 function App() {
   const { t } = useI18n();
-  const { loadImages, uploadImage, uploadMultipleImages } = useImageStore();
+  const { loadImages } = useImageStore();
   const initializeWorkspace = useWorkspaceStore(state => state.initialize);
-  const workspaceMode = useWorkspaceStore(state => state.mode);
+  const localActive = useWorkspaceStore(state => state.isLocalActive());
 
   useEffect(() => {
-    if (!isDesktopWorkspaceAvailable()) {
+    if (!isWorkspaceAvailable()) {
       return;
     }
     void initializeWorkspace().then(() => {
-      const mode = useWorkspaceStore.getState().mode;
-      if (mode === 'local' || mode === 'remote-only') {
+      if (useWorkspaceStore.getState().isLocalActive()) {
         void loadImages();
       }
     });
@@ -77,9 +76,7 @@ function App() {
   // 配置管理
   const { handleSaveConfig, handleClearConfig } = useConfigManagement();
 
-  const hasConfig =
-    sources.length > 0 ||
-    (isDesktopWorkspaceAvailable() && workspaceMode === 'local');
+  const hasConfig = isWorkspaceAvailable() ? localActive : sources.length > 0;
 
   const handleLoadImages = useCallback(async () => {
     try {
@@ -88,9 +85,6 @@ function App() {
       console.error('Failed to load images:', error);
     }
   }, [loadImages]);
-
-  const handleUploadImage = uploadImage;
-  const handleUploadMultipleImages = uploadMultipleImages;
 
   // 保存配置（包装以包含 editingSourceId）
   const handleSaveConfigWithId = useMemo(
@@ -126,9 +120,9 @@ function App() {
     [handleDeleteSource, t],
   );
 
-  // 同步选中源到配置，并在同步后加载图片
+  // 同步选中源到配置（远端源仅用于同步绑定，不触发远端列表加载）
   useSelectedSourceSync(selectedSource ?? null, () => {
-    if (useWorkspaceStore.getState().isLocalActive()) {
+    if (isWorkspaceAvailable()) {
       return;
     }
     if (sources.length > 0 && selectedSource) {
@@ -187,9 +181,6 @@ function App() {
         onSourceDelete={handleDeleteSourceWithT}
         hasConfig={hasConfig}
         onAddSource={addSource}
-        onLoadImages={handleLoadImages}
-        onUploadImage={handleUploadImage}
-        onUploadMultipleImages={handleUploadMultipleImages}
         onSaveConfig={handleSaveConfigWithId}
         onClearConfig={handleClearConfigWithId}
         onSelectSourceType={handleSelectSourceType}

--- a/apps/pixuli/src/contexts/SearchContext.tsx
+++ b/apps/pixuli/src/contexts/SearchContext.tsx
@@ -1,6 +1,6 @@
 /**
  * 搜索上下文
- * 用于在 Header 中显示搜索框
+ * 用于照片页 ImageBrowser 中的搜索与筛选
  */
 
 import React, {
@@ -28,8 +28,6 @@ interface SearchContextValue {
   setFilters: (
     filters: FilterOptions | ((prev: FilterOptions) => FilterOptions),
   ) => void;
-  showSearch: boolean;
-  setShowSearch: (show: boolean) => void;
   history: SearchHistoryItem[];
   handleSelectHistory: (query: string) => void;
   handleDeleteHistory: (query: string) => void;
@@ -61,7 +59,6 @@ interface SearchProviderProps {
 export const SearchProvider: React.FC<SearchProviderProps> = ({ children }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [filters, setFilters] = useState<FilterOptions>(createDefaultFilters());
-  const [showSearch, setShowSearch] = useState(false);
   const [history, setHistory] = useState<SearchHistoryItem[]>([]);
 
   // 加载历史记录
@@ -110,8 +107,6 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({ children }) => {
         setSearchQuery: handleSearchQueryChange,
         filters,
         setFilters,
-        showSearch,
-        setShowSearch,
         history,
         handleSelectHistory,
         handleDeleteHistory,

--- a/apps/pixuli/src/features/image-content/ImageContent.tsx
+++ b/apps/pixuli/src/features/image-content/ImageContent.tsx
@@ -1,8 +1,11 @@
 import { EmptyState, ImageBrowser } from '@pixuli/ui';
+import type { ImageBrowserSearchConfig } from '@pixuli/ui';
 import { formatFileSize, getImageDimensionsFromUrl } from '@pixuli/core/utils';
 import { RefreshCw } from 'lucide-react';
 import React from 'react';
+import { isWorkspaceAvailable } from '../../platforms/workspacePlatform';
 import { useImageStore } from '../../stores/imageStore';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
 
 interface ImageContentProps {
   hasConfig: boolean;
@@ -18,6 +21,7 @@ interface ImageContentProps {
   onUpdateImage: (data: any) => Promise<void>;
   onOpenConfigModal: () => void;
   t: (key: string, options?: Record<string, any>) => string;
+  search?: ImageBrowserSearchConfig;
 }
 
 export const ImageContent: React.FC<ImageContentProps> = ({
@@ -31,7 +35,19 @@ export const ImageContent: React.FC<ImageContentProps> = ({
   onUpdateImage,
   onOpenConfigModal,
   t,
+  search,
 }) => {
+  const uploadImage = useImageStore(state => state.uploadImage);
+  const uploadMultipleImages = useImageStore(
+    state => state.uploadMultipleImages,
+  );
+  const batchUploadProgress = useImageStore(state => state.batchUploadProgress);
+  const imageLoading = useImageStore(state => state.loading);
+  const workspaceMode = useWorkspaceStore(state => state.mode);
+  const workspaceLoading = useWorkspaceStore(state => state.loading);
+  const localActive = isWorkspaceAvailable() && workspaceMode === 'local';
+  const uploadLoading = localActive ? workspaceLoading : imageLoading;
+
   if (!hasConfig) {
     return (
       <div className="w-full px-4 sm:px-6 lg:px-8 py-4">
@@ -94,9 +110,15 @@ export const ImageContent: React.FC<ImageContentProps> = ({
         <ImageBrowser
           t={t}
           images={images}
+          hasConfig={hasConfig}
+          search={search}
           onDeleteImage={onDeleteImage}
           onDeleteMultipleImages={onDeleteMultipleImages}
           onUpdateImage={onUpdateImage}
+          onUploadImage={uploadImage}
+          onUploadMultipleImages={uploadMultipleImages}
+          uploadLoading={uploadLoading}
+          batchUploadProgress={batchUploadProgress}
           getImageDimensionsFromUrl={getImageDimensionsFromUrl}
           formatFileSize={formatFileSize}
         />

--- a/apps/pixuli/src/features/workspace/WorkspaceMigrationWizard.tsx
+++ b/apps/pixuli/src/features/workspace/WorkspaceMigrationWizard.tsx
@@ -1,5 +1,10 @@
 import React, { useState } from 'react';
-import { Cloud, FolderOpen } from 'lucide-react';
+import { FolderOpen, FolderSync } from 'lucide-react';
+import {
+  isFileSystemAccessSupported,
+  isOpfsSupported,
+  isWebWorkspaceActive,
+} from '@/platforms/workspacePlatform';
 import { useImageStore } from '@/stores/imageStore';
 import { useSourceStore } from '@/stores/sourceStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
@@ -14,26 +19,23 @@ export const WorkspaceMigrationWizard: React.FC<
 > = ({ onComplete }) => {
   const { t } = useI18n();
   const sourceCount = useSourceStore(state => state.sources.length);
-  const { pickWorkspace, setRemoteOnlyMode, loading, error } =
-    useWorkspaceStore();
+  const { pickWorkspace, loading, error } = useWorkspaceStore();
   const loadImages = useImageStore(state => state.loadImages);
   const [pullAfter, setPullAfter] = useState(false);
+  const isWebWorkspace = isWebWorkspaceActive();
+  const canPickFolder = isWebWorkspace && isFileSystemAccessSupported();
+  const canCreateOpfs = isWebWorkspace && isOpfsSupported();
 
   const finish = async () => {
     await loadImages();
     onComplete?.();
   };
 
-  const handlePickLocal = async () => {
-    const ok = await pickWorkspace({ pullAfter });
+  const handlePickLocal = async (backend: 'opfs' | 'fsa') => {
+    const ok = await pickWorkspace({ pullAfter, backend });
     if (ok) {
       await finish();
     }
-  };
-
-  const handleRemoteOnly = async () => {
-    setRemoteOnlyMode();
-    await finish();
   };
 
   return (
@@ -43,63 +45,78 @@ export const WorkspaceMigrationWizard: React.FC<
           {t('workspace.migrationTitle')}
         </h2>
         <p className="text-sm text-gray-600 mb-6">
-          {t('workspace.migrationHint', { count: sourceCount })}
+          {isWebWorkspace
+            ? t('workspace.migrationHintWebLocal', { count: sourceCount })
+            : t('workspace.migrationHint', { count: sourceCount })}
         </p>
 
-        <div className="space-y-4">
-          <div className="rounded-lg border border-gray-200 p-4">
-            <div className="flex items-start gap-3">
-              <FolderOpen className="mt-0.5 shrink-0 text-blue-600" size={22} />
-              <div className="min-w-0 flex-1">
-                <p className="text-sm font-medium text-gray-900">
-                  {t('workspace.migrationLocalTitle')}
-                </p>
-                <p className="mt-1 text-xs text-gray-600">
-                  {t('workspace.migrationLocalHint')}
-                </p>
-                <label className="mt-3 flex items-center gap-2 text-xs text-gray-700">
-                  <input
-                    type="checkbox"
-                    checked={pullAfter}
-                    onChange={event => setPullAfter(event.target.checked)}
-                    className="rounded border-gray-300"
-                  />
-                  {t('workspace.migrationPullAfter')}
-                </label>
-                <button
-                  type="button"
-                  onClick={() => void handlePickLocal()}
-                  disabled={loading}
-                  className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
-                >
-                  <FolderOpen size={16} />
-                  {loading
-                    ? t('workspace.picking')
-                    : t('workspace.migrationPickFolder')}
-                </button>
-              </div>
-            </div>
-          </div>
-
-          <div className="rounded-lg border border-gray-200 p-4">
-            <div className="flex items-start gap-3">
-              <Cloud className="mt-0.5 shrink-0 text-gray-600" size={22} />
-              <div className="min-w-0 flex-1">
-                <p className="text-sm font-medium text-gray-900">
-                  {t('workspace.migrationRemoteTitle')}
-                </p>
-                <p className="mt-1 text-xs text-gray-600">
-                  {t('workspace.migrationRemoteHint')}
-                </p>
-                <button
-                  type="button"
-                  onClick={() => void handleRemoteOnly()}
-                  disabled={loading}
-                  className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-800 hover:bg-gray-50 disabled:opacity-60"
-                >
-                  <Cloud size={16} />
-                  {t('workspace.migrationRemoteOnly')}
-                </button>
+        <div className="rounded-lg border border-gray-200 p-4">
+          <div className="flex items-start gap-3">
+            <FolderOpen className="mt-0.5 shrink-0 text-blue-600" size={22} />
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium text-gray-900">
+                {isWebWorkspace
+                  ? t('workspace.migrationLocalTitleWeb')
+                  : t('workspace.migrationLocalTitle')}
+              </p>
+              <p className="mt-1 text-xs text-gray-600">
+                {isWebWorkspace
+                  ? t('workspace.migrationLocalHintWeb')
+                  : t('workspace.migrationLocalHint')}
+              </p>
+              <label className="mt-3 flex items-center gap-2 text-xs text-gray-700">
+                <input
+                  type="checkbox"
+                  checked={pullAfter}
+                  onChange={event => setPullAfter(event.target.checked)}
+                  className="rounded border-gray-300"
+                />
+                {t('workspace.migrationPullAfter')}
+              </label>
+              <div className="mt-3 flex flex-col gap-2">
+                {canPickFolder && (
+                  <button
+                    type="button"
+                    onClick={() => void handlePickLocal('fsa')}
+                    disabled={loading}
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+                  >
+                    <FolderSync size={16} />
+                    {loading
+                      ? t('workspace.picking')
+                      : t('workspace.connectFolder')}
+                  </button>
+                )}
+                {canCreateOpfs && (
+                  <button
+                    type="button"
+                    onClick={() => void handlePickLocal('opfs')}
+                    disabled={loading}
+                    className={`inline-flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium disabled:opacity-60 ${
+                      canPickFolder
+                        ? 'border border-blue-300 bg-white text-blue-800 hover:bg-blue-50'
+                        : 'bg-blue-600 text-white hover:bg-blue-700'
+                    }`}
+                  >
+                    <FolderOpen size={16} />
+                    {loading
+                      ? t('workspace.picking')
+                      : t('workspace.createWorkspace')}
+                  </button>
+                )}
+                {!isWebWorkspace && (
+                  <button
+                    type="button"
+                    onClick={() => void handlePickLocal('opfs')}
+                    disabled={loading}
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+                  >
+                    <FolderOpen size={16} />
+                    {loading
+                      ? t('workspace.picking')
+                      : t('workspace.migrationPickFolder')}
+                  </button>
+                )}
               </div>
             </div>
           </div>

--- a/apps/pixuli/src/features/workspace/WorkspacePanel.tsx
+++ b/apps/pixuli/src/features/workspace/WorkspacePanel.tsx
@@ -2,14 +2,21 @@ import React from 'react';
 import {
   DownloadCloud,
   FolderOpen,
+  FolderSync,
   RefreshCw,
   ScanSearch,
   UploadCloud,
 } from 'lucide-react';
+import {
+  isFileSystemAccessSupported,
+  isOpfsSupported,
+  isWebWorkspaceActive,
+} from '@/platforms/workspacePlatform';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
-import { useImageStore } from '@/stores/imageStore';
 import { useSourceStore } from '@/stores/sourceStore';
 import { useI18n } from '@/i18n/useI18n';
+
+import { WorkspaceSourceSection } from './WorkspaceSourceSection';
 
 function formatSyncTime(
   iso: string | null | undefined,
@@ -29,9 +36,12 @@ export const WorkspaceSetupPanel: React.FC = () => {
   const { t } = useI18n();
   const { pickWorkspace, loading, error } = useWorkspaceStore();
   const loadImages = useImageStore(state => state.loadImages);
+  const isWebWorkspace = isWebWorkspaceActive();
+  const canPickFolder = isWebWorkspace && isFileSystemAccessSupported();
+  const canCreateOpfs = isWebWorkspace && isOpfsSupported();
 
-  const handlePick = async () => {
-    const ok = await pickWorkspace();
+  const handlePick = async (backend: 'opfs' | 'fsa') => {
+    const ok = await pickWorkspace({ backend });
     if (ok) {
       await loadImages();
     }
@@ -44,16 +54,52 @@ export const WorkspaceSetupPanel: React.FC = () => {
         <h2 className="text-lg font-semibold text-gray-900 mb-2">
           {t('workspace.setupTitle')}
         </h2>
-        <p className="text-sm text-gray-600 mb-6">{t('workspace.setupHint')}</p>
-        <button
-          type="button"
-          onClick={() => void handlePick()}
-          disabled={loading}
-          className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
-        >
-          <FolderOpen size={16} />
-          {loading ? t('workspace.picking') : t('workspace.pickFolder')}
-        </button>
+        <p className="text-sm text-gray-600 mb-6">
+          {isWebWorkspace
+            ? t('workspace.setupHintWebLocal')
+            : t('workspace.setupHint')}
+        </p>
+        <div className="flex flex-col gap-3">
+          {canPickFolder && (
+            <button
+              type="button"
+              onClick={() => void handlePick('fsa')}
+              disabled={loading}
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+            >
+              <FolderSync size={16} />
+              {loading ? t('workspace.picking') : t('workspace.connectFolder')}
+            </button>
+          )}
+          {canCreateOpfs && (
+            <button
+              type="button"
+              onClick={() => void handlePick('opfs')}
+              disabled={loading}
+              className={`inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium disabled:opacity-60 ${
+                canPickFolder
+                  ? 'border border-blue-300 bg-white text-blue-800 hover:bg-blue-50'
+                  : 'bg-blue-600 text-white hover:bg-blue-700'
+              }`}
+            >
+              <FolderOpen size={16} />
+              {loading
+                ? t('workspace.picking')
+                : t('workspace.createWorkspace')}
+            </button>
+          )}
+          {!isWebWorkspace && (
+            <button
+              type="button"
+              onClick={() => void handlePick('opfs')}
+              disabled={loading}
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+            >
+              <FolderOpen size={16} />
+              {loading ? t('workspace.picking') : t('workspace.pickFolder')}
+            </button>
+          )}
+        </div>
         {error && (
           <p className="mt-4 text-sm text-red-600" role="alert">
             {error}
@@ -79,9 +125,7 @@ export const WorkspaceToolbar: React.FC = () => {
     runSync,
     scanWorkspace,
     clearError,
-    setRemoteOnlyMode,
   } = useWorkspaceStore();
-  const loadImages = useImageStore(state => state.loadImages);
   const sources = useSourceStore(state => state.sources);
   const hasRemote = sources.length > 0;
   const busy = pushing || syncing;
@@ -93,11 +137,19 @@ export const WorkspaceToolbar: React.FC = () => {
           <p className="text-sm font-medium text-gray-900">
             {t('workspace.current')}: {displayName || t('workspace.unnamed')}
           </p>
-          {rootPath && (
-            <p className="text-xs text-gray-500 truncate" title={rootPath}>
-              {rootPath}
-            </p>
+          {rootPath?.startsWith('fsa://') && (
+            <p className="text-xs text-gray-500">{t('workspace.fsaStorage')}</p>
           )}
+          {rootPath?.startsWith('opfs://') && (
+            <p className="text-xs text-gray-500">{t('workspace.webStorage')}</p>
+          )}
+          {rootPath &&
+            !rootPath.startsWith('opfs://') &&
+            !rootPath.startsWith('fsa://') && (
+              <p className="text-xs text-gray-500 truncate" title={rootPath}>
+                {rootPath}
+              </p>
+            )}
           <div className="mt-2 flex flex-wrap gap-2">
             <span className="inline-flex items-center rounded-full bg-white px-2 py-0.5 text-xs text-gray-700 border border-gray-200">
               {t('workspace.lastSync')}:{' '}
@@ -181,18 +233,8 @@ export const WorkspaceToolbar: React.FC = () => {
           {t('workspace.pushNeedsRemote')}
         </p>
       )}
-      <div className="mt-3 border-t border-gray-200 pt-3">
-        <button
-          type="button"
-          onClick={() => {
-            setRemoteOnlyMode();
-            void loadImages();
-          }}
-          className="text-xs text-gray-500 hover:text-gray-800 hover:underline"
-        >
-          {t('workspace.switchRemoteOnly')}
-        </button>
-      </div>
+
+      <WorkspaceSourceSection showDivider />
     </div>
   );
 };

--- a/apps/pixuli/src/features/workspace/WorkspaceSourceSection.tsx
+++ b/apps/pixuli/src/features/workspace/WorkspaceSourceSection.tsx
@@ -1,0 +1,177 @@
+import type { SidebarSource } from '@pixuli/ui';
+import { Edit, Github, MoreHorizontal, Plus, Trash2 } from 'lucide-react';
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useI18n } from '@/i18n/useI18n';
+import { useSourceManagement } from '@/hooks/useSourceManagement';
+import { useUIStore } from '@/stores/uiStore';
+
+interface SourceContextMenu {
+  x: number;
+  y: number;
+  sourceId: string;
+}
+
+export const WorkspaceSourceSection: React.FC<{
+  showDivider?: boolean;
+}> = ({ showDivider = true }) => {
+  const { t } = useI18n();
+  const {
+    sidebarSources,
+    handleSourceSelect,
+    handleEditSource,
+    handleDeleteSource,
+  } = useSourceManagement();
+  const addSource = useUIStore(state => state.addSource);
+  const openConfigModalForEdit = useUIStore(
+    state => state.openConfigModalForEdit,
+  );
+  const [contextMenu, setContextMenu] = useState<SourceContextMenu | null>(
+    null,
+  );
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!contextMenu) return;
+    const close = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setContextMenu(null);
+      }
+    };
+    document.addEventListener('mousedown', close);
+    return () => document.removeEventListener('mousedown', close);
+  }, [contextMenu]);
+
+  const openContextMenu = (event: React.MouseEvent, sourceId: string) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setContextMenu({ x: event.clientX, y: event.clientY, sourceId });
+  };
+
+  const handleEdit = (sourceId: string) => {
+    const id = handleEditSource(sourceId);
+    if (id) {
+      openConfigModalForEdit(id);
+    }
+    setContextMenu(null);
+  };
+
+  const handleDelete = (sourceId: string) => {
+    handleDeleteSource(sourceId, t);
+    setContextMenu(null);
+  };
+
+  const renderSourceIcon = (source: SidebarSource) => {
+    if (source.type === 'github') {
+      return <Github size={14} className="shrink-0" />;
+    }
+    return (
+      <span className="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded bg-red-500 text-[9px] font-bold text-white">
+        码
+      </span>
+    );
+  };
+
+  return (
+    <div
+      className={showDivider ? 'mt-3 border-t border-gray-200 pt-3' : undefined}
+    >
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <span className="text-xs font-medium text-gray-700">
+          {t('sidebar.sources')}
+        </span>
+        <button
+          type="button"
+          onClick={addSource}
+          className="inline-flex items-center gap-1 rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
+          title={t('sidebar.addSource')}
+        >
+          <Plus size={14} />
+          {t('sidebar.addSource')}
+        </button>
+      </div>
+
+      {sidebarSources.length === 0 ? (
+        <p className="text-xs text-gray-500">{t('sidebar.emptyState.text')}</p>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {sidebarSources.map((source: SidebarSource) => {
+            const unavailable = source.available === false;
+            const active = source.active && !unavailable;
+            return (
+              <div key={source.id} className="flex items-center gap-0.5">
+                <button
+                  type="button"
+                  disabled={unavailable}
+                  onClick={() => {
+                    if (!unavailable) {
+                      handleSourceSelect(source.id);
+                    }
+                  }}
+                  onContextMenu={event => openContextMenu(event, source.id)}
+                  title={
+                    unavailable
+                      ? t('sidebar.pluginUnavailable')
+                      : `${source.owner}/${source.repo}`
+                  }
+                  className={`inline-flex max-w-[min(100%,14rem)] items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-left text-xs transition-colors ${
+                    active
+                      ? 'border-blue-400 bg-blue-50 text-blue-900'
+                      : 'border-gray-200 bg-white text-gray-800 hover:bg-gray-50'
+                  } ${unavailable ? 'cursor-not-allowed opacity-50' : ''}`}
+                >
+                  {renderSourceIcon(source)}
+                  <span className="min-w-0 truncate font-medium">
+                    {source.name}
+                  </span>
+                  <span className="hidden sm:inline truncate text-gray-500">
+                    {unavailable
+                      ? t('sidebar.pluginUnavailable')
+                      : `${source.owner}/${source.repo}`}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className="rounded-md p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-800"
+                  title={t('sidebar.editSource')}
+                  onClick={event => openContextMenu(event, source.id)}
+                  aria-label={t('sidebar.editSource')}
+                >
+                  <MoreHorizontal size={14} />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {contextMenu &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            ref={menuRef}
+            className="fixed z-[999999] min-w-[10rem] rounded-lg border border-gray-200 bg-white py-1 shadow-lg"
+            style={{ left: contextMenu.x, top: contextMenu.y }}
+          >
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-800 hover:bg-gray-50"
+              onClick={() => handleEdit(contextMenu.sourceId)}
+            >
+              <Edit size={14} />
+              {t('sidebar.editSource')}
+            </button>
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-red-600 hover:bg-red-50"
+              onClick={() => handleDelete(contextMenu.sourceId)}
+            >
+              <Trash2 size={14} />
+              {t('sidebar.deleteSource')}
+            </button>
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+};

--- a/apps/pixuli/src/features/workspace/localImageMapper.ts
+++ b/apps/pixuli/src/features/workspace/localImageMapper.ts
@@ -1,5 +1,9 @@
 import type { ImageItem, LinkKind } from '@pixuli/core/types';
 import type { LocalImageIndexEntry } from '@pixuli/core/vault';
+import {
+  getWorkspaceAdapter,
+  isWorkspaceAvailable,
+} from '@/platforms/workspacePlatform';
 
 const previewUrlCache = new Map<string, string>();
 
@@ -18,10 +22,10 @@ export async function resolveLocalPreviewUrl(
   if (cached) {
     return cached;
   }
-  if (!window.workspaceAPI) {
-    throw new Error('workspaceAPI unavailable');
+  if (!isWorkspaceAvailable()) {
+    throw new Error('workspace unavailable');
   }
-  const bytes = await window.workspaceAPI.readFile(relativePath);
+  const bytes = await getWorkspaceAdapter().readFile(relativePath);
   const blob = new Blob([Uint8Array.from(bytes)], {
     type: mimeType || 'image/jpeg',
   });

--- a/apps/pixuli/src/hooks/useAppInitialization.ts
+++ b/apps/pixuli/src/hooks/useAppInitialization.ts
@@ -67,8 +67,8 @@ export function useAppInitialization(
       return;
     }
 
-    // 如果使用仓库源模式（hasConfig），不在这里加载，由 useSelectedSourceSync 处理
-    if (hasConfig && sources.length > 0) {
+    // local 工作区由 workspace 初始化触发加载
+    if (hasConfig) {
       return;
     }
 

--- a/apps/pixuli/src/i18n/locales/en-US.json
+++ b/apps/pixuli/src/i18n/locales/en-US.json
@@ -72,6 +72,12 @@
   "workspace": {
     "setupTitle": "Choose a local workspace",
     "setupHint": "Pick a folder as your Pixuli local image workspace. Images are stored under images/ in that directory.",
+    "setupHintWeb": "Create a browser-local workspace (OPFS). Images and index stay on this device; clearing site data may remove the workspace.",
+    "setupHintWebLocal": "Web supports local workspace only. Connect a folder on your computer (recommended) or create a browser workspace.",
+    "connectFolder": "Connect local folder",
+    "fsaStorage": "Connected local folder",
+    "createWorkspace": "Create browser workspace",
+    "webStorage": "Browser local storage (OPFS)",
     "pickFolder": "Choose folder",
     "picking": "Opening…",
     "current": "Workspace",
@@ -95,11 +101,10 @@
     "migrationHint": "You have {{count}} remote source(s). Choose how to continue:",
     "migrationLocalTitle": "Use a local folder",
     "migrationLocalHint": "Pick a folder as your workspace. Existing remote sources will be bound for sync.",
+    "migrationHintWebLocal": "You have {{count}} remote source(s). On Web, choose a local workspace first, then sync.",
+    "migrationLocalTitleWeb": "Choose a local workspace",
+    "migrationLocalHintWeb": "Connect a local folder or create a browser workspace; existing remotes will be bound for sync.",
     "migrationPickFolder": "Choose folder and continue",
-    "migrationPullAfter": "Pull all images from remote after setup (may take a while)",
-    "migrationRemoteTitle": "Keep remote-only browsing",
-    "migrationRemoteHint": "Continue listing images directly from GitHub/Gitee without a local folder.",
-    "migrationRemoteOnly": "Continue with remote only",
-    "switchRemoteOnly": "Switch to remote-only browsing"
+    "migrationPullAfter": "Pull all images from remote after setup (may take a while)"
   }
 }

--- a/apps/pixuli/src/i18n/locales/zh-CN.json
+++ b/apps/pixuli/src/i18n/locales/zh-CN.json
@@ -72,6 +72,12 @@
   "workspace": {
     "setupTitle": "选择本地工作区",
     "setupHint": "选择一个文件夹作为 Pixuli 本地图床工作区，图片将保存在该目录下的 images/ 中。",
+    "setupHintWeb": "在浏览器中创建受控本地工作区（OPFS），图片与索引保存在本机，不会上传至 Pixuli 服务器。清除站点数据可能丢失工作区。",
+    "setupHintWebLocal": "Web 端仅支持本地工作区。可连接本机文件夹（推荐），或在浏览器内创建虚拟工作区。",
+    "connectFolder": "连接本机文件夹",
+    "fsaStorage": "已连接本机文件夹",
+    "createWorkspace": "创建浏览器工作区",
+    "webStorage": "浏览器本地存储（OPFS）",
     "pickFolder": "选择文件夹",
     "picking": "正在打开…",
     "current": "当前工作区",
@@ -95,11 +101,10 @@
     "migrationHint": "检测到 {{count}} 个远端源，请选择使用方式：",
     "migrationLocalTitle": "使用本地文件夹",
     "migrationLocalHint": "选择文件夹作为工作区，现有远端源将自动绑定以便同步。",
+    "migrationHintWebLocal": "检测到 {{count}} 个远端源。Web 端需先选择本地工作区，再与远端同步。",
+    "migrationLocalTitleWeb": "选择本地工作区",
+    "migrationLocalHintWeb": "连接本机文件夹或创建浏览器工作区；现有远端源将自动绑定以便同步。",
     "migrationPickFolder": "选择文件夹并继续",
-    "migrationPullAfter": "设置完成后从远端全量拉取（可能耗时较长）",
-    "migrationRemoteTitle": "继续仅远端浏览",
-    "migrationRemoteHint": "不选本地目录，继续直接从 GitHub/Gitee 拉取列表。",
-    "migrationRemoteOnly": "仅使用远端",
-    "switchRemoteOnly": "切换为仅远端浏览"
+    "migrationPullAfter": "设置完成后从远端全量拉取（可能耗时较长）"
   }
 }

--- a/apps/pixuli/src/layouts/AppMain.tsx
+++ b/apps/pixuli/src/layouts/AppMain.tsx
@@ -3,68 +3,27 @@
  * 包含 Header 和主内容区域
  */
 
-import {
-  DemoIcon,
-  Header,
-  LanguageSwitcher,
-  RefreshButton,
-  Search,
-  UploadButton,
-  useDemoMode,
-} from '@pixuli/ui';
-import type { ImageUploadData, MultiImageUploadData } from '@pixuli/core/types';
+import { Header, LanguageSwitcher } from '@pixuli/ui';
 import { Menu, ScrollText } from 'lucide-react';
 import React from 'react';
-import { useLocation } from 'react-router-dom';
-import { ROUTES } from '../router/routes';
-import { useSearchContextSafe } from '../contexts/SearchContext';
 import { useMobileViewport } from '../hooks/useMobileViewport';
 import { useI18n } from '../i18n/useI18n';
-import { isDesktopWorkspaceAvailable } from '../platforms/desktop/workspaceAdapter';
-import { useImageStore } from '../stores/imageStore';
-import { useSourceStore } from '../stores/sourceStore';
 import { useUIStore } from '../stores/uiStore';
-import { useWorkspaceStore } from '../stores/workspaceStore';
 
 interface AppMainProps {
   children: React.ReactNode;
-  hasConfig: boolean;
-  onLoadImages: () => Promise<void>;
-  onUploadImage: (data: ImageUploadData) => Promise<void>;
-  onUploadMultipleImages: (data: MultiImageUploadData) => Promise<void>;
 }
 
-export const AppMain: React.FC<AppMainProps> = ({
-  children,
-  hasConfig,
-  onLoadImages,
-  onUploadImage,
-  onUploadMultipleImages,
-}) => {
+export const AppMain: React.FC<AppMainProps> = ({ children }) => {
   const { t, changeLanguage, getCurrentLanguage, getAvailableLanguages } =
     useI18n();
-  const { loading, batchUploadProgress, images } = useImageStore();
-  const workspaceMode = useWorkspaceStore(state => state.mode);
-  const localImages = useWorkspaceStore(state => state.localImages);
-  const workspaceLoading = useWorkspaceStore(state => state.loading);
-  const localActive =
-    isDesktopWorkspaceAvailable() && workspaceMode === 'local';
-  const displayLoading = localActive ? workspaceLoading : loading;
-  const displayImages = localActive ? localImages : images;
-  const { sources } = useSourceStore();
   const {
     isFullscreenMode,
     openOperationLog,
     toggleMobileSidebar,
     mobileSidebarOpen,
   } = useUIStore();
-  const { isDemoMode } = useDemoMode();
-  const location = useLocation();
-  const searchContext = useSearchContextSafe();
   const isMobile = useMobileViewport();
-
-  // 判断是否在照片页面，如果是则显示搜索框
-  const isPhotosPage = location.pathname === ROUTES.PHOTOS;
 
   const mobileMenuButton = isMobile ? (
     <button
@@ -79,73 +38,14 @@ export const AppMain: React.FC<AppMainProps> = ({
     </button>
   ) : null;
 
-  const searchAction =
-    isPhotosPage && searchContext && searchContext.showSearch ? (
-      <div
-        className={
-          isMobile
-            ? 'header-search-slot header-search-slot--mobile'
-            : 'header-search-slot flex-1 min-w-0 max-w-2xl'
-        }
-      >
-        <Search
-          searchQuery={searchContext.searchQuery}
-          onSearchChange={searchContext.setSearchQuery}
-          variant="header"
-          hasConfig={hasConfig}
-          images={displayImages}
-          externalFilters={searchContext.filters}
-          onFiltersChange={searchContext.setFilters}
-          showFilter={true}
-          showHistory={true}
-          history={searchContext.history}
-          onSelectHistory={searchContext.handleSelectHistory}
-          onDeleteHistory={searchContext.handleDeleteHistory}
-          onClearHistory={searchContext.handleClearHistory}
-          onSaveHistory={searchContext.handleSaveHistory}
-          t={t}
-        />
-      </div>
-    ) : null;
-
-  const leftActions =
-    mobileMenuButton || searchAction ? (
-      <>
-        {mobileMenuButton}
-        {searchAction}
-      </>
-    ) : null;
-
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
       {/* 顶部：Header */}
       {!isFullscreenMode && (
         <Header
-          leftActions={leftActions}
+          leftActions={mobileMenuButton}
           rightActions={
             <>
-              <DemoIcon
-                t={t}
-                isDemoMode={isDemoMode}
-                className={isMobile ? 'demo-icon--hide-mobile' : undefined}
-              />
-              {hasConfig && (
-                <UploadButton
-                  onUploadImage={onUploadImage}
-                  onUploadMultipleImages={onUploadMultipleImages}
-                  loading={displayLoading}
-                  batchUploadProgress={batchUploadProgress}
-                  t={t}
-                />
-              )}
-              {hasConfig && (
-                <RefreshButton
-                  onRefresh={onLoadImages}
-                  loading={displayLoading}
-                  disabled={!hasConfig}
-                  t={t}
-                />
-              )}
               <button
                 type="button"
                 onClick={openOperationLog}

--- a/apps/pixuli/src/layouts/MainLayout.tsx
+++ b/apps/pixuli/src/layouts/MainLayout.tsx
@@ -14,12 +14,7 @@ import {
 } from '@pixuli/ui';
 import type { VersionInfo } from '@pixuli/ui';
 import { pluginIdToLegacyType } from '@pixuli/core/sources';
-import type {
-  GiteeConfig,
-  GitHubConfig,
-  ImageUploadData,
-  MultiImageUploadData,
-} from '@pixuli/core/types';
+import type { GiteeConfig, GitHubConfig } from '@pixuli/core/types';
 import React, { useMemo } from 'react';
 import {
   OfflineIndicator,
@@ -34,7 +29,7 @@ import { useImageStore } from '../stores/imageStore';
 import { useSourceStore } from '../stores/sourceStore';
 import { useUIStore } from '../stores/uiStore';
 import { useWorkspaceStore } from '../stores/workspaceStore';
-import { isDesktopWorkspaceAvailable } from '../platforms/desktop/workspaceAdapter';
+import { isWorkspaceAvailable } from '../platforms/workspacePlatform';
 import { listStoragePluginManifests } from '../storage/registry';
 import { getPlatform, isNativeMobile } from '../utils/platform';
 import {
@@ -58,10 +53,6 @@ interface MainLayoutProps {
   onSourceDelete: (sourceId: string) => void;
   hasConfig: boolean;
   onAddSource: () => void;
-  // Header 相关 props
-  onLoadImages: () => Promise<void>;
-  onUploadImage: (data: ImageUploadData) => Promise<void>;
-  onUploadMultipleImages: (data: MultiImageUploadData) => Promise<void>;
   // 配置相关 props（用于弹窗）
   onSaveConfig: (config: any) => void;
   onClearConfig: () => void;
@@ -77,9 +68,6 @@ export const MainLayout: React.FC<MainLayoutProps> = ({
   onSourceDelete,
   hasConfig,
   onAddSource,
-  onLoadImages,
-  onUploadImage,
-  onUploadMultipleImages,
   onSaveConfig,
   onClearConfig,
   onSelectSourceType,
@@ -88,8 +76,7 @@ export const MainLayout: React.FC<MainLayoutProps> = ({
   const { loading, storageType, githubConfig, giteeConfig } = useImageStore();
   const workspaceMode = useWorkspaceStore(state => state.mode);
   const workspaceLoading = useWorkspaceStore(state => state.loading);
-  const localActive =
-    isDesktopWorkspaceAvailable() && workspaceMode === 'local';
+  const localActive = isWorkspaceAvailable() && workspaceMode === 'local';
   const showGlobalLoading = localActive ? workspaceLoading : loading;
   const sources = useSourceStore(state => state.sources);
   const { isDemoMode } = useDemoMode();
@@ -173,14 +160,7 @@ export const MainLayout: React.FC<MainLayoutProps> = ({
         t={t}
       />
 
-      <AppMain
-        hasConfig={hasConfig}
-        onLoadImages={onLoadImages}
-        onUploadImage={onUploadImage}
-        onUploadMultipleImages={onUploadMultipleImages}
-      >
-        {children}
-      </AppMain>
+      <AppMain>{children}</AppMain>
 
       <SourceTypeMenu
         isOpen={showSourceTypeMenu}

--- a/apps/pixuli/src/layouts/Sidebar.tsx
+++ b/apps/pixuli/src/layouts/Sidebar.tsx
@@ -13,9 +13,7 @@ import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMobileViewport } from '../hooks/useMobileViewport';
 import { ROUTES } from '../router/routes';
-import { isDesktopWorkspaceAvailable } from '../platforms/desktop/workspaceAdapter';
 import { useUIStore } from '../stores/uiStore';
-import { useWorkspaceStore } from '../stores/workspaceStore';
 
 interface SidebarProps {
   sidebarSources: any[];
@@ -41,10 +39,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const navigate = useNavigate();
   const isMobile = useMobileViewport();
   const { isDemoMode } = useDemoMode();
-  const workspaceMode = useWorkspaceStore(state => state.mode);
-  const displayName = useWorkspaceStore(state => state.displayName);
-  const showWorkspaceHint =
-    isDesktopWorkspaceAvailable() && workspaceMode === 'local';
   const {
     activeMenu,
     sidebarCollapsed,
@@ -55,7 +49,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
     setCurrentView,
     setCurrentUtilityTool,
     setActiveMenu,
-    openConfigModal,
   } = useUIStore();
 
   useEffect(() => {
@@ -96,11 +89,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
       if (route) {
         navigate(route);
       }
-    } else if (menuItem.type === 'settings') {
-      setCurrentView('settings');
-      setCurrentUtilityTool(null);
-      setActiveMenu('settings');
-      openConfigModal();
     }
     closeDrawerIfMobile();
   };
@@ -132,6 +120,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
           onSourceDelete={onSourceDelete}
           hasConfig={hasConfig}
           onAddSource={handleAddSource}
+          hideSources
           collapsed={isMobile ? false : sidebarCollapsed}
           onToggleCollapse={isMobile ? undefined : toggleSidebar}
           mobileOpen={isMobile && mobileSidebarOpen}
@@ -140,17 +129,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
           t={t}
         />
       </div>
-      {showWorkspaceHint && (
-        <div
-          className="border-t border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400"
-          title={displayName ?? undefined}
-        >
-          <span className="font-medium">{t('workspace.current')}:</span>{' '}
-          <span className="truncate">
-            {displayName || t('workspace.unnamed')}
-          </span>
-        </div>
-      )}
     </div>
   );
 };

--- a/apps/pixuli/src/pages/photos/index.tsx
+++ b/apps/pixuli/src/pages/photos/index.tsx
@@ -10,8 +10,9 @@ import { useI18n } from '@/i18n/useI18n';
 import { useImageStore } from '@/stores/imageStore';
 import { useSourceStore } from '@/stores/sourceStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
-import { createDefaultFilters, filterImages } from '@pixuli/core/utils';
-import React, { useEffect, useMemo, useRef } from 'react';
+import { isWorkspaceAvailable } from '@/platforms/workspacePlatform';
+import type { ImageBrowserSearchConfig } from '@pixuli/ui';
+import React, { useMemo } from 'react';
 
 interface PhotosPageProps {
   onOpenConfigModal: () => void;
@@ -31,55 +32,29 @@ export const PhotosPage: React.FC<PhotosPageProps> = ({
   const { handleDeleteImage, handleDeleteMultipleImages, handleUpdateImage } =
     useImageOperations();
   const searchContext = useSearchContextSafe();
-  const searchContextRef = useRef(searchContext);
 
   const showMigration = needsSetup && sources.length > 0;
   const showSetup = needsSetup && sources.length === 0;
-  const hasConfig = sources.length > 0 || localActive;
+  const hasConfig = isWorkspaceAvailable() ? localActive : sources.length > 0;
 
-  useEffect(() => {
-    searchContextRef.current = searchContext;
+  const search = useMemo<ImageBrowserSearchConfig | undefined>(() => {
+    if (!searchContext) {
+      return undefined;
+    }
+    return {
+      searchQuery: searchContext.searchQuery,
+      onSearchChange: searchContext.setSearchQuery,
+      filters: searchContext.filters,
+      onFiltersChange: searchContext.setFilters,
+      history: searchContext.history,
+      onSelectHistory: searchContext.handleSelectHistory,
+      onDeleteHistory: searchContext.handleDeleteHistory,
+      onClearHistory: searchContext.handleClearHistory,
+      onSaveHistory: searchContext.handleSaveHistory,
+    };
   }, [searchContext]);
 
-  useEffect(() => {
-    if (searchContextRef.current) {
-      searchContextRef.current.setShowSearch(true);
-      return () => {
-        if (searchContextRef.current) {
-          searchContextRef.current.setShowSearch(false);
-        }
-      };
-    }
-  }, []);
-
-  const searchQuery = searchContext?.searchQuery ?? '';
-  const setFiltersRef = useRef(searchContext?.setFilters);
-
-  useEffect(() => {
-    setFiltersRef.current = searchContext?.setFilters;
-  }, [searchContext?.setFilters]);
-
-  useEffect(() => {
-    if (!setFiltersRef.current) return;
-
-    const currentQuery = searchQuery;
-    setFiltersRef.current(prev => {
-      if (prev.searchTerm === currentQuery) {
-        return prev;
-      }
-      return {
-        ...prev,
-        searchTerm: currentQuery,
-      };
-    });
-  }, [searchQuery]);
-
-  const filteredImages = useMemo(() => {
-    if (!searchContext) {
-      return filterImages(images, createDefaultFilters());
-    }
-    return filterImages(images, searchContext.filters);
-  }, [images, searchContext]);
+  const showWorkspaceBar = localActive;
 
   if (showMigration) {
     return (
@@ -100,7 +75,7 @@ export const PhotosPage: React.FC<PhotosPageProps> = ({
   return (
     <div className="photos-page h-full flex flex-col overflow-hidden">
       <div className="flex-1 overflow-y-auto">
-        {localActive && (
+        {showWorkspaceBar && (
           <div className="px-4 pt-4 sm:px-6 lg:px-8">
             <WorkspaceToolbar />
           </div>
@@ -109,12 +84,13 @@ export const PhotosPage: React.FC<PhotosPageProps> = ({
           hasConfig={hasConfig}
           error={error}
           onClearError={clearError}
-          images={filteredImages}
+          images={images}
           loading={loading}
           onDeleteImage={handleDeleteImage}
           onDeleteMultipleImages={handleDeleteMultipleImages}
           onUpdateImage={handleUpdateImage}
           onOpenConfigModal={onOpenConfigModal}
+          search={search}
           t={t}
         />
       </div>

--- a/apps/pixuli/src/platforms/web/__tests__/opfsWorkspaceFs.test.ts
+++ b/apps/pixuli/src/platforms/web/__tests__/opfsWorkspaceFs.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { formatFsaRootPath, parseFsaRootPath } from '../fsaWorkspaceFs';
+import {
+  formatOpfsRootPath,
+  normalizeRelativePath,
+  parseOpfsRootPath,
+} from '../opfsWorkspaceFs';
+
+describe('web workspace root paths', () => {
+  it('formats and parses opfs root paths', () => {
+    const id = 'abc-123';
+    const root = formatOpfsRootPath(id);
+    expect(root).toBe('opfs://abc-123');
+    expect(parseOpfsRootPath(root)).toBe(id);
+    expect(parseOpfsRootPath('/Users/foo')).toBeNull();
+  });
+
+  it('formats and parses fsa root paths', () => {
+    const id = 'workspace-uuid';
+    const root = formatFsaRootPath(id);
+    expect(root).toBe('fsa://workspace-uuid');
+    expect(parseFsaRootPath(root)).toBe(id);
+    expect(parseFsaRootPath('opfs://x')).toBeNull();
+  });
+
+  it('normalizes relative paths', () => {
+    expect(normalizeRelativePath('/images/a.jpg')).toBe('images/a.jpg');
+    expect(normalizeRelativePath('images\\b.jpg')).toBe('images/b.jpg');
+  });
+});

--- a/apps/pixuli/src/platforms/web/fsaWorkspaceFs.ts
+++ b/apps/pixuli/src/platforms/web/fsaWorkspaceFs.ts
@@ -1,0 +1,213 @@
+import { normalizeRelativePath } from './opfsWorkspaceFs';
+
+const FSA_ROOT_PREFIX = 'fsa://';
+const FSA_DB_NAME = 'pixuli-workspace-fsa';
+const FSA_STORE = 'handles';
+const FSA_DB_VERSION = 1;
+
+export function formatFsaRootPath(workspaceId: string): string {
+  return `${FSA_ROOT_PREFIX}${workspaceId}`;
+}
+
+export function parseFsaRootPath(rootPath: string): string | null {
+  if (!rootPath.startsWith(FSA_ROOT_PREFIX)) {
+    return null;
+  }
+  const id = rootPath.slice(FSA_ROOT_PREFIX.length).trim();
+  return id.length > 0 ? id : null;
+}
+
+export function isFileSystemAccessSupported(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.showDirectoryPicker === 'function'
+  );
+}
+
+function openFsaDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(FSA_DB_NAME, FSA_DB_VERSION);
+    request.onerror = () =>
+      reject(request.error ?? new Error('IDB open failed'));
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(FSA_STORE)) {
+        db.createObjectStore(FSA_STORE);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+  });
+}
+
+export async function storeFsaDirectoryHandle(
+  workspaceId: string,
+  handle: FileSystemDirectoryHandle,
+): Promise<void> {
+  const db = await openFsaDb();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(FSA_STORE, 'readwrite');
+    tx.objectStore(FSA_STORE).put(handle, workspaceId);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error ?? new Error('IDB put failed'));
+  });
+  db.close();
+}
+
+export async function loadFsaDirectoryHandle(
+  workspaceId: string,
+): Promise<FileSystemDirectoryHandle | null> {
+  const db = await openFsaDb();
+  const handle = await new Promise<FileSystemDirectoryHandle | null>(
+    (resolve, reject) => {
+      const tx = db.transaction(FSA_STORE, 'readonly');
+      const req = tx.objectStore(FSA_STORE).get(workspaceId);
+      req.onsuccess = () =>
+        resolve((req.result as FileSystemDirectoryHandle | undefined) ?? null);
+      req.onerror = () => reject(req.error ?? new Error('IDB get failed'));
+    },
+  );
+  db.close();
+  return handle;
+}
+
+export async function ensureFsaPermission(
+  handle: FileSystemDirectoryHandle,
+): Promise<boolean> {
+  const options = { mode: 'readwrite' as const };
+  if ((await handle.queryPermission(options)) === 'granted') {
+    return true;
+  }
+  return (await handle.requestPermission(options)) === 'granted';
+}
+
+async function resolveParentInDir(
+  root: FileSystemDirectoryHandle,
+  relativePath: string,
+  create: boolean,
+): Promise<{ dir: FileSystemDirectoryHandle; name: string }> {
+  const normalized = normalizeRelativePath(relativePath);
+  const parts = normalized.split('/').filter(Boolean);
+  if (parts.length === 0) {
+    throw new Error('Invalid file path');
+  }
+  const fileName = parts.pop()!;
+  let dir = root;
+  for (const segment of parts) {
+    dir = await dir.getDirectoryHandle(segment, { create });
+  }
+  return { dir, name: fileName };
+}
+
+async function walkDirectory(
+  dir: FileSystemDirectoryHandle,
+  currentRel: string,
+  recursive: boolean,
+  results: string[],
+): Promise<void> {
+  for await (const [name, handle] of dir.entries()) {
+    const rel = currentRel ? `${currentRel}/${name}` : name;
+    if (handle.kind === 'file') {
+      results.push(rel);
+      continue;
+    }
+    if (handle.kind === 'directory') {
+      if (recursive) {
+        await walkDirectory(handle, rel, true, results);
+      } else {
+        results.push(rel);
+      }
+    }
+  }
+}
+
+export async function fsaEnsureWorkspace(
+  root: FileSystemDirectoryHandle,
+): Promise<void> {
+  await root.getDirectoryHandle('images', { create: true });
+  await root.getDirectoryHandle('.pixuli', { create: true });
+}
+
+export async function fsaWriteFile(
+  root: FileSystemDirectoryHandle,
+  relativePath: string,
+  data: Uint8Array,
+): Promise<void> {
+  const { dir, name } = await resolveParentInDir(root, relativePath, true);
+  const handle = await dir.getFileHandle(name, { create: true });
+  const writable = await handle.createWritable();
+  await writable.write(data);
+  await writable.close();
+}
+
+export async function fsaReadFile(
+  root: FileSystemDirectoryHandle,
+  relativePath: string,
+): Promise<Uint8Array> {
+  const { dir, name } = await resolveParentInDir(root, relativePath, false);
+  const handle = await dir.getFileHandle(name);
+  const file = await handle.getFile();
+  return new Uint8Array(await file.arrayBuffer());
+}
+
+export async function fsaDeleteFile(
+  root: FileSystemDirectoryHandle,
+  relativePath: string,
+): Promise<void> {
+  const { dir, name } = await resolveParentInDir(root, relativePath, false);
+  await dir.removeEntry(name);
+}
+
+export async function fsaExists(
+  root: FileSystemDirectoryHandle,
+  relativePath: string,
+): Promise<boolean> {
+  try {
+    const { dir, name } = await resolveParentInDir(root, relativePath, false);
+    await dir.getFileHandle(name);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function fsaListFiles(
+  root: FileSystemDirectoryHandle,
+  relativeDir: string,
+  recursive: boolean,
+): Promise<string[]> {
+  const normalizedDir = normalizeRelativePath(relativeDir);
+
+  let targetDir: FileSystemDirectoryHandle;
+  let baseRel: string;
+
+  if (!normalizedDir) {
+    targetDir = root;
+    baseRel = '';
+  } else {
+    try {
+      targetDir = await root.getDirectoryHandle(normalizedDir, {
+        create: false,
+      });
+      baseRel = normalizedDir.replace(/\/$/, '');
+    } catch {
+      return [];
+    }
+  }
+
+  const results: string[] = [];
+  await walkDirectory(targetDir, baseRel, recursive, results);
+  return results.sort();
+}
+
+export async function pickFsaDirectory(): Promise<FileSystemDirectoryHandle | null> {
+  if (!isFileSystemAccessSupported()) {
+    return null;
+  }
+  try {
+    const handle = await window.showDirectoryPicker({ mode: 'readwrite' });
+    const granted = await ensureFsaPermission(handle);
+    return granted ? handle : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/pixuli/src/platforms/web/opfsWorkspaceFs.ts
+++ b/apps/pixuli/src/platforms/web/opfsWorkspaceFs.ts
@@ -1,0 +1,172 @@
+const OPFS_ROOT_PREFIX = 'opfs://';
+
+export function formatOpfsRootPath(workspaceId: string): string {
+  return `${OPFS_ROOT_PREFIX}${workspaceId}`;
+}
+
+export function parseOpfsRootPath(rootPath: string): string | null {
+  if (!rootPath.startsWith(OPFS_ROOT_PREFIX)) {
+    return null;
+  }
+  const id = rootPath.slice(OPFS_ROOT_PREFIX.length).trim();
+  return id.length > 0 ? id : null;
+}
+
+export function isOpfsSupported(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    typeof navigator.storage?.getDirectory === 'function'
+  );
+}
+
+export function normalizeRelativePath(path: string): string {
+  return path.replace(/^[/\\]+/, '').replace(/\\/g, '/');
+}
+
+async function getOpfsRoot(): Promise<FileSystemDirectoryHandle> {
+  if (!isOpfsSupported()) {
+    throw new Error('OPFS is not supported in this browser');
+  }
+  return navigator.storage.getDirectory();
+}
+
+async function getWorkspaceDir(
+  workspaceId: string,
+  options?: { create?: boolean },
+): Promise<FileSystemDirectoryHandle> {
+  const root = await getOpfsRoot();
+  return root.getDirectoryHandle(workspaceId, {
+    create: options?.create ?? false,
+  });
+}
+
+async function resolveParentDir(
+  workspaceId: string,
+  relativePath: string,
+  create: boolean,
+): Promise<{ dir: FileSystemDirectoryHandle; name: string }> {
+  const normalized = normalizeRelativePath(relativePath);
+  const parts = normalized.split('/').filter(Boolean);
+  if (parts.length === 0) {
+    throw new Error('Invalid file path');
+  }
+  const fileName = parts.pop()!;
+  let dir = await getWorkspaceDir(workspaceId, { create });
+  for (const segment of parts) {
+    dir = await dir.getDirectoryHandle(segment, { create });
+  }
+  return { dir, name: fileName };
+}
+
+export async function opfsWriteFile(
+  workspaceId: string,
+  relativePath: string,
+  data: Uint8Array,
+): Promise<void> {
+  const { dir, name } = await resolveParentDir(workspaceId, relativePath, true);
+  const handle = await dir.getFileHandle(name, { create: true });
+  const writable = await handle.createWritable();
+  await writable.write(data);
+  await writable.close();
+}
+
+export async function opfsReadFile(
+  workspaceId: string,
+  relativePath: string,
+): Promise<Uint8Array> {
+  const { dir, name } = await resolveParentDir(
+    workspaceId,
+    relativePath,
+    false,
+  );
+  const handle = await dir.getFileHandle(name);
+  const file = await handle.getFile();
+  return new Uint8Array(await file.arrayBuffer());
+}
+
+export async function opfsDeleteFile(
+  workspaceId: string,
+  relativePath: string,
+): Promise<void> {
+  const { dir, name } = await resolveParentDir(
+    workspaceId,
+    relativePath,
+    false,
+  );
+  await dir.removeEntry(name);
+}
+
+export async function opfsExists(
+  workspaceId: string,
+  relativePath: string,
+): Promise<boolean> {
+  try {
+    const { dir, name } = await resolveParentDir(
+      workspaceId,
+      relativePath,
+      false,
+    );
+    await dir.getFileHandle(name);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function walkDirectory(
+  dir: FileSystemDirectoryHandle,
+  currentRel: string,
+  recursive: boolean,
+  results: string[],
+): Promise<void> {
+  for await (const [name, handle] of dir.entries()) {
+    const rel = currentRel ? `${currentRel}/${name}` : name;
+    if (handle.kind === 'file') {
+      results.push(rel);
+      continue;
+    }
+    if (handle.kind === 'directory') {
+      if (recursive) {
+        await walkDirectory(handle, rel, true, results);
+      } else {
+        results.push(rel);
+      }
+    }
+  }
+}
+
+export async function opfsListFiles(
+  workspaceId: string,
+  relativeDir: string,
+  recursive: boolean,
+): Promise<string[]> {
+  const normalizedDir = normalizeRelativePath(relativeDir);
+  const workspaceDir = await getWorkspaceDir(workspaceId, { create: false });
+
+  let targetDir: FileSystemDirectoryHandle;
+  let baseRel: string;
+
+  if (!normalizedDir) {
+    targetDir = workspaceDir;
+    baseRel = '';
+  } else {
+    try {
+      targetDir = await workspaceDir.getDirectoryHandle(normalizedDir, {
+        create: false,
+      });
+      baseRel = normalizedDir.replace(/\/$/, '');
+    } catch {
+      return [];
+    }
+  }
+
+  const results: string[] = [];
+  await walkDirectory(targetDir, baseRel, recursive, results);
+  return results.sort();
+}
+
+export async function opfsEnsureWorkspace(workspaceId: string): Promise<void> {
+  const dir = await getWorkspaceDir(workspaceId, { create: true });
+  await dir.getDirectoryHandle('images', { create: true });
+  await dir.getDirectoryHandle('.pixuli', { create: true });
+}

--- a/apps/pixuli/src/platforms/web/workspaceAdapter.ts
+++ b/apps/pixuli/src/platforms/web/workspaceAdapter.ts
@@ -1,0 +1,212 @@
+import type { WorkspaceAdapter } from '@pixuli/core/vault';
+import { isNativeMobile } from '@/utils/platform';
+import {
+  formatFsaRootPath,
+  fsaDeleteFile,
+  fsaEnsureWorkspace,
+  fsaExists,
+  fsaListFiles,
+  fsaReadFile,
+  fsaWriteFile,
+  isFileSystemAccessSupported,
+  loadFsaDirectoryHandle,
+  parseFsaRootPath,
+  pickFsaDirectory,
+  storeFsaDirectoryHandle,
+  ensureFsaPermission,
+} from './fsaWorkspaceFs';
+import {
+  formatOpfsRootPath,
+  isOpfsSupported,
+  opfsDeleteFile,
+  opfsEnsureWorkspace,
+  opfsExists,
+  opfsListFiles,
+  opfsReadFile,
+  opfsWriteFile,
+  parseOpfsRootPath,
+} from './opfsWorkspaceFs';
+
+type WebWorkspaceBackend = 'opfs' | 'fsa';
+
+export class WebWorkspaceAdapter implements WorkspaceAdapter {
+  readonly kind = 'web' as const;
+  private backend: WebWorkspaceBackend | null = null;
+  private rootPath: string | null = null;
+  private workspaceId: string | null = null;
+  private fsaHandle: FileSystemDirectoryHandle | null = null;
+  private folderLabel: string | null = null;
+
+  isReady(): boolean {
+    return Boolean(this.workspaceId && this.backend);
+  }
+
+  getRootPath(): string | null {
+    return this.rootPath;
+  }
+
+  getFolderLabel(): string | null {
+    return this.folderLabel;
+  }
+
+  setRootPath(rootPath: string | null): void {
+    this.rootPath = rootPath;
+    this.fsaHandle = null;
+    this.folderLabel = null;
+
+    if (!rootPath) {
+      this.workspaceId = null;
+      this.backend = null;
+      return;
+    }
+
+    const opfsId = parseOpfsRootPath(rootPath);
+    if (opfsId) {
+      this.backend = 'opfs';
+      this.workspaceId = opfsId;
+      return;
+    }
+
+    const fsaId = parseFsaRootPath(rootPath);
+    if (fsaId) {
+      this.backend = 'fsa';
+      this.workspaceId = fsaId;
+      return;
+    }
+
+    this.workspaceId = null;
+    this.backend = null;
+  }
+
+  private requireWorkspaceId(): string {
+    if (!this.workspaceId) {
+      throw new Error('Web workspace is not initialized');
+    }
+    return this.workspaceId;
+  }
+
+  private async requireFsaHandle(): Promise<FileSystemDirectoryHandle> {
+    if (this.fsaHandle) {
+      return this.fsaHandle;
+    }
+    const id = this.requireWorkspaceId();
+    const handle = await loadFsaDirectoryHandle(id);
+    if (!handle) {
+      throw new Error(
+        'Connected folder handle not found; pick the folder again',
+      );
+    }
+    const granted = await ensureFsaPermission(handle);
+    if (!granted) {
+      throw new Error('Folder permission denied');
+    }
+    this.fsaHandle = handle;
+    this.folderLabel = handle.name;
+    return handle;
+  }
+
+  /** OPFS 虚拟工作区 */
+  async pickRoot(): Promise<boolean> {
+    if (!isOpfsSupported()) {
+      return false;
+    }
+    const id = crypto.randomUUID();
+    await opfsEnsureWorkspace(id);
+    this.backend = 'opfs';
+    this.workspaceId = id;
+    this.rootPath = formatOpfsRootPath(id);
+    this.fsaHandle = null;
+    this.folderLabel = null;
+    return true;
+  }
+
+  /** File System Access API：连接本机真实文件夹 */
+  async pickFsaRoot(): Promise<boolean> {
+    const handle = await pickFsaDirectory();
+    if (!handle) {
+      return false;
+    }
+    const id = crypto.randomUUID();
+    await storeFsaDirectoryHandle(id, handle);
+    await fsaEnsureWorkspace(handle);
+    this.backend = 'fsa';
+    this.workspaceId = id;
+    this.fsaHandle = handle;
+    this.folderLabel = handle.name;
+    this.rootPath = formatFsaRootPath(id);
+    return true;
+  }
+
+  async readFile(relativePath: string): Promise<Uint8Array> {
+    if (this.backend === 'fsa') {
+      return fsaReadFile(await this.requireFsaHandle(), relativePath);
+    }
+    return opfsReadFile(this.requireWorkspaceId(), relativePath);
+  }
+
+  async writeFile(relativePath: string, data: Uint8Array): Promise<void> {
+    if (this.backend === 'fsa') {
+      await fsaWriteFile(await this.requireFsaHandle(), relativePath, data);
+      return;
+    }
+    await opfsWriteFile(this.requireWorkspaceId(), relativePath, data);
+  }
+
+  async deleteFile(relativePath: string): Promise<void> {
+    if (this.backend === 'fsa') {
+      await fsaDeleteFile(await this.requireFsaHandle(), relativePath);
+      return;
+    }
+    await opfsDeleteFile(this.requireWorkspaceId(), relativePath);
+  }
+
+  async listFiles(
+    relativeDir: string,
+    options?: { recursive?: boolean },
+  ): Promise<string[]> {
+    const recursive = options?.recursive ?? false;
+    if (this.backend === 'fsa') {
+      return fsaListFiles(
+        await this.requireFsaHandle(),
+        relativeDir,
+        recursive,
+      );
+    }
+    return opfsListFiles(this.requireWorkspaceId(), relativeDir, recursive);
+  }
+
+  async exists(relativePath: string): Promise<boolean> {
+    if (this.backend === 'fsa') {
+      return fsaExists(await this.requireFsaHandle(), relativePath);
+    }
+    return opfsExists(this.requireWorkspaceId(), relativePath);
+  }
+}
+
+export function createWebWorkspaceAdapter(): WebWorkspaceAdapter {
+  return new WebWorkspaceAdapter();
+}
+
+export function isWebWorkspaceAdapter(
+  adapter: WorkspaceAdapter,
+): adapter is WebWorkspaceAdapter {
+  return adapter.kind === 'web';
+}
+
+export function isWebWorkspaceAvailable(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  if (typeof __IS_WEB__ !== 'undefined' && !__IS_WEB__) {
+    return false;
+  }
+  if (typeof window.workspaceAPI !== 'undefined' && window.workspaceAPI) {
+    return false;
+  }
+  if (isNativeMobile()) {
+    return false;
+  }
+  return isOpfsSupported() || isFileSystemAccessSupported();
+}
+
+export { isFileSystemAccessSupported, isOpfsSupported };

--- a/apps/pixuli/src/platforms/workspacePlatform.ts
+++ b/apps/pixuli/src/platforms/workspacePlatform.ts
@@ -1,0 +1,41 @@
+import type { WorkspaceAdapter } from '@pixuli/core/vault';
+import {
+  createDesktopWorkspaceAdapter,
+  isDesktopWorkspaceAvailable,
+} from './desktop/workspaceAdapter';
+import {
+  createWebWorkspaceAdapter,
+  isWebWorkspaceAvailable,
+} from './web/workspaceAdapter';
+
+let adapterInstance: WorkspaceAdapter | null = null;
+
+export function isWorkspaceAvailable(): boolean {
+  return isDesktopWorkspaceAvailable() || isWebWorkspaceAvailable();
+}
+
+export function getWorkspaceAdapter(): WorkspaceAdapter {
+  if (!adapterInstance) {
+    if (isDesktopWorkspaceAvailable()) {
+      adapterInstance = createDesktopWorkspaceAdapter();
+    } else if (isWebWorkspaceAvailable()) {
+      adapterInstance = createWebWorkspaceAdapter();
+    } else {
+      throw new Error('No workspace adapter available on this platform');
+    }
+  }
+  return adapterInstance;
+}
+
+export function resetWorkspaceAdapter(): void {
+  adapterInstance = null;
+}
+
+export function isWebWorkspaceActive(): boolean {
+  return isWebWorkspaceAvailable() && !isDesktopWorkspaceAvailable();
+}
+
+export {
+  isFileSystemAccessSupported,
+  isOpfsSupported,
+} from './web/workspaceAdapter';

--- a/apps/pixuli/src/stores/imageStore.ts
+++ b/apps/pixuli/src/stores/imageStore.ts
@@ -13,6 +13,7 @@ import {
   storagePluginLabel,
   type StoragePluginId,
 } from '@/storage/createProvider';
+import { isWorkspaceAvailable } from '@/platforms/workspacePlatform';
 import { LogActionType, LogStatus } from '@/types/log';
 import { useLogStore } from '@/stores/logStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
@@ -192,6 +193,10 @@ export const useImageStore = create<ImageState>((set, get) => {
     },
 
     loadImages: async () => {
+      if (isWorkspaceAvailable() && !isLocalListMode()) {
+        return;
+      }
+
       if (isLocalListMode()) {
         await refreshLocalIntoImageStore(set);
         return;

--- a/apps/pixuli/src/stores/workspaceStore.ts
+++ b/apps/pixuli/src/stores/workspaceStore.ts
@@ -23,10 +23,12 @@ import {
   mapEntriesToImageItems,
 } from '../features/workspace/localImageMapper';
 import {
-  createDesktopWorkspaceAdapter,
-  DesktopWorkspaceAdapter,
-  isDesktopWorkspaceAvailable,
-} from '../platforms/desktop/workspaceAdapter';
+  getWorkspaceAdapter,
+  isWebWorkspaceActive,
+  isWorkspaceAvailable,
+  resetWorkspaceAdapter,
+} from '../platforms/workspacePlatform';
+import { isWebWorkspaceAdapter } from '../platforms/web/workspaceAdapter';
 
 const WORKSPACE_STORAGE_KEY = 'pixuli.workspace.v1';
 const WORKSPACE_MODE_KEY = 'pixuli.workspaceMode.v1';
@@ -34,6 +36,7 @@ const WORKSPACE_MODE_KEY = 'pixuli.workspaceMode.v1';
 interface WorkspacePersist {
   rootPath: string;
   workspaceId: string;
+  folderLabel?: string;
 }
 
 interface WorkspaceState {
@@ -50,8 +53,10 @@ interface WorkspaceState {
   isLocalActive: () => boolean;
   needsWorkspaceSetup: () => boolean;
   initialize: () => Promise<void>;
-  pickWorkspace: (options?: { pullAfter?: boolean }) => Promise<boolean>;
-  setRemoteOnlyMode: () => void;
+  pickWorkspace: (options?: {
+    pullAfter?: boolean;
+    backend?: 'opfs' | 'fsa';
+  }) => Promise<boolean>;
   resumeLocalWorkspace: () => Promise<boolean>;
   syncBindingsFromSources: () => Promise<void>;
   refreshLocalImages: () => Promise<void>;
@@ -71,13 +76,9 @@ interface WorkspaceState {
 
 let vaultInstance: LocalVault | null = null;
 let syncEngineInstance: SyncEngine | null = null;
-let adapterInstance: DesktopWorkspaceAdapter | null = null;
 
-function getAdapter(): DesktopWorkspaceAdapter {
-  if (!adapterInstance) {
-    adapterInstance = createDesktopWorkspaceAdapter();
-  }
-  return adapterInstance;
+function getAdapter() {
+  return getWorkspaceAdapter();
 }
 
 function getVault(): LocalVault {
@@ -106,18 +107,7 @@ function resetWorkspaceRuntime(): void {
   clearLocalPreviewCache();
   vaultInstance = null;
   syncEngineInstance = null;
-}
-
-function loadModePref(): WorkspaceMode | null {
-  try {
-    const raw = localStorage.getItem(WORKSPACE_MODE_KEY);
-    if (raw === 'local' || raw === 'remote-only') {
-      return raw;
-    }
-  } catch {
-    // ignore
-  }
-  return null;
+  resetWorkspaceAdapter();
 }
 
 function saveModePref(mode: Exclude<WorkspaceMode, 'unset'>): void {
@@ -142,15 +132,38 @@ function loadPersistedWorkspace(): WorkspacePersist | null {
   return null;
 }
 
-function savePersistedWorkspace(rootPath: string, workspaceId: string): void {
+function savePersistedWorkspace(
+  rootPath: string,
+  workspaceId: string,
+  folderLabel?: string,
+): void {
   try {
     localStorage.setItem(
       WORKSPACE_STORAGE_KEY,
-      JSON.stringify({ rootPath, workspaceId }),
+      JSON.stringify({ rootPath, workspaceId, folderLabel }),
     );
   } catch {
     // ignore
   }
+}
+
+async function pickAdapterRoot(
+  adapter: ReturnType<typeof getWorkspaceAdapter>,
+  backend?: 'opfs' | 'fsa',
+): Promise<boolean> {
+  if (backend === 'fsa' && isWebWorkspaceAdapter(adapter)) {
+    return adapter.pickFsaRoot();
+  }
+  return adapter.pickRoot();
+}
+
+function readFolderLabel(
+  adapter: ReturnType<typeof getWorkspaceAdapter>,
+): string | null {
+  if (isWebWorkspaceAdapter(adapter)) {
+    return adapter.getFolderLabel();
+  }
+  return null;
 }
 
 function sanitizeFileName(name: string): string {
@@ -159,7 +172,9 @@ function sanitizeFileName(name: string): string {
 
 async function openVaultWithRoot(rootPath: string): Promise<LocalVault> {
   const adapter = getAdapter();
-  adapter.setRootPath(rootPath);
+  if ('setRootPath' in adapter && typeof adapter.setRootPath === 'function') {
+    adapter.setRootPath(rootPath);
+  }
   if (window.workspaceAPI) {
     await window.workspaceAPI.setRoot(rootPath);
   }
@@ -181,22 +196,29 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   syncMessage: null,
 
   isLocalActive: () => {
-    return isDesktopWorkspaceAvailable() && get().mode === 'local';
+    return isWorkspaceAvailable() && get().mode === 'local';
   },
 
   needsWorkspaceSetup: () => {
-    return isDesktopWorkspaceAvailable() && get().mode === 'unset';
+    return isWorkspaceAvailable() && get().mode === 'unset';
   },
 
   initialize: async () => {
-    if (!isDesktopWorkspaceAvailable()) {
-      set({ mode: 'remote-only' });
-      return;
+    try {
+      if (localStorage.getItem(WORKSPACE_MODE_KEY) === 'remote-only') {
+        localStorage.removeItem(WORKSPACE_MODE_KEY);
+      }
+    } catch {
+      // ignore
     }
 
-    const modePref = loadModePref();
-    if (modePref === 'remote-only') {
-      set({ mode: 'remote-only' });
+    if (!isWorkspaceAvailable()) {
+      set({
+        mode: 'unset',
+        error: isWebWorkspaceActive()
+          ? '当前浏览器不支持本地工作区（需 OPFS 或文件夹访问 API）'
+          : null,
+      });
       return;
     }
 
@@ -210,12 +232,18 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     try {
       const vault = await openVaultWithRoot(persisted.rootPath);
       const config = vault.getConfig();
-      savePersistedWorkspace(persisted.rootPath, config.workspaceId);
+      const folderLabel =
+        persisted.folderLabel ?? readFolderLabel(getAdapter()) ?? undefined;
+      savePersistedWorkspace(
+        persisted.rootPath,
+        config.workspaceId,
+        folderLabel,
+      );
       saveModePref('local');
       set({
         mode: 'local',
         rootPath: persisted.rootPath,
-        displayName: config.displayName,
+        displayName: folderLabel ?? config.displayName,
         loading: false,
       });
       await get().syncBindingsFromSources();
@@ -230,25 +258,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
   },
 
-  setRemoteOnlyMode: () => {
-    saveModePref('remote-only');
-    resetWorkspaceRuntime();
-    set({
-      mode: 'remote-only',
-      rootPath: null,
-      displayName: null,
-      localImages: [],
-      loading: false,
-      pushing: false,
-      syncing: false,
-      syncStatus: null,
-      error: null,
-      syncMessage: null,
-    });
-  },
-
   resumeLocalWorkspace: async () => {
-    if (!isDesktopWorkspaceAvailable()) {
+    if (!isWorkspaceAvailable()) {
       return false;
     }
     const persisted = loadPersistedWorkspace();
@@ -262,11 +273,13 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       resetWorkspaceRuntime();
       const vault = await openVaultWithRoot(persisted.rootPath);
       const config = vault.getConfig();
+      const folderLabel =
+        persisted.folderLabel ?? readFolderLabel(getAdapter()) ?? undefined;
       saveModePref('local');
       set({
         mode: 'local',
         rootPath: persisted.rootPath,
-        displayName: config.displayName,
+        displayName: folderLabel ?? config.displayName,
         loading: false,
         syncMessage: null,
       });
@@ -296,8 +309,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     resetSyncEngineOnly();
   },
 
-  pickWorkspace: async (options?: { pullAfter?: boolean }) => {
-    if (!isDesktopWorkspaceAvailable()) {
+  pickWorkspace: async (options?: {
+    pullAfter?: boolean;
+    backend?: 'opfs' | 'fsa';
+  }) => {
+    if (!isWorkspaceAvailable()) {
       return false;
     }
 
@@ -305,22 +321,23 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     try {
       resetWorkspaceRuntime();
       const adapter = getAdapter();
-      const picked = await adapter.pickRoot();
+      const picked = await pickAdapterRoot(adapter, options?.backend);
       if (!picked || !adapter.getRootPath()) {
         set({ loading: false });
         return false;
       }
 
       const rootPath = adapter.getRootPath()!;
+      const folderLabel = readFolderLabel(adapter) ?? undefined;
       const vault = await openVaultWithRoot(rootPath);
       const config = vault.getConfig();
-      savePersistedWorkspace(rootPath, config.workspaceId);
+      savePersistedWorkspace(rootPath, config.workspaceId, folderLabel);
       saveModePref('local');
 
       set({
         mode: 'local',
         rootPath,
-        displayName: config.displayName,
+        displayName: folderLabel ?? config.displayName,
         loading: false,
         syncMessage: null,
       });

--- a/packages/core/src/vault/types.ts
+++ b/packages/core/src/vault/types.ts
@@ -141,4 +141,4 @@ export interface SyncEngine {
   run(options?: SyncRunOptions): Promise<SyncRunResult>;
 }
 
-export type WorkspaceMode = 'unset' | 'local' | 'remote-only';
+export type WorkspaceMode = 'unset' | 'local';

--- a/packages/ui/src/image/image-browser/web/ImageBrowser.css
+++ b/packages/ui/src/image/image-browser/web/ImageBrowser.css
@@ -43,6 +43,31 @@
   gap: 1rem;
 }
 
+.image-browser-upload-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border: 1px solid #2563eb;
+  border-radius: 0.375rem;
+  background-color: #ffffff;
+  color: #2563eb;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  flex-shrink: 0;
+}
+
+.image-browser-upload-btn:hover:not(:disabled) {
+  background-color: #eff6ff;
+}
+
+.image-browser-upload-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .image-browser-batch-delete-btn {
   display: inline-flex;
   align-items: center;
@@ -71,7 +96,16 @@
 
 /* 筛选区域样式 */
 .image-browser-filter-section {
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
+  padding: 0 1rem;
+}
+
+.image-browser-search {
+  width: 100%;
+}
+
+.image-browser-search.search-wrapper--header {
+  max-width: 100%;
 }
 
 /* 内容区域样式 */
@@ -152,6 +186,16 @@
     min-height: 2.75rem;
     min-width: 2.75rem;
     padding: 0.5rem 0.75rem;
+  }
+
+  .image-browser-upload-btn {
+    min-height: 2.75rem;
+    min-width: 2.75rem;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .image-browser-upload-btn .upload-button-label {
+    display: none;
   }
 
   .image-browser-batch-delete-label {

--- a/packages/ui/src/image/image-browser/web/ImageBrowser.tsx
+++ b/packages/ui/src/image/image-browser/web/ImageBrowser.tsx
@@ -6,14 +6,28 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { ImageItem } from '@pixuli/core/types';
+import {
+  BatchUploadProgress,
+  ImageItem,
+  ImageUploadData,
+  MultiImageUploadData,
+} from '@pixuli/core/types';
+import Search, {
+  type SearchHistoryItem,
+} from '../../../primitives/search/web/Search';
+import UploadButton from '../../../primitives/upload-button/web/UploadButton';
 import {
   COMMON_SHORTCUTS,
   keyboardManager,
   SHORTCUT_CATEGORIES,
 } from '@pixuli/ui/utils/keyboardShortcuts';
-import { getSortedImages } from '@pixuli/core/utils';
-import type { SortField, SortOrder, ViewMode } from '../common/types';
+import { filterImages, getSortedImages } from '@pixuli/core/utils';
+import type {
+  FilterOptions,
+  SortField,
+  SortOrder,
+  ViewMode,
+} from '../common/types';
 import BatchDeleteModal from './ImageBatchDeleteModal';
 import './ImageBrowser.css';
 import ImageGrid from './ImageGrid';
@@ -21,9 +35,25 @@ import ImageList from './ImageList';
 import ImageSorter from './ImageSorter';
 import ViewToggle from './ImageViewToggle';
 
+export interface ImageBrowserSearchConfig {
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+  filters: FilterOptions;
+  onFiltersChange: (
+    filters: FilterOptions | ((prev: FilterOptions) => FilterOptions),
+  ) => void;
+  history?: SearchHistoryItem[];
+  onSelectHistory?: (query: string) => void;
+  onDeleteHistory?: (query: string) => void;
+  onClearHistory?: () => void;
+  onSaveHistory?: (query: string) => void;
+}
+
 interface ImageBrowserProps {
   images: ImageItem[];
   className?: string;
+  hasConfig?: boolean;
+  search?: ImageBrowserSearchConfig;
   onDeleteImage?: (id: string, name: string) => Promise<void>;
   onDeleteMultipleImages?: (ids: string[], names: string[]) => Promise<void>;
   onUpdateImage?: (data: any) => Promise<void>;
@@ -32,23 +62,53 @@ interface ImageBrowserProps {
   ) => Promise<{ width: number; height: number }>;
   formatFileSize?: (size: number) => string;
   t: (key: string) => string;
+  onUploadImage?: (data: ImageUploadData) => Promise<void>;
+  onUploadMultipleImages?: (data: MultiImageUploadData) => Promise<void>;
+  uploadLoading?: boolean;
+  batchUploadProgress?: BatchUploadProgress | null;
 }
 
 const ImageBrowser: React.FC<ImageBrowserProps> = ({
   images,
   className = '',
+  hasConfig = true,
+  search,
   onDeleteImage,
   onDeleteMultipleImages,
   onUpdateImage,
   getImageDimensionsFromUrl,
   formatFileSize,
   t,
+  onUploadImage,
+  onUploadMultipleImages,
+  uploadLoading = false,
+  batchUploadProgress,
 }) => {
   const [currentView, setCurrentView] = useState<ViewMode>('grid');
   const [currentSort, setCurrentSort] = useState<SortField>('createdAt');
   const [currentOrder, setCurrentOrder] = useState<SortOrder>('desc');
   const [selectedImageIndex, setSelectedImageIndex] = useState<number>(-1);
   const [showBatchDeleteModal, setShowBatchDeleteModal] = useState(false);
+
+  useEffect(() => {
+    if (!search) return;
+    search.onFiltersChange(prev => {
+      if (prev.searchTerm === search.searchQuery) {
+        return prev;
+      }
+      return {
+        ...prev,
+        searchTerm: search.searchQuery,
+      };
+    });
+  }, [search?.searchQuery, search?.onFiltersChange]);
+
+  const filteredImages = useMemo(() => {
+    if (!search?.filters) {
+      return images;
+    }
+    return filterImages(images, search.filters);
+  }, [images, search?.filters]);
 
   const handleViewChange = useCallback((view: ViewMode) => {
     setCurrentView(view);
@@ -92,11 +152,13 @@ const ImageBrowser: React.FC<ImageBrowserProps> = ({
   // 排序图片，并确保没有重复ID
   const sortedImages = useMemo(() => {
     // 生成依赖项的字符串表示，用于比较
-    const imagesIds = images.map(img => `${img.id}:${img.updatedAt}`).join(',');
+    const imagesIds = filteredImages
+      .map(img => `${img.id}:${img.updatedAt}`)
+      .join(',');
     const sortKey = `${currentSort}:${currentOrder}`;
 
     // 去重：确保没有重复的图片ID
-    const uniqueImages = images.reduce((acc: ImageItem[], current) => {
+    const uniqueImages = filteredImages.reduce((acc: ImageItem[], current) => {
       const existingIndex = acc.findIndex(img => img.id === current.id);
       if (existingIndex === -1) {
         acc.push(current);
@@ -133,7 +195,7 @@ const ImageBrowser: React.FC<ImageBrowserProps> = ({
     // 如果结果不同，检查依赖项是否变化
     if (
       prevDeps &&
-      prevDeps.imagesLength === images.length &&
+      prevDeps.imagesLength === filteredImages.length &&
       prevDeps.imagesIds === imagesIds &&
       prevDeps.sort === sortKey &&
       prevResultRef.current.length > 0
@@ -144,7 +206,7 @@ const ImageBrowser: React.FC<ImageBrowserProps> = ({
 
     // 更新缓存
     prevDepsRef.current = {
-      imagesLength: images.length,
+      imagesLength: filteredImages.length,
       imagesIds,
       sort: sortKey,
       resultIds,
@@ -152,7 +214,7 @@ const ImageBrowser: React.FC<ImageBrowserProps> = ({
     prevResultRef.current = result;
 
     return result;
-  }, [images, currentSort, currentOrder]);
+  }, [filteredImages, currentSort, currentOrder]);
 
   // 预览选中的图片
   const handlePreviewSelectedImage = useCallback(() => {
@@ -424,6 +486,29 @@ const ImageBrowser: React.FC<ImageBrowserProps> = ({
 
   return (
     <div className={`image-browser ${className}`}>
+      {search && (
+        <div className="image-browser-filter-section">
+          <Search
+            variant="header"
+            searchQuery={search.searchQuery}
+            onSearchChange={search.onSearchChange}
+            hasConfig={hasConfig}
+            images={images}
+            externalFilters={search.filters}
+            onFiltersChange={search.onFiltersChange}
+            showFilter={true}
+            showHistory={true}
+            history={search.history}
+            onSelectHistory={search.onSelectHistory}
+            onDeleteHistory={search.onDeleteHistory}
+            onClearHistory={search.onClearHistory}
+            onSaveHistory={search.onSaveHistory}
+            t={t}
+            className="image-browser-search"
+          />
+        </div>
+      )}
+
       {/* 工具栏 */}
       <div className="image-browser-toolbar">
         <div className="image-browser-header">
@@ -431,12 +516,29 @@ const ImageBrowser: React.FC<ImageBrowserProps> = ({
           <span className="image-browser-count">
             {t('image.list.totalImages').replace(
               '{count}',
-              images.length.toString(),
+              sortedImages.length.toString(),
+            )}
+            {search && sortedImages.length !== images.length && (
+              <span className="image-browser-filter-count">
+                {' '}
+                / {images.length}
+              </span>
             )}
           </span>
         </div>
 
         <div className="image-browser-controls">
+          {onUploadImage && onUploadMultipleImages && (
+            <UploadButton
+              onUploadImage={onUploadImage}
+              onUploadMultipleImages={onUploadMultipleImages}
+              loading={uploadLoading}
+              batchUploadProgress={batchUploadProgress}
+              t={t}
+              className="image-browser-upload-btn"
+            />
+          )}
+
           {/* 批量删除按钮 */}
           {onDeleteMultipleImages && sortedImages.length > 0 && (
             <button

--- a/packages/ui/src/image/image-browser/web/index.ts
+++ b/packages/ui/src/image/image-browser/web/index.ts
@@ -1,6 +1,7 @@
 // 只导出 ImageBrowser 组件
 // 注意：各个子组件已经引入了自己的 CSS 样式，无需在此重复引入
 export { default as ImageBrowser } from './ImageBrowser';
+export type { ImageBrowserSearchConfig } from './ImageBrowser';
 
 // 类型导出（如果需要的话）
 export type {

--- a/packages/ui/src/layout/sidebar/web/Sidebar.tsx
+++ b/packages/ui/src/layout/sidebar/web/Sidebar.tsx
@@ -11,28 +11,21 @@ import {
   Trash2,
   Zap,
   FileImage,
-  Settings,
 } from 'lucide-react';
 import React, { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { defaultTranslate } from '@pixuli/ui/locales';
 import './Sidebar.css';
 
-export type SidebarView =
-  | 'photos'
-  | 'explore'
-  | 'tags'
-  | 'favorites'
-  | 'settings';
+export type SidebarView = 'photos' | 'explore' | 'tags' | 'favorites';
 
 export type SidebarFilter = 'all' | 'tags' | 'favorites';
 export type SidebarUtilityTool = 'compress' | 'convert';
 
-// 统一的菜单项类型（图床 + 工具 + 设置）
+// 统一的菜单项类型（图床 + 工具）
 export type SidebarMenuItem =
   | { type: 'photos' }
-  | { type: 'utility'; tool: SidebarUtilityTool }
-  | { type: 'settings' };
+  | { type: 'utility'; tool: SidebarUtilityTool };
 
 export interface SidebarSource {
   id: string;
@@ -67,6 +60,8 @@ interface SidebarProps {
   onMobileClose?: () => void;
   /** 侧栏底部区域上方插槽（如演示模式区块） */
   footerExtra?: React.ReactNode;
+  /** 为 true 时不渲染侧栏内仓库源区块（由主内容区工作区栏承载） */
+  hideSources?: boolean;
   t?: (key: string) => string;
 }
 
@@ -140,6 +135,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   mobileOpen = false,
   onMobileClose,
   footerExtra,
+  hideSources = false,
   t,
 }) => {
   const translate = t || defaultTranslate;
@@ -214,12 +210,6 @@ const Sidebar: React.FC<SidebarProps> = ({
       icon: <FileImage size={20} />,
       label: translate('sidebar.imageConvert'),
       menuItem: { type: 'utility', tool: 'convert' },
-    },
-    {
-      menuKey: 'settings',
-      icon: <Settings size={20} />,
-      label: translate('sidebar.settings'),
-      menuItem: { type: 'settings' },
     },
   ];
 
@@ -401,7 +391,7 @@ const Sidebar: React.FC<SidebarProps> = ({
           )}
 
           {/* 仓库源 - 折叠状态 */}
-          {sources.length > 0 && (
+          {!hideSources && sources.length > 0 && (
             <div className="sidebar-collapsed-sources">
               {sources.slice(0, 3).map(source => (
                 <button
@@ -438,18 +428,20 @@ const Sidebar: React.FC<SidebarProps> = ({
           )}
 
           {/* 添加源按钮 - 折叠状态 */}
-          <div className="sidebar-collapsed-add">
-            <button
-              onClick={onAddSource}
-              className="sidebar-collapsed-add-btn"
-              title={translate('sidebar.addSource')}
-            >
-              <Plus size={28} />
-              <span className="sidebar-collapsed-tooltip">
-                {translate('sidebar.addSource')}
-              </span>
-            </button>
-          </div>
+          {!hideSources && (
+            <div className="sidebar-collapsed-add">
+              <button
+                onClick={onAddSource}
+                className="sidebar-collapsed-add-btn"
+                title={translate('sidebar.addSource')}
+              >
+                <Plus size={28} />
+                <span className="sidebar-collapsed-tooltip">
+                  {translate('sidebar.addSource')}
+                </span>
+              </button>
+            </div>
+          )}
 
           {/* 底部操作 - 折叠状态 */}
           <div className="sidebar-collapsed-footer">
@@ -555,81 +547,83 @@ const Sidebar: React.FC<SidebarProps> = ({
         )}
 
         {/* 仓库源列表 */}
-        <div className="sidebar-section sidebar-sources">
-          <div className="sidebar-section-header">
-            <span className="sidebar-section-title">
-              {translate('sidebar.sources')}
-            </span>
-            <button
-              onClick={onAddSource}
-              className="sidebar-add-source-btn"
-              title={translate('sidebar.addSource')}
-            >
-              <Plus size={16} />
-            </button>
-          </div>
-
-          {sources.length === 0 ? (
-            <div className="sidebar-empty-state">
-              <div className="sidebar-empty-icon">
-                <Plus size={24} className="text-gray-400" />
-              </div>
-              <p className="sidebar-empty-text">
-                {translate('sidebar.emptyState.text')}
-              </p>
-              <button onClick={onAddSource} className="sidebar-add-button">
+        {!hideSources && (
+          <div className="sidebar-section sidebar-sources">
+            <div className="sidebar-section-header">
+              <span className="sidebar-section-title">
+                {translate('sidebar.sources')}
+              </span>
+              <button
+                onClick={onAddSource}
+                className="sidebar-add-source-btn"
+                title={translate('sidebar.addSource')}
+              >
                 <Plus size={16} />
-                {translate('sidebar.emptyState.addSource')}
               </button>
             </div>
-          ) : (
-            <div className="sidebar-source-list">
-              {sources.map(source => {
-                const unavailable = source.available === false;
-                return (
-                  <button
-                    key={source.id}
-                    type="button"
-                    className={`sidebar-source-item ${
-                      selectedSourceId === source.id ? 'active' : ''
-                    } ${unavailable ? 'sidebar-source-item--unavailable' : ''}`}
-                    onClick={() => {
-                      if (!unavailable) {
-                        onSourceSelect(source.id);
-                      }
-                    }}
-                    onContextMenu={e => handleContextMenu(e, source.id)}
-                    title={
-                      unavailable
-                        ? translate('sidebar.pluginUnavailable')
-                        : `${source.owner}/${source.repo}`
-                    }
-                    disabled={unavailable}
-                  >
-                    <div className="sidebar-source-icon">
-                      {source.type === 'github' ? (
-                        <Github size={16} />
-                      ) : (
-                        <div className="gitee-icon">码</div>
-                      )}
-                    </div>
-                    <div className="sidebar-source-info">
-                      <div className="sidebar-source-name">{source.name}</div>
-                      <div className="sidebar-source-path">
-                        {unavailable
+
+            {sources.length === 0 ? (
+              <div className="sidebar-empty-state">
+                <div className="sidebar-empty-icon">
+                  <Plus size={24} className="text-gray-400" />
+                </div>
+                <p className="sidebar-empty-text">
+                  {translate('sidebar.emptyState.text')}
+                </p>
+                <button onClick={onAddSource} className="sidebar-add-button">
+                  <Plus size={16} />
+                  {translate('sidebar.emptyState.addSource')}
+                </button>
+              </div>
+            ) : (
+              <div className="sidebar-source-list">
+                {sources.map(source => {
+                  const unavailable = source.available === false;
+                  return (
+                    <button
+                      key={source.id}
+                      type="button"
+                      className={`sidebar-source-item ${
+                        selectedSourceId === source.id ? 'active' : ''
+                      } ${unavailable ? 'sidebar-source-item--unavailable' : ''}`}
+                      onClick={() => {
+                        if (!unavailable) {
+                          onSourceSelect(source.id);
+                        }
+                      }}
+                      onContextMenu={e => handleContextMenu(e, source.id)}
+                      title={
+                        unavailable
                           ? translate('sidebar.pluginUnavailable')
-                          : `${source.owner}/${source.repo}`}
+                          : `${source.owner}/${source.repo}`
+                      }
+                      disabled={unavailable}
+                    >
+                      <div className="sidebar-source-icon">
+                        {source.type === 'github' ? (
+                          <Github size={16} />
+                        ) : (
+                          <div className="gitee-icon">码</div>
+                        )}
                       </div>
-                    </div>
-                    {source.active && !unavailable && (
-                      <div className="sidebar-source-active-dot" />
-                    )}
-                  </button>
-                );
-              })}
-            </div>
-          )}
-        </div>
+                      <div className="sidebar-source-info">
+                        <div className="sidebar-source-name">{source.name}</div>
+                        <div className="sidebar-source-path">
+                          {unavailable
+                            ? translate('sidebar.pluginUnavailable')
+                            : `${source.owner}/${source.repo}`}
+                        </div>
+                      </div>
+                      {source.active && !unavailable && (
+                        <div className="sidebar-source-active-dot" />
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
 
         {footerExtra}
 


### PR DESCRIPTION
## Summary

- **Web 本地工作区（P5 / #160）**：新增 OPFS + File System Access 双后端 `WorkspaceAdapter`，接入 `workspaceStore` 与 `workspacePlatform` 工厂
- **local-only 锁死（P7 子项）**：桌面端与 Web 统一移除 `remote-only` 模式；迁移向导与工作区工具栏不再提供「仅远端浏览」；`WorkspaceMode` 收敛为 `unset | local`
- **UI 聚合**：搜索、上传从 Header 迁入 `ImageBrowser`；仓库源移至工作区工具栏；侧栏移除设置入口与源列表
- **REFACTOR_PLAN**：P5 / #160 标记为 ✅

## 关联 Issue

- **Fixes #160** — Web OPFS/FSA 虚拟工作区适配器
- **Related #173** — 本 PR 完成 P7 中的 `remote-only` 移除与浏览 UI 聚合；Gitee 图片代理退役留后续 PR

## Test plan

- [x] `pnpm test`（516 passed）
- [ ] Web：首次进入引导选择 OPFS/文件夹工作区，本地列表与上传正常
- [ ] Desktop：无 `remote-only` 入口；须选本地目录后方可浏览
- [ ] 照片页：搜索/筛选/上传均在 ImageBrowser 工具栏区域


Made with [Cursor](https://cursor.com)