### PR TITLE
fix(pixuli): 工作区切换/重置与侧栏菜单精简

### DIFF
--- a/apps/pixuli/src/features/workspace/WorkspacePanel.tsx
+++ b/apps/pixuli/src/features/workspace/WorkspacePanel.tsx
@@ -13,6 +13,7 @@ import {
   isWebWorkspaceActive,
 } from '@/platforms/workspacePlatform';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { useImageStore } from '@/stores/imageStore';
 import { useSourceStore } from '@/stores/sourceStore';
 import { useI18n } from '@/i18n/useI18n';
 
@@ -120,15 +121,36 @@ export const WorkspaceToolbar: React.FC = () => {
     syncStatus,
     syncMessage,
     error,
+    loading,
     pushPendingToRemote,
     pullFromRemote,
     runSync,
     scanWorkspace,
+    pickWorkspace,
+    clearWorkspace,
     clearError,
   } = useWorkspaceStore();
+  const loadImages = useImageStore(state => state.loadImages);
   const sources = useSourceStore(state => state.sources);
   const hasRemote = sources.length > 0;
-  const busy = pushing || syncing;
+  const busy = pushing || syncing || loading;
+  const isWebWorkspace = isWebWorkspaceActive();
+  const canPickFolder = isWebWorkspace && isFileSystemAccessSupported();
+  const canCreateOpfs = isWebWorkspace && isOpfsSupported();
+
+  const handleSwitchWorkspace = async (backend: 'opfs' | 'fsa') => {
+    const ok = await pickWorkspace({ backend });
+    if (ok) {
+      await loadImages();
+    }
+  };
+
+  const handleClearWorkspace = () => {
+    if (!window.confirm(t('workspace.clearConfirm'))) {
+      return;
+    }
+    void clearWorkspace().then(() => loadImages());
+  };
 
   return (
     <div className="mb-4 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
@@ -233,6 +255,58 @@ export const WorkspaceToolbar: React.FC = () => {
           {t('workspace.pushNeedsRemote')}
         </p>
       )}
+
+      <div className="mt-3 border-t border-gray-200 pt-3">
+        <p className="text-xs font-medium text-gray-700 mb-2">
+          {t('workspace.manageTitle')}
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {canPickFolder && (
+            <button
+              type="button"
+              onClick={() => void handleSwitchWorkspace('fsa')}
+              disabled={busy}
+              className="inline-flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50"
+            >
+              <FolderSync size={16} />
+              {loading ? t('workspace.picking') : t('workspace.switchFolder')}
+            </button>
+          )}
+          {canCreateOpfs && (
+            <button
+              type="button"
+              onClick={() => void handleSwitchWorkspace('opfs')}
+              disabled={busy}
+              className="inline-flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50"
+            >
+              <FolderOpen size={16} />
+              {loading ? t('workspace.picking') : t('workspace.switchOpfs')}
+            </button>
+          )}
+          {!isWebWorkspace && (
+            <button
+              type="button"
+              onClick={() => void handleSwitchWorkspace('opfs')}
+              disabled={busy}
+              className="inline-flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50"
+            >
+              <FolderOpen size={16} />
+              {loading ? t('workspace.picking') : t('workspace.switchFolder')}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleClearWorkspace}
+            disabled={busy}
+            className="inline-flex items-center gap-1.5 rounded-md border border-red-200 bg-white px-3 py-1.5 text-sm text-red-700 hover:bg-red-50 disabled:opacity-50"
+          >
+            {t('workspace.clearWorkspace')}
+          </button>
+        </div>
+        <p className="mt-2 text-xs text-gray-500">
+          {t('workspace.manageHint')}
+        </p>
+      </div>
 
       <WorkspaceSourceSection showDivider />
     </div>

--- a/apps/pixuli/src/i18n/locales/en-US.json
+++ b/apps/pixuli/src/i18n/locales/en-US.json
@@ -105,6 +105,12 @@
     "migrationLocalTitleWeb": "Choose a local workspace",
     "migrationLocalHintWeb": "Connect a local folder or create a browser workspace; existing remotes will be bound for sync.",
     "migrationPickFolder": "Choose folder and continue",
-    "migrationPullAfter": "Pull all images from remote after setup (may take a while)"
+    "migrationPullAfter": "Pull all images from remote after setup (may take a while)",
+    "manageTitle": "Workspace",
+    "manageHint": "Switching folders uses a new workspace. Disconnect clears saved workspace state and returns to setup (files on disk are not deleted).",
+    "switchFolder": "Change folder",
+    "switchOpfs": "New browser workspace",
+    "clearWorkspace": "Disconnect workspace",
+    "clearConfirm": "Disconnect the current workspace? Saved workspace state will be cleared and you will need to pick a folder or create a workspace again. Files on disk will not be deleted."
   }
 }

--- a/apps/pixuli/src/i18n/locales/zh-CN.json
+++ b/apps/pixuli/src/i18n/locales/zh-CN.json
@@ -105,6 +105,12 @@
     "migrationLocalTitleWeb": "选择本地工作区",
     "migrationLocalHintWeb": "连接本机文件夹或创建浏览器工作区；现有远端源将自动绑定以便同步。",
     "migrationPickFolder": "选择文件夹并继续",
-    "migrationPullAfter": "设置完成后从远端全量拉取（可能耗时较长）"
+    "migrationPullAfter": "设置完成后从远端全量拉取（可能耗时较长）",
+    "manageTitle": "工作区管理",
+    "manageHint": "切换文件夹会改用新工作区；断开连接将清除本机记录并返回初始设置（不删除磁盘上的图片文件）。",
+    "switchFolder": "更换文件夹",
+    "switchOpfs": "新建浏览器工作区",
+    "clearWorkspace": "断开工作区",
+    "clearConfirm": "确定断开当前工作区？将清除本机保存的工作区记录，需要重新选择文件夹或创建工作区。磁盘上的图片文件不会被删除。"
   }
 }

--- a/apps/pixuli/src/platforms/web/fsaWorkspaceFs.ts
+++ b/apps/pixuli/src/platforms/web/fsaWorkspaceFs.ts
@@ -53,6 +53,19 @@ export async function storeFsaDirectoryHandle(
   db.close();
 }
 
+export async function deleteFsaDirectoryHandle(
+  workspaceId: string,
+): Promise<void> {
+  const db = await openFsaDb();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(FSA_STORE, 'readwrite');
+    tx.objectStore(FSA_STORE).delete(workspaceId);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error ?? new Error('IDB delete failed'));
+  });
+  db.close();
+}
+
 export async function loadFsaDirectoryHandle(
   workspaceId: string,
 ): Promise<FileSystemDirectoryHandle | null> {

--- a/apps/pixuli/src/stores/workspaceStore.ts
+++ b/apps/pixuli/src/stores/workspaceStore.ts
@@ -29,6 +29,10 @@ import {
   resetWorkspaceAdapter,
 } from '../platforms/workspacePlatform';
 import { isWebWorkspaceAdapter } from '../platforms/web/workspaceAdapter';
+import {
+  deleteFsaDirectoryHandle,
+  parseFsaRootPath,
+} from '../platforms/web/fsaWorkspaceFs';
 
 const WORKSPACE_STORAGE_KEY = 'pixuli.workspace.v1';
 const WORKSPACE_MODE_KEY = 'pixuli.workspaceMode.v1';
@@ -57,6 +61,7 @@ interface WorkspaceState {
     pullAfter?: boolean;
     backend?: 'opfs' | 'fsa';
   }) => Promise<boolean>;
+  clearWorkspace: () => Promise<void>;
   resumeLocalWorkspace: () => Promise<boolean>;
   syncBindingsFromSources: () => Promise<void>;
   refreshLocalImages: () => Promise<void>;
@@ -144,6 +149,30 @@ function savePersistedWorkspace(
     );
   } catch {
     // ignore
+  }
+}
+
+function clearPersistedWorkspace(): void {
+  try {
+    localStorage.removeItem(WORKSPACE_STORAGE_KEY);
+    localStorage.removeItem(WORKSPACE_MODE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+async function cleanupFsaWorkspaceRoot(rootPath: string | null): Promise<void> {
+  if (!rootPath) {
+    return;
+  }
+  const workspaceId = parseFsaRootPath(rootPath);
+  if (!workspaceId) {
+    return;
+  }
+  try {
+    await deleteFsaDirectoryHandle(workspaceId);
+  } catch {
+    // ignore stale handle cleanup errors
   }
 }
 
@@ -317,13 +346,29 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       return false;
     }
 
+    const previousRootPath = get().rootPath;
+    const previousDisplayName = get().displayName;
+    const hadLocal = get().mode === 'local' && Boolean(previousRootPath);
+
     set({ loading: true, error: null });
     try {
       resetWorkspaceRuntime();
       const adapter = getAdapter();
       const picked = await pickAdapterRoot(adapter, options?.backend);
       if (!picked || !adapter.getRootPath()) {
-        set({ loading: false });
+        if (hadLocal && previousRootPath) {
+          await openVaultWithRoot(previousRootPath);
+          set({
+            mode: 'local',
+            rootPath: previousRootPath,
+            displayName: previousDisplayName,
+            loading: false,
+          });
+          await get().refreshLocalImages();
+          await get().refreshSyncStatus();
+        } else {
+          set({ loading: false });
+        }
         return false;
       }
 
@@ -333,6 +378,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       const config = vault.getConfig();
       savePersistedWorkspace(rootPath, config.workspaceId, folderLabel);
       saveModePref('local');
+
+      if (previousRootPath && previousRootPath !== rootPath) {
+        await cleanupFsaWorkspaceRoot(previousRootPath);
+      }
 
       set({
         mode: 'local',
@@ -355,6 +404,27 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       });
       return false;
     }
+  },
+
+  clearWorkspace: async () => {
+    const { rootPath } = get();
+    await cleanupFsaWorkspaceRoot(rootPath);
+    clearPersistedWorkspace();
+    resetWorkspaceRuntime();
+    set({
+      mode: 'unset',
+      rootPath: null,
+      displayName: null,
+      localImages: [],
+      loading: false,
+      pushing: false,
+      syncing: false,
+      syncStatus: null,
+      error: null,
+      syncMessage: null,
+    });
+    const { useImageStore } = await import('./imageStore');
+    useImageStore.setState({ images: [], loading: false, error: null });
   },
 
   refreshLocalImages: async () => {

--- a/packages/ui/src/layout/sidebar/web/Sidebar.tsx
+++ b/packages/ui/src/layout/sidebar/web/Sidebar.tsx
@@ -22,6 +22,12 @@ export type SidebarView = 'photos' | 'explore' | 'tags' | 'favorites';
 export type SidebarFilter = 'all' | 'tags' | 'favorites';
 export type SidebarUtilityTool = 'compress' | 'convert';
 
+/** 暂时隐藏的侧栏菜单项（恢复显示时从此集合移除 key） */
+const TEMPORARILY_HIDDEN_MENU_KEYS = new Set(['compress', 'convert']);
+
+/** 暂时隐藏的侧栏底部项 */
+const TEMPORARILY_HIDDEN_FOOTER_KEYS = new Set(['docs', 'keyboardShortcuts']);
+
 // 统一的菜单项类型（图床 + 工具）
 export type SidebarMenuItem =
   | { type: 'photos' }
@@ -211,7 +217,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       label: translate('sidebar.imageConvert'),
       menuItem: { type: 'utility', tool: 'convert' },
     },
-  ];
+  ].filter(item => !TEMPORARILY_HIDDEN_MENU_KEYS.has(item.menuKey));
 
   // 处理右键菜单
   const handleContextMenu = (
@@ -445,33 +451,37 @@ const Sidebar: React.FC<SidebarProps> = ({
 
           {/* 底部操作 - 折叠状态 */}
           <div className="sidebar-collapsed-footer">
-            <button
-              className="sidebar-collapsed-item"
-              onClick={() => {
-                window.open(
-                  'https://github.com/trueLoving/Pixuli/wiki/Pixuli-Usage-Tutorial',
-                  '_blank',
-                );
-              }}
-              title={translate('sidebar.docs')}
-            >
-              <HelpCircle size={28} />
-              <span className="sidebar-collapsed-tooltip">
-                {translate('sidebar.docs')}
-              </span>
-            </button>
-            <button
-              className="sidebar-collapsed-item"
-              onClick={() => {
-                window.dispatchEvent(new CustomEvent('openKeyboardHelp'));
-              }}
-              title={translate('sidebar.keyboardShortcuts')}
-            >
-              <Keyboard size={28} />
-              <span className="sidebar-collapsed-tooltip">
-                {translate('sidebar.keyboardShortcuts')}
-              </span>
-            </button>
+            {!TEMPORARILY_HIDDEN_FOOTER_KEYS.has('docs') && (
+              <button
+                className="sidebar-collapsed-item"
+                onClick={() => {
+                  window.open(
+                    'https://github.com/trueLoving/Pixuli/wiki/Pixuli-Usage-Tutorial',
+                    '_blank',
+                  );
+                }}
+                title={translate('sidebar.docs')}
+              >
+                <HelpCircle size={28} />
+                <span className="sidebar-collapsed-tooltip">
+                  {translate('sidebar.docs')}
+                </span>
+              </button>
+            )}
+            {!TEMPORARILY_HIDDEN_FOOTER_KEYS.has('keyboardShortcuts') && (
+              <button
+                className="sidebar-collapsed-item"
+                onClick={() => {
+                  window.dispatchEvent(new CustomEvent('openKeyboardHelp'));
+                }}
+                title={translate('sidebar.keyboardShortcuts')}
+              >
+                <Keyboard size={28} />
+                <span className="sidebar-collapsed-tooltip">
+                  {translate('sidebar.keyboardShortcuts')}
+                </span>
+              </button>
+            )}
             <button
               className="sidebar-collapsed-item"
               onClick={() => {
@@ -629,25 +639,27 @@ const Sidebar: React.FC<SidebarProps> = ({
 
         {/* 底部操作 */}
         <div className="sidebar-footer">
-          <NavItem
-            icon={<HelpCircle size={20} />}
-            label={translate('sidebar.docs')}
-            onClick={() => {
-              // 打开文档链接
-              window.open(
-                'https://github.com/trueLoving/Pixuli/wiki/Pixuli-Usage-Tutorial',
-                '_blank',
-              );
-            }}
-          />
-          <NavItem
-            icon={<Keyboard size={20} />}
-            label={translate('sidebar.keyboardShortcuts')}
-            onClick={() => {
-              // 触发快捷键说明事件
-              window.dispatchEvent(new CustomEvent('openKeyboardHelp'));
-            }}
-          />
+          {!TEMPORARILY_HIDDEN_FOOTER_KEYS.has('docs') && (
+            <NavItem
+              icon={<HelpCircle size={20} />}
+              label={translate('sidebar.docs')}
+              onClick={() => {
+                window.open(
+                  'https://github.com/trueLoving/Pixuli/wiki/Pixuli-Usage-Tutorial',
+                  '_blank',
+                );
+              }}
+            />
+          )}
+          {!TEMPORARILY_HIDDEN_FOOTER_KEYS.has('keyboardShortcuts') && (
+            <NavItem
+              icon={<Keyboard size={20} />}
+              label={translate('sidebar.keyboardShortcuts')}
+              onClick={() => {
+                window.dispatchEvent(new CustomEvent('openKeyboardHelp'));
+              }}
+            />
+          )}
           <NavItem
             icon={<Info size={20} />}
             label={translate('sidebar.versionInfo')}


### PR DESCRIPTION
## Summary

- 工作区工具栏新增「工作区管理」：更换文件夹、新建浏览器工作区（Web OPFS）、断开工作区
- `clearWorkspace` 清除 localStorage 与 FSA 目录句柄；切换工作区时清理旧句柄
- 取消文件夹选择时自动恢复先前工作区，避免误操作导致状态丢失
- 侧栏暂时隐藏：图片压缩、图片转换、文档、快捷键（保留版本信息）

## Test plan

- [x] `pnpm test`
- [ ] Web：连接文件夹后可「更换文件夹」或「断开工作区」回到设置页
- [ ] 选目录对话框点取消后，当前工作区与图片列表保持不变
- [ ] 侧栏仅显示照片与版本信息入口

Related: #174


Made with [Cursor](https://cursor.com)