### PR TITLE
[M5] REF-512 移动端 Web UI 适配（窄屏/触控）

### DIFF
--- a/apps/pixuli/src/App.css
+++ b/apps/pixuli/src/App.css
@@ -452,6 +452,39 @@ body {
   .photos-page {
     padding-left: env(safe-area-inset-left, 0);
     padding-right: env(safe-area-inset-right, 0);
+    overflow-x: hidden;
+    max-width: 100%;
+  }
+
+  .workspace-toolbar {
+    padding-left: max(0.75rem, env(safe-area-inset-left, 0));
+    padding-right: max(0.75rem, env(safe-area-inset-right, 0));
+  }
+
+  .workspace-toolbar-actions {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    padding-bottom: 0.125rem;
+  }
+
+  .workspace-toolbar-actions::-webkit-scrollbar {
+    display: none;
+  }
+
+  .workspace-toolbar-actions > button {
+    flex-shrink: 0;
+    min-height: 2.75rem;
+    white-space: nowrap;
+  }
+
+  .operation-log-modal-panel {
+    padding-bottom: env(safe-area-inset-bottom, 0);
   }
 
   .utility-page {

--- a/apps/pixuli/src/features/operation-log/OperationLogModal.tsx
+++ b/apps/pixuli/src/features/operation-log/OperationLogModal.tsx
@@ -167,44 +167,58 @@ const OperationLogModal: React.FC<OperationLogModalProps> = ({
 
   if (!isOpen) return null;
 
+  const iconButtonClass =
+    'inline-flex min-h-[2.75rem] min-w-[2.75rem] items-center justify-center rounded-md hover:bg-gray-100';
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-      <div className="bg-white rounded-lg shadow-xl w-[90vw] h-[90vh] flex flex-col">
+    <div className="operation-log-modal-overlay fixed inset-0 z-50 flex bg-black/50 md:items-center md:justify-center md:p-4">
+      <div className="operation-log-modal-panel flex h-full w-full flex-col bg-white shadow-xl md:h-[90vh] md:max-h-[90vh] md:w-[90vw] md:rounded-lg">
         {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b">
-          <h2 className="text-xl font-semibold">{t('title')}</h2>
-          <div className="flex items-center gap-2">
+        <div className="flex items-center justify-between border-b p-4 pt-[max(1rem,env(safe-area-inset-top))]">
+          <h2 className="text-lg font-semibold md:text-xl">{t('title')}</h2>
+          <div className="flex shrink-0 items-center gap-1">
             <button
+              type="button"
               onClick={() => setShowFilter(!showFilter)}
-              className="p-2 hover:bg-gray-100 rounded"
+              className={iconButtonClass}
               title={t('filter')}
+              aria-label={t('filter')}
             >
-              <Filter className="w-5 h-5" />
+              <Filter className="h-5 w-5" />
             </button>
             <button
+              type="button"
               onClick={() => handleExport('json')}
-              className="p-2 hover:bg-gray-100 rounded"
+              className={iconButtonClass}
               title={t('exportJSON')}
+              aria-label={t('exportJSON')}
             >
-              <Download className="w-5 h-5" />
+              <Download className="h-5 w-5" />
             </button>
             <button
+              type="button"
               onClick={() => handleClearLogs('all')}
-              className="p-2 hover:bg-gray-100 rounded text-red-600"
+              className={`${iconButtonClass} text-red-600`}
               title={t('clearAll')}
+              aria-label={t('clearAll')}
             >
-              <Trash2 className="w-5 h-5" />
+              <Trash2 className="h-5 w-5" />
             </button>
-            <button onClick={onClose} className="p-2 hover:bg-gray-100 rounded">
-              <X className="w-5 h-5" />
+            <button
+              type="button"
+              onClick={onClose}
+              className={iconButtonClass}
+              aria-label={t('close')}
+            >
+              <X className="h-5 w-5" />
             </button>
           </div>
         </div>
 
         {/* Statistics */}
         {statistics && (
-          <div className="p-4 border-b bg-gray-50">
-            <div className="grid grid-cols-4 gap-4">
+          <div className="border-b bg-gray-50 p-4">
+            <div className="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4">
               <div className="text-center">
                 <div className="text-2xl font-bold">{statistics.total}</div>
                 <div className="text-sm text-gray-600">{t('total')}</div>
@@ -233,8 +247,8 @@ const OperationLogModal: React.FC<OperationLogModalProps> = ({
 
         {/* Filter Panel */}
         {showFilter && (
-          <div className="p-4 border-b bg-gray-50">
-            <div className="grid grid-cols-2 gap-4">
+          <div className="border-b bg-gray-50 p-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div>
                 <label className="block text-sm font-medium mb-1">
                   {t('action')}

--- a/apps/pixuli/src/features/operation-log/locales/en-US.json
+++ b/apps/pixuli/src/features/operation-log/locales/en-US.json
@@ -47,5 +47,6 @@
   "startDate": "Start Date",
   "endDate": "End Date",
   "reset": "Reset",
-  "apply": "Apply"
+  "apply": "Apply",
+  "close": "Close"
 }

--- a/apps/pixuli/src/features/operation-log/locales/zh-CN.json
+++ b/apps/pixuli/src/features/operation-log/locales/zh-CN.json
@@ -47,5 +47,6 @@
   "startDate": "开始日期",
   "endDate": "结束日期",
   "reset": "重置",
-  "apply": "应用"
+  "apply": "应用",
+  "close": "关闭"
 }

--- a/apps/pixuli/src/features/workspace/WorkspacePanel.tsx
+++ b/apps/pixuli/src/features/workspace/WorkspacePanel.tsx
@@ -153,7 +153,7 @@ export const WorkspaceToolbar: React.FC = () => {
   };
 
   return (
-    <div className="mb-4 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
+    <div className="workspace-toolbar mb-4 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="min-w-0">
           <p className="text-sm font-medium text-gray-900">
@@ -193,7 +193,7 @@ export const WorkspaceToolbar: React.FC = () => {
             )}
           </div>
         </div>
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="workspace-toolbar-actions flex flex-wrap items-center gap-2">
           <button
             type="button"
             onClick={() => void scanWorkspace()}
@@ -260,7 +260,7 @@ export const WorkspaceToolbar: React.FC = () => {
         <p className="text-xs font-medium text-gray-700 mb-2">
           {t('workspace.manageTitle')}
         </p>
-        <div className="flex flex-wrap gap-2">
+        <div className="workspace-toolbar-actions flex flex-wrap gap-2">
           {canPickFolder && (
             <button
               type="button"

--- a/apps/pixuli/src/layouts/AppMain.tsx
+++ b/apps/pixuli/src/layouts/AppMain.tsx
@@ -50,7 +50,7 @@ export const AppMain: React.FC<AppMainProps> = ({ children }) => {
                 type="button"
                 onClick={openOperationLog}
                 title={t('header.operationLog')}
-                className="p-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 transition-colors"
+                className="header-button icon-only p-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 transition-colors"
                 aria-label={t('header.operationLog')}
               >
                 <ScrollText size={18} />

--- a/packages/ui/src/config/gitee-config/web/GiteeConfigModal.css
+++ b/packages/ui/src/config/gitee-config/web/GiteeConfigModal.css
@@ -314,6 +314,14 @@
     justify-content: center;
   }
 
+  .gitee-config-modal-close {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   .gitee-config-form-save-button,
   .gitee-config-modal-actions button {
     min-height: 2.75rem;

--- a/packages/ui/src/config/github-config/web/GitHubConfigModal.css
+++ b/packages/ui/src/config/github-config/web/GitHubConfigModal.css
@@ -493,6 +493,14 @@
     justify-content: center;
   }
 
+  .github-config-modal-close {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   .github-config-form-save-button,
   .github-config-modal-actions button {
     min-height: 2.75rem;

--- a/packages/ui/src/image/image-browser/web/ImageGrid.css
+++ b/packages/ui/src/image/image-browser/web/ImageGrid.css
@@ -392,7 +392,8 @@
 
 .image-grid-actions-mobile .image-action-button {
   flex: 1;
-  min-height: 2.5rem;
+  min-height: 2.75rem;
+  min-width: 2.75rem;
   border-radius: 0.375rem;
   border: 1px solid #e5e7eb;
   background: #f9fafb;


### PR DESCRIPTION
## Summary

- **照片列表**：网格窄屏操作钮升至 44px 热区；`photos-page` 防横向溢出。
- **工作区工具栏**：窄屏横向滚动 + 同步/推送等按钮 `min-height: 2.75rem`。
- **弹层**：操作日志 Modal 窄屏全屏 + safe-area；GitHub/Gitee 配置关闭钮触控热区；Header 操作日志按钮对齐 `header-button` 规范。
- **已有能力**（main 基线）：抽屉侧栏、筛选 bottom sheet、上传/预览全屏、`useCapacitorBackButton`、工具页排版、Gitee 代理文档（`07-capacitor-android-poc.md` §4.3）。

## Test plan

- [x] `pnpm test`
- [ ] 浏览器 DevTools `<768px`：`菜单 → 照片` 无横向滚动条；网格操作可点
- [ ] 打开操作日志 / 配置源 Modal：全屏或满宽、关闭钮可点
- [ ] Android 模拟器或真机：同上 + 硬件返回键逐级关闭弹层/抽屉

Fixes #150

Made with [Cursor](https://cursor.com)