### PR TITLE
[REF-516-P3] 业务补齐：批删/批传与窄屏配源

### DIFF
--- a/apps/pixuli/src/App.css
+++ b/apps/pixuli/src/App.css
@@ -456,6 +456,22 @@ body {
     max-width: 100%;
   }
 
+  .image-content-stats {
+    display: none;
+  }
+
+  .workspace-source-section .workspace-source-add-btn,
+  .workspace-source-section .workspace-source-menu-btn {
+    min-height: 2.75rem;
+    min-width: 2.75rem;
+  }
+
+  .workspace-source-section .workspace-source-chip {
+    min-height: 2.75rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+
   .workspace-toolbar {
     padding-left: max(0.75rem, env(safe-area-inset-left, 0));
     padding-right: max(0.75rem, env(safe-area-inset-right, 0));

--- a/apps/pixuli/src/features/image-content/ImageContent.tsx
+++ b/apps/pixuli/src/features/image-content/ImageContent.tsx
@@ -92,8 +92,8 @@ export const ImageContent: React.FC<ImageContentProps> = ({
         </div>
       )}
 
-      {/* 图片统计和操作区域 */}
-      <div className="mb-4 flex items-center justify-between">
+      {/* 图片统计和操作区域（窄屏由 ImageBrowser 工具栏承担，REF-516 #165） */}
+      <div className="image-content-stats mb-4 flex items-center justify-between">
         <h2 className="text-lg font-semibold text-gray-900">
           {t('app.imageLibrary')} ({images.length} {t('app.images')})
         </h2>

--- a/apps/pixuli/src/features/workspace/WorkspaceSourceSection.tsx
+++ b/apps/pixuli/src/features/workspace/WorkspaceSourceSection.tsx
@@ -74,7 +74,7 @@ export const WorkspaceSourceSection: React.FC<{
 
   return (
     <div
-      className={showDivider ? 'mt-3 border-t border-gray-200 pt-3' : undefined}
+      className={`workspace-source-section${showDivider ? ' mt-3 border-t border-gray-200 pt-3' : ''}`}
     >
       <div className="flex items-center justify-between gap-2 mb-2">
         <span className="text-xs font-medium text-gray-700">
@@ -83,7 +83,7 @@ export const WorkspaceSourceSection: React.FC<{
         <button
           type="button"
           onClick={addSource}
-          className="inline-flex items-center gap-1 rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
+          className="workspace-source-add-btn inline-flex items-center gap-1 rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
           title={t('sidebar.addSource')}
         >
           <Plus size={14} />
@@ -114,7 +114,7 @@ export const WorkspaceSourceSection: React.FC<{
                       ? t('sidebar.pluginUnavailable')
                       : `${source.owner}/${source.repo}`
                   }
-                  className={`inline-flex max-w-[min(100%,14rem)] items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-left text-xs transition-colors ${
+                  className={`workspace-source-chip inline-flex max-w-[min(100%,14rem)] items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-left text-xs transition-colors ${
                     active
                       ? 'border-blue-400 bg-blue-50 text-blue-900'
                       : 'border-gray-200 bg-white text-gray-800 hover:bg-gray-50'
@@ -132,7 +132,7 @@ export const WorkspaceSourceSection: React.FC<{
                 </button>
                 <button
                   type="button"
-                  className="rounded-md p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-800"
+                  className="workspace-source-menu-btn rounded-md p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-800"
                   title={t('sidebar.editSource')}
                   onClick={event => openContextMenu(event, source.id)}
                   aria-label={t('sidebar.editSource')}

--- a/apps/pixuli/src/layouts/MainLayout.tsx
+++ b/apps/pixuli/src/layouts/MainLayout.tsx
@@ -181,6 +181,7 @@ export const MainLayout: React.FC<MainLayoutProps> = ({
         githubConfig={modalGitHubConfig}
         onSaveConfig={onSaveConfig}
         onClearConfig={onClearConfig}
+        platform={platform}
         t={t}
       />
 

--- a/apps/pixuli/src/stores/imageStore.ts
+++ b/apps/pixuli/src/stores/imageStore.ts
@@ -291,17 +291,131 @@ export const useImageStore = create<ImageState>((set, get) => {
     },
 
     uploadMultipleImages: async (uploadData: MultiImageUploadData) => {
+      const { files, name, description, tags } = uploadData;
+
       if (isLocalListMode()) {
-        const { files, name, description, tags } = uploadData;
-        for (const file of files) {
-          await useWorkspaceStore.getState().importLocalImage({
-            file,
-            name,
-            description,
-            tags,
-          });
+        const total = files.length;
+        if (total === 0) {
+          return;
         }
-        await refreshLocalIntoImageStore(set);
+
+        let completed = 0;
+        let failed = 0;
+        const startTime = Date.now();
+        const items: UploadProgress[] = files.map((_file, index) => ({
+          id: `${Date.now()}-${index}`,
+          progress: 0,
+          status: 'uploading' as const,
+          message: '等待导入...',
+        }));
+
+        set({
+          loading: true,
+          error: null,
+          batchUploadProgress: {
+            total,
+            completed: 0,
+            failed: 0,
+            current: files[0]?.name,
+            items,
+          },
+        });
+
+        try {
+          for (let i = 0; i < files.length; i++) {
+            const file = files[i];
+            const itemId = items[i].id;
+            set(state => ({
+              batchUploadProgress: state.batchUploadProgress
+                ? {
+                    ...state.batchUploadProgress,
+                    current: file.name,
+                    items: state.batchUploadProgress.items.map(item =>
+                      item.id === itemId
+                        ? {
+                            ...item,
+                            status: 'uploading',
+                            message: '正在导入...',
+                          }
+                        : item,
+                    ),
+                  }
+                : null,
+            }));
+
+            try {
+              await useWorkspaceStore.getState().importLocalImage({
+                file,
+                name,
+                description,
+                tags,
+              });
+              completed++;
+              set(state => ({
+                batchUploadProgress: state.batchUploadProgress
+                  ? {
+                      ...state.batchUploadProgress,
+                      completed,
+                      items: state.batchUploadProgress.items.map(item =>
+                        item.id === itemId
+                          ? {
+                              ...item,
+                              status: 'success',
+                              progress: 100,
+                              message: '导入成功',
+                            }
+                          : item,
+                      ),
+                    }
+                  : null,
+              }));
+            } catch (error) {
+              failed++;
+              const errorMessage =
+                error instanceof Error ? error.message : '导入失败';
+              set(state => ({
+                batchUploadProgress: state.batchUploadProgress
+                  ? {
+                      ...state.batchUploadProgress,
+                      failed,
+                      items: state.batchUploadProgress.items.map(item =>
+                        item.id === itemId
+                          ? {
+                              ...item,
+                              status: 'error',
+                              message: errorMessage,
+                            }
+                          : item,
+                      ),
+                    }
+                  : null,
+              }));
+            }
+          }
+
+          await refreshLocalIntoImageStore(set);
+          set({ batchUploadProgress: null });
+          useLogStore
+            .getState()
+            .addLog(LogActionType.BATCH_UPLOAD, LogStatus.SUCCESS, {
+              details: { total, completed, failed },
+              duration: Date.now() - startTime,
+            });
+        } catch (error) {
+          const errorMsg =
+            error instanceof Error ? error.message : '批量导入失败';
+          set({
+            error: errorMsg,
+            loading: false,
+            batchUploadProgress: null,
+          });
+          useLogStore
+            .getState()
+            .addLog(LogActionType.BATCH_UPLOAD, LogStatus.FAILED, {
+              error: errorMsg,
+              details: { total, completed, failed },
+            });
+        }
         return;
       }
 
@@ -314,7 +428,6 @@ export const useImageStore = create<ImageState>((set, get) => {
         return;
       }
 
-      const { files, name, description, tags } = uploadData;
       const total = files.length;
       let completed = 0;
       let failed = 0;
@@ -516,10 +629,18 @@ export const useImageStore = create<ImageState>((set, get) => {
     },
 
     deleteMultipleImages: async (imageIds: string[], fileNames: string[]) => {
+      if (imageIds.length === 0) {
+        return;
+      }
+
+      const batchLogDetails = {
+        imageIds,
+        imageNames: fileNames,
+        count: imageIds.length,
+      };
+
       if (isLocalListMode()) {
-        if (imageIds.length === 0) {
-          return;
-        }
+        const startTime = Date.now();
         set({ loading: true, error: null });
         try {
           const { images } = get();
@@ -532,11 +653,25 @@ export const useImageStore = create<ImageState>((set, get) => {
             }
           }
           await refreshLocalIntoImageStore(set);
+          useLogStore
+            .getState()
+            .addLog(LogActionType.BATCH_DELETE, LogStatus.SUCCESS, {
+              details: batchLogDetails,
+              duration: Date.now() - startTime,
+            });
         } catch (error) {
+          const errorMsg =
+            error instanceof Error ? error.message : '批量删除图片失败';
           set({
             loading: false,
-            error: error instanceof Error ? error.message : '批量删除图片失败',
+            error: errorMsg,
           });
+          useLogStore
+            .getState()
+            .addLog(LogActionType.BATCH_DELETE, LogStatus.FAILED, {
+              details: batchLogDetails,
+              error: errorMsg,
+            });
         }
         return;
       }
@@ -547,10 +682,6 @@ export const useImageStore = create<ImageState>((set, get) => {
           error: `${storagePluginLabel(storageType)} 配置未初始化`,
           loading: false,
         });
-        return;
-      }
-
-      if (imageIds.length === 0) {
         return;
       }
 
@@ -568,14 +699,12 @@ export const useImageStore = create<ImageState>((set, get) => {
           loading: false,
         }));
 
-        useLogStore.getState().addLog(LogActionType.DELETE, LogStatus.SUCCESS, {
-          details: {
-            imageIds,
-            imageNames: fileNames,
-            count: imageIds.length,
-          },
-          duration,
-        });
+        useLogStore
+          .getState()
+          .addLog(LogActionType.BATCH_DELETE, LogStatus.SUCCESS, {
+            details: batchLogDetails,
+            duration,
+          });
       } catch (error) {
         const duration = Date.now() - startTime;
         const errorMsg =
@@ -585,15 +714,13 @@ export const useImageStore = create<ImageState>((set, get) => {
           loading: false,
         });
 
-        useLogStore.getState().addLog(LogActionType.DELETE, LogStatus.FAILED, {
-          details: {
-            imageIds,
-            imageNames: fileNames,
-            count: imageIds.length,
-          },
-          error: errorMsg,
-          duration,
-        });
+        useLogStore
+          .getState()
+          .addLog(LogActionType.BATCH_DELETE, LogStatus.FAILED, {
+            details: batchLogDetails,
+            error: errorMsg,
+            duration,
+          });
       } finally {
         set({ loading: false });
       }

--- a/packages/ui/src/config/gitee-config/web/GiteeConfigModal.tsx
+++ b/packages/ui/src/config/gitee-config/web/GiteeConfigModal.tsx
@@ -15,7 +15,7 @@ interface GiteeConfigModalProps {
   giteeConfig?: GiteeConfig | null;
   onSaveConfig: (config: GiteeConfig) => void;
   onClearConfig: () => void;
-  platform?: 'web' | 'desktop';
+  platform?: 'web' | 'desktop' | 'mobile';
   t?: (key: string) => string;
 }
 

--- a/packages/ui/src/config/github-config/web/GitHubConfigModal.tsx
+++ b/packages/ui/src/config/github-config/web/GitHubConfigModal.tsx
@@ -15,7 +15,7 @@ interface GitHubConfigModalProps {
   githubConfig?: GitHubConfig | null;
   onSaveConfig: (config: GitHubConfig) => void;
   onClearConfig: () => void;
-  platform?: 'web' | 'desktop';
+  platform?: 'web' | 'desktop' | 'mobile';
   t?: (key: string) => string;
 }
 

--- a/packages/ui/src/image/image-browser/web/ImageBatchDeleteModal.css
+++ b/packages/ui/src/image/image-browser/web/ImageBatchDeleteModal.css
@@ -256,8 +256,21 @@
     padding-top: max(1rem, env(safe-area-inset-top, 0));
   }
 
+  .image-batch-delete-modal-close {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+  }
+
   .image-batch-delete-modal-footer {
+    flex-direction: column;
+    align-items: stretch;
     padding-bottom: max(1.5rem, env(safe-area-inset-bottom, 0));
+  }
+
+  .image-batch-delete-modal-cancel,
+  .image-batch-delete-modal-confirm {
+    width: 100%;
+    justify-content: center;
   }
 
   .image-batch-delete-modal-image-list {


### PR DESCRIPTION
## Summary

- **P0 批量删除（J6-02）**：本地/远端 `deleteMultipleImages` 统一写 `BATCH_DELETE` 操作日志；窄屏批删弹层底部按钮全宽 + 44px 热区。
- **P0 批量上传（J4-02）**：本地工作区 `uploadMultipleImages` 补齐 `batchUploadProgress` 进度 UI（与远端路径一致）。
- **P0 配置源（J1-06）**：GitHub/Gitee Config Modal 支持 `platform: mobile` 导出；工作区源区块窄屏触控热区；GitHub Modal 传入 `getPlatform()`。
- **窄屏体验**：隐藏 `ImageContent` 与 `ImageBrowser` 重复的统计标题行（#150 布局基础上）。

## P0 矩阵签收

| 项 | 状态 |
|----|------|
| 批量删除 Capacitor 路径 | ✅ |
| 批量上传 + 进度 | ✅（含 local vault） |
| 配置导出 JSON | ✅（已有 + mobile platform） |
| 搜索/筛选单屏 | ✅（main 已用 SearchContext，无 RN filter Tab） |
| 配置 Modal | ✅（`@pixuli/ui` web） |

## 顺延（本 PR 未做）

- P1：删除 `apps/mobile` `filter.tsx` 死路由（Issue 约定不改 RN，留 #151 归档）
- P1：Gitee release APK 代理真机验证（文档 §4.3，待 #166 冒烟）
- P2：上传裁剪默认、主题、pull-to-refresh

## Test plan

- [x] `pnpm test`
- [ ] 窄屏 `<768px`：列表 → 批删图标 → 选 2 张 → 删除 → 列表更新
- [ ] 窄屏：多选文件上传 → 进度条可见 → 列表增加
- [ ] 侧栏/工作区栏「添加源」→ 配置 Modal 全屏可保存；已配置源可导出 JSON

Related #165

Made with [Cursor](https://cursor.com)