### PR TITLE
docs: P0 文档索引、归档标记与架构过时表述修正

### DIFF
--- a/docs/02-system-design/00-System-Design.md
+++ b/docs/02-system-design/00-System-Design.md
@@ -1,9 +1,10 @@
 # Pixuli 整体系统设计
 
-> **最后核对**：2026-06-06 · 适用分支 `main` · REF-407  
+> **最后核对**：2026-06-17 · 适用分支 `main` · REF-407 / 文档 P0  
 > **说明**：M3 后共享层为 `@pixuli/core` + `@pixuli/ui` +
-> `@pixuli/provider-*`；`packages/common`、主路径WASM、`server/`
-> 已归档。官方不提供 NestJS
+> `@pixuli/provider-*`；`packages/common`、主路径 WASM、`server/`
+> 已归档。Mobile 由 **`apps/pixuli` + Capacitor Android** 交付（非 Expo
+> RN）。官方不提供 NestJS
 > Server。图床主界面为**网格/列表**（幻灯片/时间线已移除，见
 > [backlog](../backlog.md)）。
 
@@ -68,13 +69,13 @@
 
 ### 2.2 前端与多端术语
 
-| 术语           | 英文              | 说明                                                                      |
-| -------------- | ----------------- | ------------------------------------------------------------------------- |
-| **Web 端**     | Web               | 基于 Vite + React，运行在浏览器中的 Web 应用，支持 PWA                    |
-| **Desktop 端** | Desktop           | 基于 Electron + React 的桌面应用，与 Web 共享同一套前端代码与 Vite 构建   |
-| **Mobile 端**  | Mobile            | 基于 React Native + Expo 的移动应用，使用 RN 组件与原生能力               |
-| **仓库源**     | Repository Source | 用户配置的 GitHub 或 Gitee 仓库，作为当前图片存储的「来源」               |
-| **当前源**     | Current Source    | 用户选中的、用于读写图片的仓库配置（owner、repo、branch、path、token 等） |
+| 术语           | 英文              | 说明                                                                                         |
+| -------------- | ----------------- | -------------------------------------------------------------------------------------------- |
+| **Web 端**     | Web               | 基于 Vite + React，运行在浏览器中的 Web 应用，支持 PWA                                       |
+| **Desktop 端** | Desktop           | 基于 Electron + React 的桌面应用，与 Web 共享同一套前端代码与 Vite 构建                      |
+| **Mobile 端**  | Mobile            | **`apps/pixuli` + Capacitor Android**（与 Web 同一套 UI）；归档 RN 见 `archive/apps/mobile/` |
+| **仓库源**     | Repository Source | 用户配置的 GitHub 或 Gitee 仓库，作为当前图片存储的「来源」                                  |
+| **当前源**     | Current Source    | 用户选中的、用于读写图片的仓库配置（owner、repo、branch、path、token 等）                    |
 
 ### 2.3 图片处理术语
 
@@ -262,18 +263,18 @@ graph LR
 
 ### 6.1 技术栈总览
 
-| 层级                    | 技术选型                       | 说明                                    |
-| ----------------------- | ------------------------------ | --------------------------------------- |
-| 前端框架                | React 19.x + TypeScript        | 三端统一技术栈                          |
-| 构建工具                | Vite                           | Web/Desktop 构建                        |
-| 桌面运行时              | Electron                       | 跨平台桌面，主进程可调 Node、WASM、HTTP |
-| 移动端                  | React Native + Expo            | 跨平台移动应用                          |
-| 状态管理                | Zustand                        | 轻量、与框架解耦                        |
-| 图片处理（Web/Desktop） | Rust (WASM)                    | 压缩、转换、基础编辑等                  |
-| 图片处理（Mobile）      | expo-image-manipulator         | 裁剪、缩放、格式等                      |
-| 图床默认                | GitHub API / Gitee API         | 仓库即图床                              |
-| 可选后端                | NestJS + Prisma + MySQL        | 图片与元数据、MinIO/本地存储            |
-| 可选 AI                 | Dify 工作流 / Ollama / Qwen 等 | 图片分析、图片生成                      |
+| 层级                    | 技术选型                       | 说明                                |
+| ----------------------- | ------------------------------ | ----------------------------------- |
+| 前端框架                | React 19.x + TypeScript        | 三端统一技术栈                      |
+| 构建工具                | Vite                           | Web/Desktop 构建                    |
+| 桌面运行时              | Electron                       | 跨平台桌面，主进程 Node 与本地能力  |
+| 移动端                  | Capacitor（Android）           | `apps/pixuli` Web 产物 + 原生壳     |
+| 状态管理                | Zustand                        | 轻量、与框架解耦                    |
+| 图片处理（Web/Desktop） | Canvas（`@pixuli/ui`）         | 压缩、转换等；WASM 已归档           |
+| 图片处理（Mobile）      | 同 Web（Capacitor WebView）    | 与 Desktop/Web 共用 UI 处理路径     |
+| 图床默认                | GitHub API / Gitee API         | 仓库即图床；经 StorageProvider 插件 |
+| 可选后端                | 无官方 Server                  | `archive/server/` 仅社区参考        |
+| 可选 AI                 | Dify 工作流 / Ollama / Qwen 等 | 图片分析、图片生成                  |
 
 ### 6.2 关键设计文档与能力对应
 
@@ -291,17 +292,17 @@ graph LR
 
 ### 7.1 客户端制品形态
 
-| 端      | 构建产物                             | 发布方式                                       |
-| ------- | ------------------------------------ | ---------------------------------------------- |
-| Web     | 静态资源（如 `dist/`）               | 可部署至 Vercel、Nginx、任意静态托管；支持 PWA |
-| Desktop | Electron 安装包（Windows/macOS）     | GitHub Releases 提供 exe、dmg 等               |
-| Mobile  | Android APK、iOS IPA（或 Expo 渠道） | 应用商店或内部分发                             |
+| 端      | 构建产物                              | 发布方式                                       |
+| ------- | ------------------------------------- | ---------------------------------------------- |
+| Web     | 静态资源（如 `dist/`）                | 可部署至 Vercel、Nginx、任意静态托管；支持 PWA |
+| Desktop | Electron 安装包（Windows/macOS）      | GitHub Releases 提供 exe、dmg 等               |
+| Mobile  | Capacitor Android APK（`v*-android`） | GitHub Releases / CI（REF-515 #153）           |
 
-### 7.2 服务端部署（Pixuli Server）
+### 7.2 服务端部署（非官方）
 
-- **技术**：NestJS + Prisma + MySQL；存储为本地磁盘或 MinIO。
-- **部署方式**：与客户端解耦，可 Docker 部署或直接 Node 进程；环境变量配置数据库、存储类型、API
-  Key 等。
+- **官方态度**：不提供 NestJS Server 为一等公民；`archive/server/`
+  仅供社区自建参考。
+- 若需中心化 API，请实现自定义 `StorageProvider` 或 fork 归档 server。
 
 ### 7.3 构建与发布流程（概念）
 
@@ -382,14 +383,13 @@ flowchart LR
 ```
 Pixuli/
 ├── apps/
-│   ├── pixuli/                    # Web + Desktop
-│   └── mobile/                    # Expo + React Native
+│   └── pixuli/                    # Web + Desktop + Mobile（Capacitor）
 ├── packages/
 │   ├── core/                      # @pixuli/core
 │   ├── ui/                        # @pixuli/ui
 │   └── plugin-provider-github|gitee/
 ├── docs/                          # PRD、系统设计、业务设计
-├── archive/                       # wasm、benchmark、server（非 workspace）
+├── archive/                       # wasm、benchmark、server、apps/mobile（非 workspace）
 ├── .github/workflows/
 ├── pnpm-workspace.yaml
 └── package.json

--- a/docs/02-system-design/06-Plugin-Host-Integration.md
+++ b/docs/02-system-design/06-Plugin-Host-Integration.md
@@ -1,5 +1,12 @@
 # 插件 Host 运行时集成
 
+> **文档状态**：📦 **已归档（只读快照）** · 2026-06-17  
+> **归档原因**：Gitee Host 代理已从 `apps/pixuli`
+> 移除；REF-411 范围已改为 Obsidian 式插件重设计（[#126](https://github.com/trueLoving/Pixuli/issues/126)）。  
+> **当前请读**：[REFACTOR_PLAN §1.6](../../REFACTOR_PLAN.md#16-ref-411--插件体系重设计obsidian-参考)
+> · [04-Plugin-System.md](./04-Plugin-System.md) · 索引
+> [archive/design/README.md](../archive/design/README.md)
+
 - **文档版本**：1.0
 - **计划编号**：REF-411（M4）· 模块解析 REF-416
 - **关联 Issue**：[#126](https://github.com/trueLoving/Pixuli/issues/126)

--- a/docs/02-system-design/07-capacitor-android-poc.md
+++ b/docs/02-system-design/07-capacitor-android-poc.md
@@ -1,5 +1,11 @@
 # Capacitor Android PoC（REF-509）
 
+> **文档状态**：📦 **已归档（只读快照）** · 2026-06-17  
+> **归档原因**：REF-509 #118 ✅；PoC 工程约定已并入
+> [15-apps-pixuli-engineering.md](./15-apps-pixuli-engineering.md)。  
+> **当前请读**：[15-apps-pixuli-engineering.md](./15-apps-pixuli-engineering.md) · 索引
+> [archive/design/README.md](../archive/design/README.md)
+
 > **Issue**：[#118](https://github.com/trueLoving/Pixuli/issues/118) ·
 > **范围**：仅 **Android**（不含 iOS）  
 > **路线**：方案 A — `apps/pixuli` 的 `build:web` 产物 + Capacitor WebView 壳  

--- a/docs/02-system-design/09-cross-platform-sharing-matrix.md
+++ b/docs/02-system-design/09-cross-platform-sharing-matrix.md
@@ -1,5 +1,11 @@
 # 三端代码共享矩阵（现状盘点）
 
+> **文档状态**：📦 **已归档（只读快照）** · 2026-06-17  
+> **归档原因**：REF-506 #116 ✅；2026-05-27 代码级盘点快照。  
+> **当前请读**：[15-apps-pixuli-engineering.md](./15-apps-pixuli-engineering.md) ·
+> [00-System-Design.md](./00-System-Design.md) · 索引
+> [archive/design/README.md](../archive/design/README.md)
+
 - **文档版本**：1.0
 - **计划编号**：REF-506（M5）
 - **关联 Issue**：[#116](https://github.com/trueLoving/Pixuli/issues/116)

--- a/docs/02-system-design/11-mobile-feature-parity-matrix.md
+++ b/docs/02-system-design/11-mobile-feature-parity-matrix.md
@@ -1,5 +1,11 @@
 # Mobile 功能对齐矩阵（RN ↔ pixuli ↔ Capacitor）
 
+> **文档状态**：📦 **已归档（只读快照）** · 2026-06-17  
+> **归档原因**：REF-516 P0 #164 ✅；产品交互 SSOT 已收敛至
+> [04-three-platform-interaction-spec.md](../01-product/04-three-platform-interaction-spec.md)。  
+> **当前请读**：[04-three-platform-interaction-spec.md](../01-product/04-three-platform-interaction-spec.md)
+> · 索引 [archive/design/README.md](../archive/design/README.md)
+
 - **文档版本**：1.0
 - **计划编号**：REF-516 P0
 - **关联 Issue**：[#164](https://github.com/trueLoving/Pixuli/issues/164)

--- a/docs/02-system-design/12-ui-native-migration-assessment.md
+++ b/docs/02-system-design/12-ui-native-migration-assessment.md
@@ -1,5 +1,10 @@
 # @pixuli/ui L1/L2 与 RN 组件迁入评估（REF-508）
 
+> **文档状态**：📦 **已归档（只读快照）** · 2026-06-17  
+> **归档原因**：REF-508 #119 ✅；RN 已迁入 `archive/apps/mobile/`（REF-513）。  
+> **当前请读**：[15-apps-pixuli-engineering.md](./15-apps-pixuli-engineering.md) · 索引
+> [archive/design/README.md](../archive/design/README.md)
+
 > **Issue**：[#119](https://github.com/trueLoving/Pixuli/issues/119) ·
 > **计划编号**：REF-508  
 > **父追踪**：[REF-516 P4](https://github.com/trueLoving/Pixuli/issues/163) ·

--- a/docs/02-system-design/13-capacitor-native-plugins.md
+++ b/docs/02-system-design/13-capacitor-native-plugins.md
@@ -1,5 +1,10 @@
 # Capacitor 原生能力插件（REF-510 / #120）
 
+> **文档状态**：📦 **已归档（只读快照）** · 2026-06-17  
+> **归档原因**：REF-510 #120 ✅；L3 插件选型已落地于 `apps/pixuli`。  
+> **当前请读**：[15-apps-pixuli-engineering.md](./15-apps-pixuli-engineering.md) · 索引
+> [archive/design/README.md](../archive/design/README.md)
+
 > 三端融合 P4 L3：在 `apps/pixuli`
 > 内用 Capacitor 插件补齐 PoC 未覆盖的原生能力；**不在** `apps/mobile`
 > 重复实现。

--- a/docs/02-system-design/14-capacitor-android-smoke-acceptance.md
+++ b/docs/02-system-design/14-capacitor-android-smoke-acceptance.md
@@ -1,5 +1,11 @@
 # Capacitor Android 功能对齐验收与真机冒烟（REF-516 P6 / #166）
 
+> **文档状态**：📦 **已归档（只读快照）** · 2026-06-17  
+> **归档原因**：REF-516 P6 #166 ✅；工程签收见
+> [15-apps-pixuli-engineering.md](./15-apps-pixuli-engineering.md)。  
+> **当前请读**：[15-apps-pixuli-engineering.md](./15-apps-pixuli-engineering.md) · 索引
+> [archive/design/README.md](../archive/design/README.md)
+
 > **Issue**：[#166](https://github.com/trueLoving/Pixuli/issues/166) · 父 Issue
 > [#163](https://github.com/trueLoving/Pixuli/issues/163)  
 > **前置**：#165 ✅、#150 ✅、#119/#120/#141 ✅、#118 工程 ✅  

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,112 +2,102 @@
 
 > **最后核对**：2026-06-17 · 适用分支 `main`
 
-本目录（`docs/`）集中存放项目文档，按职责分为子目录。终端用户日常操作见
+本目录（`docs/`）集中存放项目文档。终端用户日常操作见
 **[GitHub Wiki](https://github.com/trueLoving/Pixuli/wiki)**（源稿：
-[01-product/02-Product-User-Manual.md](01-product/02-Product-User-Manual.md)（含附录 Wiki 同步说明））。
+[01-product/02-Product-User-Manual.md](01-product/02-Product-User-Manual.md)）。
 
 ---
 
-## 按角色阅读
+## 按角色阅读（推荐路径）
 
-| 角色                | 建议路径                                                                                                                                                                                                                                                  |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **终端用户**        | [GitHub Wiki](https://github.com/trueLoving/Pixuli/wiki) ← 源稿 [产品使用手册](01-product/02-Product-User-Manual.md)                                                                                                                                      |
-| **产品 / 测试**     | [产品需求规格说明书](01-product/01-Product-Requirements-Specification.md) → [backlog](backlog.md)（已移除项）                                                                                                                                             |
-| **前端 / 多端开发** | [00-System-Design](02-system-design/00-System-Design.md) → [三端能力共享](02-system-design/01-Three-Platform-Capability-Sharing.md) → [三端设计](02-system-design/02-Three-Platform-Design.md) → [04-Plugin-System](02-system-design/04-Plugin-System.md) |
-| **插件作者**        | [04-Plugin-System](02-system-design/04-Plugin-System.md)（§第二部分 开发指南）                                                                                                                                                                            |
-| **协作者 / Issue**  | [REFACTOR_PLAN.md](../REFACTOR_PLAN.md) · AI 辅助 [AGENTS.md](../AGENTS.md)（REF-414）                                                                                                                                                                    |
+| 角色               | 路径                                                                                                                                                                        |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **终端用户**       | [GitHub Wiki](https://github.com/trueLoving/Pixuli/wiki) ← 源稿 [产品使用手册](01-product/02-Product-User-Manual.md)                                                        |
+| **产品 / 测试**    | [PRS](01-product/01-Product-Requirements-Specification.md) → [三端交互规范](01-product/04-three-platform-interaction-spec.md) → [backlog](backlog.md)                       |
+| **工程师**         | [00-System-Design](02-system-design/00-System-Design.md) → [15-apps-pixuli 工程](02-system-design/15-apps-pixuli-engineering.md) → 按需打开专题（插件 / 本地工作区 / 性能） |
+| **插件作者**       | [04-Plugin-System](02-system-design/04-Plugin-System.md) §第二部分 · Skill：[storage-provider](../.cursor/skills/storage-provider/SKILL.md)                                 |
+| **协作者 / Issue** | [REFACTOR_PLAN.md](../REFACTOR_PLAN.md) · [AGENTS.md](../AGENTS.md)                                                                                                         |
 
----
-
-## 目录结构
-
-| 目录                   | 定位 | 说明                                                   |
-| ---------------------- | ---- | ------------------------------------------------------ |
-| **01-product**         | 产物 | PRD、使用教程、裁剪清单；描述「做什么」与「怎么用」。  |
-| **（根目录）**         | 产物 | [backlog.md](backlog.md)：已移除/延后需求（REF-402）。 |
-| **02-system-design**   | 技术 | 架构、跨端、插件、性能等；描述「怎么实现」。           |
-| **03-business-design** | 业务 | 业务场景与规则（**暂缓编写**，见目录 README）。        |
-
-**当前架构（摘要）**：`apps/pixuli`（Web + Desktop + Capacitor Android）·
-`@pixuli/core` · `@pixuli/ui` · `@pixuli/provider-*` · `archive/`（`apps/mobile`
-RN、wasm、server、benchmark，非 workspace）。
+**当前架构（一句话）**：`apps/pixuli`（Web + Desktop + Capacitor Android）·
+`@pixuli/core` · `@pixuli/ui` · `@pixuli/provider-*` ·
+`archive/`（RN、wasm、server 等，非 workspace）。
 
 ---
 
-## 01-product（产物）
+## 01-product（产物 · 4 篇）
 
-| 文档                                                                                            | 关注内容                                                                                      |
-| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| [01-Product-Requirements-Specification.md](01-product/01-Product-Requirements-Specification.md) | **基线产品需求规格说明书**：底线、裁剪、功能/非功能需求、路线图（REF-401 合并）。             |
-| [02-Product-User-Manual.md](01-product/02-Product-User-Manual.md)                               | **产品使用手册（Wiki 源稿）**：配置源、上传、三端、FAQ；附录 Wiki 同步（REF-408 合并）。      |
-| [03-Release-Versioning.md](01-product/03-Release-Versioning.md)                                 | **版本发布策略**（REF-409）：基线 **2.0.0**、三端统一 semver、`v*-{desktop,mobile,web}` tag。 |
-| [04-three-platform-interaction-spec.md](01-product/04-three-platform-interaction-spec.md)       | **三端交互规范**（REF-601）：IA、旅程、差异矩阵、断点与验收路径（#130）。                     |
-
----
-
-## 02-system-design（技术）
-
-| 文档                                                                                                | 关注内容                                                                             |
-| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [00-System-Design.md](02-system-design/00-System-Design.md)                                         | 整体架构、模块职责、数据流（REF-407 已对齐 M3 后结构）。                             |
-| [01-Three-Platform-Capability-Sharing.md](02-system-design/01-Three-Platform-Capability-Sharing.md) | 三端能力共享：资源共享、`@pixuli/core`/`@pixuli/ui`、图片处理契约、日志。            |
-| [02-Three-Platform-Design.md](02-system-design/02-Three-Platform-Design.md)                         | 三端设计方案：最大化代码复用（Capacitor 方案 A 等）。                                |
-| [03-Performance.md](02-system-design/03-Performance.md)                                             | 列表虚拟化、懒加载、性能监控。                                                       |
-| [04-Plugin-System.md](02-system-design/04-Plugin-System.md)                                         | Pixuli 插件体系：存储架构、开发指南、M3 回归清单（REF-301～311）。                   |
-| [05-TypeScript-JavaScript-Policy.md](02-system-design/05-TypeScript-JavaScript-Policy.md)           | TS/JS 统一策略与例外登记（REF-410）。                                                |
-| [06-Plugin-Host-Integration.md](02-system-design/06-Plugin-Host-Integration.md)                     | 插件 Host 集成：manifest、`registerHostIntegrations`（REF-411）。                    |
-| [07-capacitor-android-poc.md](02-system-design/07-capacitor-android-poc.md)                         | Capacitor Android PoC：dev/prod 构建与冒烟清单（REF-509 #118）。                     |
-| [15-apps-pixuli-engineering.md](02-system-design/15-apps-pixuli-engineering.md)                     | **apps/pixuli 工程约定**：目录、脚本分组、构建矩阵、CI（REF-514 #152）。             |
-| [09-cross-platform-sharing-matrix.md](02-system-design/09-cross-platform-sharing-matrix.md)         | 三端代码共享矩阵：pixuli vs 归档 RN（REF-506）。                                     |
-| [11-mobile-feature-parity-matrix.md](02-system-design/11-mobile-feature-parity-matrix.md)           | **Mobile 功能对齐矩阵**：用户旅程、Capacitor 决策、#165 输入（REF-516 P0 / #164）。  |
-| [12-ui-native-migration-assessment.md](02-system-design/12-ui-native-migration-assessment.md)       | **UI 对齐与 RN 归档边界**（REF-508 / #119）；RN 已迁入 `archive/`（REF-513）。       |
-| [10-local-workspace-sync.md](02-system-design/10-local-workspace-sync.md)                           | 本地工作区 + 远端同步：`LocalVault` / `SyncEngine` / Provider 扩展（REF-607 #144）。 |
+| 文档                                                                                            | SSOT 职责                          |
+| ----------------------------------------------------------------------------------------------- | ---------------------------------- |
+| [01-Product-Requirements-Specification.md](01-product/01-Product-Requirements-Specification.md) | 产品底线、需求、验收（REF-401）    |
+| [02-Product-User-Manual.md](01-product/02-Product-User-Manual.md)                               | 用户手册源稿 → Wiki（REF-408）     |
+| [03-Release-Versioning.md](01-product/03-Release-Versioning.md)                                 | 版本与 tag 策略（REF-409）         |
+| [04-three-platform-interaction-spec.md](01-product/04-three-platform-interaction-spec.md)       | 三端 IA、旅程、交互差异（REF-601） |
 
 ---
 
-## 03-business-design（业务）
+## 02-system-design（技术 · 活跃文档）
 
-| 文档                                      | 关注内容                                          |
-| ----------------------------------------- | ------------------------------------------------- |
-| [README.md](03-business-design/README.md) | 业务设计目录说明；原草稿已移除，将依据 PRS 重写。 |
+以下为主目录**现行**技术文档；读架构请从 **00 → 15**，再按需深入。
+
+| 文档                                                                                                | 职责                                                 |
+| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| [00-System-Design.md](02-system-design/00-System-Design.md)                                         | 整体架构、模块、数据流                               |
+| [01-Three-Platform-Capability-Sharing.md](02-system-design/01-Three-Platform-Capability-Sharing.md) | 跨端资源共享与图片处理契约（文内部分 M2 段落为历史） |
+| [02-Three-Platform-Design.md](02-system-design/02-Three-Platform-Design.md)                         | Capacitor 路线与三端复用（§二 RN 为历史背景）        |
+| [03-Performance.md](02-system-design/03-Performance.md)                                             | 性能与虚拟化（REF-603 规划）                         |
+| [04-Plugin-System.md](02-system-design/04-Plugin-System.md)                                         | 存储插件契约、开发指南、M3 回归                      |
+| [05-TypeScript-JavaScript-Policy.md](02-system-design/05-TypeScript-JavaScript-Policy.md)           | TS/JS 策略（REF-410）                                |
+| [10-local-workspace-sync.md](02-system-design/10-local-workspace-sync.md)                           | 本地工作区 + 同步（REF-607）                         |
+| [15-apps-pixuli-engineering.md](02-system-design/15-apps-pixuli-engineering.md)                     | **三端工程 SSOT**：目录、脚本、构建、Capacitor       |
+
+### 已归档快照（勿作现产品验收）
+
+REF 已交付的 PoC / 矩阵 / Host 集成等仍保留原路径（便于 Issue 互链），文首已标
+**📦 已归档**。索引见 **[archive/design/README.md](archive/design/README.md)**：
+
+`06` Host 集成 · `07` Capacitor PoC · `09` 代码共享矩阵 · `11` Mobile 对齐矩阵 ·
+`12` RN UI 评估 · `13` 原生插件 · `14` 真机冒烟
 
 ---
 
-## 文档间关系
+## 其他
 
-- **01-product** 定需求与验收；**02-system-design**
-  定技术；**03-business-design** 定业务流程（暂缓，见该目录 README）。
-- **[backlog.md](backlog.md)**
-  承接已移除、不做与延后项；勿按归档文档验收现产品。
-- 遇 `packages/common`、幻灯片、官方 Server 主路径等表述，以 PRD +
-  backlog 为准；系统设计文中若未标注「历史」则可能仍在迁移 REF-407 中。
+| 路径                                       | 说明                                |
+| ------------------------------------------ | ----------------------------------- |
+| [backlog.md](backlog.md)                   | 已移除 / Won't Do / 延后（REF-402） |
+| [03-business-design/](03-business-design/) | 业务设计暂缓，见该目录 README       |
+| [archive/design/](archive/design/)         | 系统设计归档索引                    |
+
+---
+
+## 文档分工
+
+| 层级                 | 写什么                       | 不写什么              |
+| -------------------- | ---------------------------- | --------------------- |
+| **01-product**       | 做什么、怎么验收、用户怎么用 | 实现细节、REF 进度表  |
+| **02-system-design** | 怎么做、API/架构             | 重复 REF 已完成矩阵   |
+| **REFACTOR_PLAN**    | 进行中 Issue、优先级         | 长篇设计正文          |
+| **Wiki**             | 终端用户发布面               | 与 PRS 矛盾的过时能力 |
 
 ---
 
 ## AI 编程辅助（REF-414）
 
-面向 **Cursor / Copilot 等 AI 助手**与协作者，与用户向 `docs/`、Wiki
-**职责分离**：
+| 资产          | 路径                      |
+| ------------- | ------------------------- |
+| Agent 总览    | [AGENTS.md](../AGENTS.md) |
+| Cursor Rules  | `.cursor/rules/`          |
+| Cursor Skills | `.cursor/skills/`         |
 
-| 资产          | 路径                        | 何时更新                                              |
-| ------------- | --------------------------- | ----------------------------------------------------- |
-| Agent 总览    | [AGENTS.md](../AGENTS.md)   | 三端底线、包结构、PR 流程、Skill 清单                 |
-| Cursor Rules  | `.cursor/rules/*.mdc`       | monorepo / storage-plugin / electron-desktop 边界变更 |
-| Cursor Skills | `.cursor/skills/*/SKILL.md` | 新增 provider、Host 集成模式、REF 工作流变化          |
-
-**不必**随每个功能 PR 改 Agent 文件；架构里程碑（M1～M4 合并）或插件 Host 契约变更时再同步。详见
-[AGENTS.md §何时更新](../AGENTS.md#何时更新-agentskill)。
+架构边界变更时再更新 Agent/Skill；详见 [AGENTS.md](../AGENTS.md)。
 
 ---
 
 ## 修订
 
-| 日期       | 变更                                                                                 |
-| ---------- | ------------------------------------------------------------------------------------ |
-| 2026-06-06 | 01-product 合并为 `01-Product-Requirements-Specification` + `02-Product-User-Manual` |
-| 2026-05-27 | 03-business-design 移除早期草稿，暂缓依 PRS 重写                                     |
-| 2026-06-06 | REF-407：角色索引、架构摘要                                                          |
-| 2026-05-27 | REF-401/402：PRD v2.0、backlog 索引                                                  |
-| 2026-05-27 | REF-409：`03-Release-Versioning.md` 版本发布策略与历史盘点                           |
-| 2026-05-27 | REF-414：`AGENTS.md`、`.cursor/rules/`、`.cursor/skills/` AI 编程辅助资产            |
+| 日期       | 变更                                                                                           |
+| ---------- | ---------------------------------------------------------------------------------------------- |
+| 2026-06-17 | **P0 文档整理**：精简角色路径；`06`～`14` 标归档；新增 [archive/design/](archive/design/) 索引 |
+| 2026-06-06 | REF-407：角色索引、架构摘要                                                                    |
+| 2026-06-06 | 01-product 合并 PRS + 用户手册                                                                 |
+| 2026-05-27 | REF-401/402/409/414 等初版索引                                                                 |

--- a/docs/archive/design/README.md
+++ b/docs/archive/design/README.md
@@ -1,0 +1,33 @@
+# 系统设计文档归档（REF 交付快照）
+
+> **归档日期**：2026-06-17 ·
+> **维护策略**：只读；Issue 关闭后的盘点/PoC/矩阵迁入此处索引，**勿按本文验收现产品**。
+
+本目录索引仍位于 `docs/02-system-design/`
+下的历史文稿（未物理搬迁，避免破坏 Issue/PR 链接）。文首已加 **📦 已归档**
+标记。
+
+---
+
+## 归档清单
+
+| 文档                                                                                                        | REF / Issue             | 归档原因                                                | 当前请读                                                                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------- | ----------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [06-Plugin-Host-Integration.md](../../02-system-design/06-Plugin-Host-Integration.md)                       | REF-411（旧 Host 集成） | Gitee Host 已移除；REF-411 已改为 Obsidian 式插件重设计 | [REFACTOR_PLAN §1.6](../../../REFACTOR_PLAN.md#16-ref-411--插件体系重设计obsidian-参考) · [04-Plugin-System](../../02-system-design/04-Plugin-System.md) |
+| [07-capacitor-android-poc.md](../../02-system-design/07-capacitor-android-poc.md)                           | REF-509 #118            | PoC ✅；工程约定已收敛                                  | [15-apps-pixuli-engineering.md](../../02-system-design/15-apps-pixuli-engineering.md)                                                                    |
+| [09-cross-platform-sharing-matrix.md](../../02-system-design/09-cross-platform-sharing-matrix.md)           | REF-506 #116            | 代码级矩阵快照（2026-05-27）                            | [15-apps-pixuli-engineering.md](../../02-system-design/15-apps-pixuli-engineering.md) · [00-System-Design](../../02-system-design/00-System-Design.md)   |
+| [11-mobile-feature-parity-matrix.md](../../02-system-design/11-mobile-feature-parity-matrix.md)             | REF-516 P0 #164         | 旅程对齐矩阵 ✅                                         | [04-three-platform-interaction-spec.md](../../01-product/04-three-platform-interaction-spec.md)                                                          |
+| [12-ui-native-migration-assessment.md](../../02-system-design/12-ui-native-migration-assessment.md)         | REF-508 #119            | RN UI 迁入评估 ✅；RN 已归档                            | [15-apps-pixuli-engineering.md](../../02-system-design/15-apps-pixuli-engineering.md)                                                                    |
+| [13-capacitor-native-plugins.md](../../02-system-design/13-capacitor-native-plugins.md)                     | REF-510 #120            | L3 插件选型 ✅                                          | [15-apps-pixuli-engineering.md](../../02-system-design/15-apps-pixuli-engineering.md)                                                                    |
+| [14-capacitor-android-smoke-acceptance.md](../../02-system-design/14-capacitor-android-smoke-acceptance.md) | REF-516 P6 #166         | 真机冒烟签收 ✅                                         | [15-apps-pixuli-engineering.md](../../02-system-design/15-apps-pixuli-engineering.md)                                                                    |
+
+---
+
+## 与活跃文档的关系
+
+- **产品交互 SSOT**：[04-three-platform-interaction-spec.md](../../01-product/04-three-platform-interaction-spec.md)
+- **工程与三端基线 SSOT**：[15-apps-pixuli-engineering.md](../../02-system-design/15-apps-pixuli-engineering.md)
+- **架构总览**：[00-System-Design.md](../../02-system-design/00-System-Design.md)
+- **进行中 Issue**：[REFACTOR_PLAN.md](../../../REFACTOR_PLAN.md)
+
+P1 可选：将上表文件物理迁入 `docs/archive/design/` 并留 stub 重定向。


### PR DESCRIPTION
## Summary

- 重写 `docs/README.md`：按角色阅读路径、活跃 vs 归档文档分区、指向工程/产品 SSOT
- 新增 `docs/archive/design/README.md`：7 篇 REF 交付快照的归档索引与替代阅读链接
- 为 `06`/`07`/`09`/`11`/`12`/`13`/`14` 文首加 **📦 已归档** 横幅（保留原路径以兼容 Issue 链接）
- 修正 `00-System-Design.md`：Mobile → Capacitor + `apps/pixuli`、技术栈（Canvas 非 WASM）、仓库结构、服务端非官方表述

## Test plan

- [ ] 打开 `docs/README.md`，确认角色路径与归档链接可跳转
- [ ] 打开 `docs/archive/design/README.md`，确认 7 篇归档文档链接有效
- [ ] 抽查 `06`/`11`/`14` 文首归档横幅与「当前请读」链接
- [ ] 阅读 `00-System-Design.md` §6.1 / §10.1，确认无 Expo RN / `apps/mobile` 主路径表述

## 范围说明

本 PR 仅含文档 P0（索引 + 归档标记 + 过时表述）。根目录 README/CHANGELOG/CONTRIBUTING 中文化与 `REFACTOR_PLAN` 精简留待后续 PR。


Made with [Cursor](https://cursor.com)