### PR TITLE
feat(ui): 将资源类型筛选收进过滤器并去掉 banner 标题

### DIFF
--- a/app/src/features/library/AssetLibrary.css
+++ b/app/src/features/library/AssetLibrary.css
@@ -25,13 +25,6 @@
   flex-shrink: 0;
 }
 
-.asset-library-title-row {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  min-width: 0;
-}
-
 .asset-library-loading-indicator {
   display: inline-flex;
   align-items: center;
@@ -51,12 +44,6 @@
   flex-shrink: 0;
 }
 
-.asset-library-title {
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: #111827;
-}
-
 .asset-library-count {
   font-size: 0.875rem;
   color: #6b7280;
@@ -65,30 +52,6 @@
 .asset-library-filter-count {
   margin-left: 0.5rem;
   color: #3b82f6;
-}
-
-.asset-library-kind-chips {
-  display: flex;
-  flex-shrink: 0;
-  gap: 0.375rem;
-}
-
-.asset-library-kind-chip {
-  min-height: 2.25rem;
-  padding: 0.25rem 0.75rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 999px;
-  background: #fff;
-  color: #4b5563;
-  font-size: 0.8125rem;
-  cursor: pointer;
-}
-
-.asset-library-kind-chip--active {
-  border-color: #93c5fd;
-  background: #eff6ff;
-  color: #1d4ed8;
-  font-weight: 600;
 }
 
 .asset-library-chrome-btn {
@@ -335,11 +298,6 @@
     border-bottom: 1px solid #f3f4f6;
   }
 
-  .asset-library-kind-chips {
-    order: 1;
-    flex: 1 1 auto;
-  }
-
   .asset-library-folders-btn {
     display: inline-flex;
   }
@@ -348,17 +306,13 @@
     display: none;
   }
 
-  .asset-library-title {
-    font-size: 1rem;
-  }
-
   .asset-library-count {
     font-size: 0.8125rem;
     white-space: nowrap;
   }
 
   .asset-library-search {
-    order: 2;
+    order: 1;
     flex: 1 1 auto;
     min-width: 0;
     max-width: none;
@@ -369,7 +323,7 @@
   }
 
   .asset-library-controls {
-    order: 3;
+    order: 2;
     margin-left: 0;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;

--- a/app/src/features/library/AssetLibrary.tsx
+++ b/app/src/features/library/AssetLibrary.tsx
@@ -8,11 +8,7 @@ import {
 } from '@/ui';
 import type { LibrarySearchConfig } from '@/ui';
 import type { NativeImagePickers } from '@/ui/image/image-upload/common/nativePickers';
-import {
-  filterAssetsByKind,
-  getAssetKind,
-  type AssetKindFilter,
-} from '@/utils/assetKind';
+import { filterAssetsByKinds, getAssetKind } from '@/utils/assetKind';
 import type {
   BatchUploadProgress,
   ImageItem,
@@ -54,13 +50,6 @@ interface AssetLibraryProps {
   selectedFileId?: string | null;
   onSelectedFileChange?: (file: ImageItem | null) => void;
 }
-
-const KIND_CHIPS: Array<[AssetKindFilter, string]> = [
-  ['image', 'image.kind.image'],
-  ['video', 'image.kind.video'],
-  ['pdf', 'image.kind.pdf'],
-  ['all', 'image.kind.all'],
-];
 
 function kindLabel(item: ImageItem, t: (key: string) => string): string {
   const kind = getAssetKind(item);
@@ -105,7 +94,6 @@ export const AssetLibrary: React.FC<AssetLibraryProps> = ({
   selectedFileId = null,
   onSelectedFileChange,
 }) => {
-  const [assetKind, setAssetKind] = useState<AssetKindFilter>('image');
   const [sortField, setSortField] = useState<SortField>('name');
   const [sortOrder, setSortOrder] = useState<SortOrder>('asc');
 
@@ -123,7 +111,10 @@ export const AssetLibrary: React.FC<AssetLibraryProps> = ({
   }, [images, search?.filters]);
 
   const files = useMemo(() => {
-    const byKind = filterAssetsByKind(filteredImages, assetKind);
+    const byKind = filterAssetsByKinds(
+      filteredImages,
+      search?.filters.selectedKinds ?? [],
+    );
     const unique = new Map<string, ImageItem>();
     for (const item of byKind) {
       const existing = unique.get(item.id);
@@ -136,7 +127,7 @@ export const AssetLibrary: React.FC<AssetLibraryProps> = ({
       }
     }
     return getSortedImages([...unique.values()], sortField, sortOrder);
-  }, [filteredImages, assetKind, sortField, sortOrder]);
+  }, [filteredImages, search?.filters.selectedKinds, sortField, sortOrder]);
 
   const selectedIndex = useMemo(
     () =>
@@ -233,49 +224,28 @@ export const AssetLibrary: React.FC<AssetLibraryProps> = ({
 
       <div className="asset-library-toolbar">
         <div className="asset-library-header">
-          <div className="asset-library-title-row">
-            <h2 className="asset-library-title">{t('image.libraryTitle')}</h2>
-            {loading ? (
-              <span className="asset-library-loading-indicator">
-                <span
-                  className="asset-library-loading-spinner-inline"
-                  aria-hidden
-                />
-                <span>{t('image.library.loading')}</span>
-              </span>
-            ) : null}
-          </div>
-          <span className="asset-library-count">
-            {t('image.library.fileCount').replace(
-              '{count}',
-              String(files.length),
-            )}
-            {search && files.length !== images.length ? (
-              <span className="asset-library-filter-count">
-                {' '}
-                / {images.length}
-              </span>
-            ) : null}
-          </span>
-        </div>
-
-        <div
-          className="asset-library-kind-chips"
-          role="tablist"
-          aria-label={t('image.kind.label')}
-        >
-          {KIND_CHIPS.map(([kind, labelKey]) => (
-            <button
-              key={kind}
-              type="button"
-              role="tab"
-              aria-selected={assetKind === kind}
-              className={`asset-library-kind-chip ${assetKind === kind ? 'asset-library-kind-chip--active' : ''}`}
-              onClick={() => setAssetKind(kind)}
-            >
-              {t(labelKey)}
-            </button>
-          ))}
+          {loading ? (
+            <span className="asset-library-loading-indicator">
+              <span
+                className="asset-library-loading-spinner-inline"
+                aria-hidden
+              />
+              <span>{t('image.library.loading')}</span>
+            </span>
+          ) : (
+            <span className="asset-library-count">
+              {t('image.library.fileCount').replace(
+                '{count}',
+                String(files.length),
+              )}
+              {search && files.length !== images.length ? (
+                <span className="asset-library-filter-count">
+                  {' '}
+                  / {images.length}
+                </span>
+              ) : null}
+            </span>
+          )}
         </div>
 
         {search ? (

--- a/app/src/ui/image/image-browser/common/types.ts
+++ b/app/src/ui/image/image-browser/common/types.ts
@@ -1,4 +1,5 @@
 export type {
+  AssetKind,
   FilterOptions,
   SortField,
   SortOrder,

--- a/app/src/ui/image/image-browser/web/index.ts
+++ b/app/src/ui/image/image-browser/web/index.ts
@@ -1,4 +1,5 @@
 export type {
+  AssetKind,
   FilterOptions,
   SortField,
   SortOrder,

--- a/app/src/ui/primitives/search/web/Search.test.tsx
+++ b/app/src/ui/primitives/search/web/Search.test.tsx
@@ -19,6 +19,10 @@ vi.mock('@/ui/locales', () => ({
       'search.image.clearFilters': '清除筛选',
       'image.filter.imageType': '图片类型',
       'image.filter.tags': '标签',
+      'image.kind.label': '资源类型',
+      'image.kind.image': '图片',
+      'image.kind.video': '视频',
+      'image.kind.pdf': 'PDF',
     };
     return translations[key] || key;
   },
@@ -171,6 +175,10 @@ describe('Search', () => {
       ) as HTMLButtonElement;
       fireEvent.click(filterButton);
 
+      expect(screen.getByText('资源类型')).toBeInTheDocument();
+      expect(screen.getByText('图片')).toBeInTheDocument();
+      expect(screen.getByText('视频')).toBeInTheDocument();
+      expect(screen.getByText('PDF')).toBeInTheDocument();
       expect(screen.getByText('image/jpeg')).toBeInTheDocument();
       expect(screen.getByText('image/png')).toBeInTheDocument();
     });
@@ -210,10 +218,8 @@ describe('Search', () => {
       ) as HTMLButtonElement;
       fireEvent.click(filterButton);
 
-      const jpegCheckbox = screen.getByLabelText(
-        'image/jpeg',
-      ) as HTMLInputElement;
-      fireEvent.click(jpegCheckbox);
+      const imageKind = screen.getByLabelText('图片') as HTMLInputElement;
+      fireEvent.click(imageKind);
 
       expect(onFiltersChange).toHaveBeenCalled();
     });
@@ -293,6 +299,7 @@ describe('Search', () => {
         expect.objectContaining({
           selectedTypes: [],
           selectedTags: [],
+          selectedKinds: [],
         }),
       );
     });

--- a/app/src/ui/primitives/search/web/Search.tsx
+++ b/app/src/ui/primitives/search/web/Search.tsx
@@ -8,7 +8,10 @@ import React, {
 } from 'react';
 import { defaultTranslate } from '@/ui/locales';
 import type { ImageItem } from '@pixuli/core/types';
-import type { FilterOptions } from '../../../image/image-browser/common/types';
+import type {
+  AssetKind,
+  FilterOptions,
+} from '../../../image/image-browser/common/types';
 import SearchBar from './SearchBar';
 import './SearchBar.css';
 import './Search.css';
@@ -114,6 +117,24 @@ const Search: React.FC<SearchProps> = ({
     return Array.from(tags).sort();
   }, [images]);
 
+  // 处理资源类型筛选
+  const handleKindChange = useCallback(
+    (kind: AssetKind, isSelected: boolean) => {
+      if (!onFiltersChange) return;
+      onFiltersChange((prev: FilterOptions) => {
+        const current = prev.selectedKinds ?? [];
+        const selectedKinds = isSelected
+          ? [...current, kind]
+          : current.filter(item => item !== kind);
+        return {
+          ...prev,
+          selectedKinds,
+        };
+      });
+    },
+    [onFiltersChange],
+  );
+
   // 处理类型筛选变化
   const handleTypeChange = useCallback(
     (type: string, isSelected: boolean) => {
@@ -155,6 +176,7 @@ const Search: React.FC<SearchProps> = ({
       ...externalFilters,
       selectedTypes: [],
       selectedTags: [],
+      selectedKinds: [],
     });
   }, [onFiltersChange, externalFilters]);
 
@@ -215,10 +237,12 @@ const Search: React.FC<SearchProps> = ({
   }, [showFilterPanel]);
 
   // 检查是否有活动的筛选条件
+  const selectedKinds = externalFilters?.selectedKinds ?? [];
   const hasActiveFilters =
     externalFilters &&
     (externalFilters.selectedTypes.length > 0 ||
-      externalFilters.selectedTags.length > 0);
+      externalFilters.selectedTags.length > 0 ||
+      selectedKinds.length > 0);
 
   // 获取占位符文本
   const getPlaceholder = () => {
@@ -299,6 +323,31 @@ const Search: React.FC<SearchProps> = ({
                         {translate('search.header.clearFilters') || '清除'}
                       </button>
                     )}
+                  </div>
+                  <div className="search-filter-section">
+                    <label className="search-filter-label">
+                      {translate('image.kind.label')}
+                    </label>
+                    <div className="search-filter-options">
+                      {(
+                        [
+                          ['image', 'image.kind.image'],
+                          ['video', 'image.kind.video'],
+                          ['pdf', 'image.kind.pdf'],
+                        ] as const
+                      ).map(([kind, labelKey]) => (
+                        <label key={kind} className="search-filter-option">
+                          <input
+                            type="checkbox"
+                            checked={selectedKinds.includes(kind)}
+                            onChange={e =>
+                              handleKindChange(kind, e.target.checked)
+                            }
+                          />
+                          <span>{translate(labelKey)}</span>
+                        </label>
+                      ))}
+                    </div>
                   </div>
                   {availableTypes.length > 0 && (
                     <div className="search-filter-section">

--- a/app/src/utils/__tests__/assetKind.test.ts
+++ b/app/src/utils/__tests__/assetKind.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { filterAssetsByKind, getAssetKind } from '../assetKind';
+import {
+  filterAssetsByKind,
+  filterAssetsByKinds,
+  getAssetKind,
+} from '../assetKind';
 
 describe('getAssetKind', () => {
   it('classifies pdf by mime or extension', () => {
@@ -32,12 +36,13 @@ describe('filterAssetsByKind', () => {
     expect(filterAssetsByKind(items, 'all')).toHaveLength(3);
   });
 
-  it('filters by kind', () => {
-    expect(filterAssetsByKind(items, 'pdf').map(i => i.name)).toEqual([
-      'b.pdf',
-    ]);
-    expect(filterAssetsByKind(items, 'video').map(i => i.name)).toEqual([
-      'c.mp4',
-    ]);
+  it('filters by multiple kinds when list is non-empty', () => {
+    expect(
+      filterAssetsByKinds(items, ['pdf', 'video']).map(i => i.name),
+    ).toEqual(['b.pdf', 'c.mp4']);
+  });
+
+  it('returns all when kinds is empty', () => {
+    expect(filterAssetsByKinds(items, [])).toHaveLength(3);
   });
 });

--- a/app/src/utils/assetKind.ts
+++ b/app/src/utils/assetKind.ts
@@ -35,3 +35,12 @@ export function filterAssetsByKind<T extends Pick<ImageItem, 'name' | 'type'>>(
   if (kind === 'all') return items;
   return items.filter(item => getAssetKind(item) === kind);
 }
+
+export function filterAssetsByKinds<T extends Pick<ImageItem, 'name' | 'type'>>(
+  items: T[],
+  kinds: AssetKind[],
+): T[] {
+  if (kinds.length === 0) return items;
+  const allowed = new Set(kinds);
+  return items.filter(item => allowed.has(getAssetKind(item)));
+}

--- a/packages/core/src/types/image-browser.ts
+++ b/packages/core/src/types/image-browser.ts
@@ -2,10 +2,14 @@
  * 图片浏览/筛选相关共享类型（Web / Mobile）
  */
 
+export type AssetKind = 'image' | 'video' | 'pdf';
+
 export interface FilterOptions {
   searchTerm: string;
   selectedTypes: string[];
   selectedTags: string[];
+  /** 资源类型：空数组表示全部 */
+  selectedKinds?: AssetKind[];
 }
 
 export type SortField = 'createdAt' | 'name' | 'size';

--- a/packages/core/src/utils/__tests__/filterUtils.test.ts
+++ b/packages/core/src/utils/__tests__/filterUtils.test.ts
@@ -72,6 +72,7 @@ describe('filterUtils', () => {
       expect(filters.searchTerm).toBe('');
       expect(filters.selectedTypes).toEqual([]);
       expect(filters.selectedTags).toEqual([]);
+      expect(filters.selectedKinds).toEqual([]);
     });
   });
 });

--- a/packages/core/src/utils/filterUtils.ts
+++ b/packages/core/src/utils/filterUtils.ts
@@ -52,5 +52,6 @@ export function createDefaultFilters(): FilterOptions {
     searchTerm: '',
     selectedTypes: [],
     selectedTags: [],
+    selectedKinds: [],
   };
 }


### PR DESCRIPTION
## Summary
- 图片 / 视频 / PDF 从 banner 按钮改到筛选面板勾选；未勾选显示全部文件
- banner 去掉「资源库」标题，只留数量、搜索筛选和上传

## Test plan
- [ ] 打开资源库：banner 无标题、无类型 chip
- [ ] 打开筛选：可勾选图片 / 视频 / PDF，列表随之变化
- [ ] 清除筛选后恢复全部文件
- [ ] `pnpm test`


Made with [Cursor](https://cursor.com)