### PR TITLE
feat(ui): 左栏/Inspector 可拖宽，并修复点选打开详情

### DIFF
--- a/app/src/constants/panelWidth.ts
+++ b/app/src/constants/panelWidth.ts
@@ -1,0 +1,17 @@
+/** 三栏面板宽度（px）— 与 uiStore / usePanelResize 共用，避免 store 依赖 hook 模块 */
+
+export function clampPanelWidth(
+  value: number,
+  min: number,
+  max: number,
+): number {
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+export const EXPLORER_WIDTH_DEFAULT = 224;
+export const EXPLORER_WIDTH_MIN = 192;
+export const EXPLORER_WIDTH_MAX = 480;
+
+export const INSPECTOR_WIDTH_DEFAULT = 320;
+export const INSPECTOR_WIDTH_MIN = 280;
+export const INSPECTOR_WIDTH_MAX = 480;

--- a/app/src/features/image-content/ImageContent.tsx
+++ b/app/src/features/image-content/ImageContent.tsx
@@ -2,7 +2,13 @@ import { EmptyState } from '@/ui';
 import type { LibrarySearchConfig } from '@/ui';
 import { getImageDimensionsFromUrl } from '@pixuli/core/utils';
 import type { ImageEditData, ImageItem } from '@pixuli/core/types';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { hasPublishableRemoteUrl } from '../access/accessCapabilities';
 import { isAssetPublished } from '../access/accessPolicyStore';
 import { AssetInspector } from '../inspector/AssetInspector';
@@ -100,23 +106,27 @@ export const ImageContent: React.FC<ImageContentProps> = ({
   const setActiveMenu = useUIStore(state => state.setActiveMenu);
 
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  /** 与 selectedIds 同步的实体，避免仅靠 id 反查失败导致 Inspector 空白 */
+  const [selectedItems, setSelectedItems] = useState<ImageItem[]>([]);
   const [sheetOpen, setSheetOpen] = useState(false);
 
   const selectedImages = useMemo(
     () =>
       selectedIds
-        .map(id => images.find(item => item.id === id))
+        .map(
+          id =>
+            selectedItems.find(item => item.id === id) ??
+            images.find(item => item.id === id),
+        )
         .filter((item): item is ImageItem => Boolean(item)),
-    [images, selectedIds],
+    [images, selectedIds, selectedItems],
   );
 
   const selectedImage = selectedImages.length === 1 ? selectedImages[0] : null;
 
-  const showDockedInspector =
-    isWide ||
-    (!isMobile && selectedImages.length > 0 && !workspaceExplorerOpen);
-  const showSheetInspector =
-    isMobile && sheetOpen && selectedImages.length === 1;
+  // 宽屏常驻右栏（空态提示点选）；有选中时中/窄屏也打开 dock；手机用 sheet
+  const showDockedInspector = !isMobile && (isWide || selectedIds.length > 0);
+  const showSheetInspector = isMobile && selectedIds.length > 0;
 
   const errorMessage = useMemo(
     () => (error ? resolveImageErrorMessage(error, t) : null),
@@ -144,9 +154,23 @@ export const ImageContent: React.FC<ImageContentProps> = ({
     [openAccessModal, selectedSourceId, sources],
   );
 
+  const imagesRef = useRef(images);
+  imagesRef.current = images;
+
   const handleSelectedIdsChange = useCallback(
-    (ids: string[]) => {
+    (ids: string[], items?: ImageItem[]) => {
       setSelectedIds(ids);
+      if (items !== undefined) {
+        setSelectedItems(items);
+      } else if (ids.length === 0) {
+        setSelectedItems([]);
+      } else {
+        setSelectedItems(
+          ids
+            .map(id => imagesRef.current.find(item => item.id === id))
+            .filter((item): item is ImageItem => Boolean(item)),
+        );
+      }
       setSheetOpen(ids.length > 0);
       if (ids.length > 0 && !isWide) {
         window.dispatchEvent(new CustomEvent('pixuli:closeFilterPanel'));
@@ -159,38 +183,32 @@ export const ImageContent: React.FC<ImageContentProps> = ({
   const handleCloseInspector = useCallback(() => {
     setSheetOpen(false);
     setSelectedIds([]);
+    setSelectedItems([]);
   }, []);
 
   useEffect(() => {
     if (!workspaceExplorerOpen) return;
-    setSheetOpen(false);
     window.dispatchEvent(new CustomEvent('pixuli:closeFilterPanel'));
   }, [workspaceExplorerOpen]);
 
   useEffect(() => {
     const onOpenFilter = () => {
-      setSheetOpen(false);
       useUIStore.getState().setWorkspaceExplorerOpen(false);
     };
-    const onCloseInspector = () => {
-      setSheetOpen(false);
-    };
-    const onClearSelection = () => {
+    const clearSelection = () => {
       setSheetOpen(false);
       setSelectedIds([]);
+      setSelectedItems([]);
     };
     window.addEventListener('pixuli:openFilterPanel', onOpenFilter);
-    window.addEventListener('pixuli:closeInspectorSheet', onCloseInspector);
-    window.addEventListener('pixuli:clearLibrarySelection', onClearSelection);
+    window.addEventListener('pixuli:closeInspectorSheet', clearSelection);
+    window.addEventListener('pixuli:clearLibrarySelection', clearSelection);
     return () => {
       window.removeEventListener('pixuli:openFilterPanel', onOpenFilter);
-      window.removeEventListener(
-        'pixuli:closeInspectorSheet',
-        onCloseInspector,
-      );
+      window.removeEventListener('pixuli:closeInspectorSheet', clearSelection);
       window.removeEventListener(
         'pixuli:clearLibrarySelection',
-        onClearSelection,
+        clearSelection,
       );
     };
   }, []);
@@ -229,6 +247,11 @@ export const ImageContent: React.FC<ImageContentProps> = ({
 
   const inspector = (
     <AssetInspector
+      key={
+        selectedImages.length >= 2
+          ? `batch:${selectedImages.map(item => item.id).join(',')}`
+          : (selectedImage?.id ?? 'empty')
+      }
       image={selectedImage}
       selectedImages={selectedImages}
       images={images}

--- a/app/src/features/inspector/AssetInspector.css
+++ b/app/src/features/inspector/AssetInspector.css
@@ -24,11 +24,53 @@
 }
 
 .asset-inspector--dock {
+  position: relative;
+  z-index: 1;
   flex-shrink: 0;
   width: 20rem;
-  max-width: 22.5rem;
+  min-width: 17.5rem;
+  max-width: 30rem;
   height: 100%;
   border-left: 1px solid #e5e7eb;
+}
+
+.asset-inspector-resize {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 5;
+  width: 10px;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  cursor: col-resize;
+  touch-action: none;
+  transform: translateX(-50%);
+}
+
+.asset-inspector-resize::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
+  background: transparent;
+  transition: background-color 0.15s ease;
+}
+
+.asset-inspector-resize:hover::after,
+.asset-inspector-resize:focus-visible::after,
+.asset-inspector-resize:active::after {
+  background: var(--pix-violet);
+}
+
+.asset-inspector-resize:focus-visible {
+  outline: none;
 }
 
 .asset-inspector--sheet {
@@ -267,11 +309,5 @@
 @media (max-width: 767px) {
   .asset-inspector-overlay {
     bottom: calc(3.75rem + env(safe-area-inset-bottom, 0px));
-  }
-}
-
-@media (max-width: 1023px) {
-  .asset-inspector--dock {
-    width: 17.5rem;
   }
 }

--- a/app/src/features/inspector/AssetInspector.tsx
+++ b/app/src/features/inspector/AssetInspector.tsx
@@ -33,6 +33,11 @@ import React, {
   useState,
 } from 'react';
 import { useNavigate } from 'react-router-dom';
+import {
+  INSPECTOR_WIDTH_MAX,
+  INSPECTOR_WIDTH_MIN,
+  usePanelResize,
+} from '@/hooks/usePanelResize';
 import './AssetInspector.css';
 
 const INSPECTOR_ACTIONS: ImageActionId[] = [
@@ -164,12 +169,24 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
   const [previewImage, setPreviewImage] = useState<ImageItem | null>(image);
 
   useEffect(() => {
-    setPreviewImage(image);
-  }, [image]);
+    setPreviewImage(
+      image ?? (selectedImages.length === 1 ? selectedImages[0] : null),
+    );
+  }, [image, selectedImages]);
 
   const isSheet = variant === 'sheet';
   const [sheetExpanded, setSheetExpanded] = useState(false);
   const sheetDragRef = useRef<{ y: number; moved: boolean } | null>(null);
+  const inspectorWidth = useUIStore(state => state.inspectorWidth);
+  const setInspectorWidth = useUIStore(state => state.setInspectorWidth);
+
+  const resizeHandlers = usePanelResize({
+    width: inspectorWidth,
+    min: INSPECTOR_WIDTH_MIN,
+    max: INSPECTOR_WIDTH_MAX,
+    edge: 'left',
+    onWidthChange: setInspectorWidth,
+  });
 
   useEffect(() => {
     if (!isSheet) setSheetExpanded(false);
@@ -227,26 +244,31 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
 
   const sourceId = selectedSourceId ?? sources[0]?.id;
   const selectedFolderPath = useUIStore(state => state.selectedFolderPath);
+  /** 单选时以 props.image 为准，缺省则回退 selectedImages[0] */
+  const activeImage =
+    image ?? (selectedImages.length === 1 ? selectedImages[0] : null);
   const published = Boolean(
-    image && sourceId && getPublishedAccess(image.id)?.sourceId === sourceId,
+    activeImage &&
+      sourceId &&
+      getPublishedAccess(activeImage.id)?.sourceId === sourceId,
   );
   const previewIndex = previewImage
     ? images.findIndex(item => item.id === previewImage.id)
     : -1;
 
-  const kind = image ? getAssetKind(image) : 'image';
+  const kind = activeImage ? getAssetKind(activeImage) : 'image';
   const dimensions =
-    image && image.width > 0 && image.height > 0
-      ? `${image.width} × ${image.height}`
+    activeImage && activeImage.width > 0 && activeImage.height > 0
+      ? `${activeImage.width} × ${activeImage.height}`
       : t('image.grid.dimensionsUnknown');
 
   const handleCopy = useCallback(async () => {
-    if (!image) return;
-    if (onCopyRemoteAccess && onCopyRemoteAccess(image) === false) {
+    if (!activeImage) return;
+    if (onCopyRemoteAccess && onCopyRemoteAccess(activeImage) === false) {
       return;
     }
     try {
-      const url = resolveRemoteCopyUrl(image);
+      const url = resolveRemoteCopyUrl(activeImage);
       if (onCopyUrl) {
         await onCopyUrl(url, 'url');
       }
@@ -256,45 +278,45 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
     } catch {
       showError(t('image.grid.copyFailed'));
     }
-  }, [image, onCopyRemoteAccess, onCopyUrl, t]);
+  }, [activeImage, onCopyRemoteAccess, onCopyUrl, t]);
 
   const handleDelete = useCallback(async () => {
-    if (!image || !onDeleteImage) return;
+    if (!activeImage || !onDeleteImage) return;
     if (
       !confirm(
-        `${t('image.grid.confirmDelete')} "${image.name}" ${t('common.confirm')}？`,
+        `${t('image.grid.confirmDelete')} "${activeImage.name}" ${t('common.confirm')}？`,
       )
     ) {
       return;
     }
     const loadingToast = showLoading(
-      `${t('image.grid.deleting')} "${image.name}"...`,
+      `${t('image.grid.deleting')} "${activeImage.name}"...`,
     );
     try {
-      await onDeleteImage(image.id, image.name);
+      await onDeleteImage(activeImage.id, activeImage.name);
       updateLoadingToSuccess(
         String(loadingToast),
-        `${t('image.grid.deleteSuccess')} "${image.name}" ${t('image.grid.deleted')}`,
+        `${t('image.grid.deleteSuccess')} "${activeImage.name}" ${t('image.grid.deleted')}`,
       );
       onClose();
     } catch (error) {
       updateLoadingToError(
         String(loadingToast),
-        `${t('image.grid.deleteFailed')} "${image.name}" ${t('image.grid.failed')}: ${error instanceof Error ? error.message : t('common.unknownError')}`,
+        `${t('image.grid.deleteFailed')} "${activeImage.name}" ${t('image.grid.failed')}: ${error instanceof Error ? error.message : t('common.unknownError')}`,
       );
     }
-  }, [image, onClose, onDeleteImage, t]);
+  }, [activeImage, onClose, onDeleteImage, t]);
 
   const handleShare = useCallback(async () => {
-    if (!image || !onShareImage) return;
+    if (!activeImage || !onShareImage) return;
     try {
-      await onShareImage(image);
+      await onShareImage(activeImage);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'unknown error';
       if (/cancel|abort|dismiss|user/i.test(message)) return;
       showError(`${t('image.grid.shareFailed')}: ${message}`);
     }
-  }, [image, onShareImage, t]);
+  }, [activeImage, onShareImage, t]);
 
   const openTool = useCallback(
     (tool: 'compress' | 'convert') => {
@@ -307,21 +329,21 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
   );
 
   const handlers = useMemo<ImageActionHandlers>(() => {
-    if (!image) return {};
-    const url = resolveRemoteCopyUrl(image);
+    if (!activeImage) return {};
+    const url = resolveRemoteCopyUrl(activeImage);
     const next: ImageActionHandlers = {
       preview: kind === 'image' ? () => setShowPreview(true) : undefined,
       edit: onUpdateImage
         ? () => {
             setShowEdit(true);
-            showInfo(`${t('image.grid.editing')} "${image.name}"`);
+            showInfo(`${t('image.grid.editing')} "${activeImage.name}"`);
           }
         : undefined,
       copyUrl: () => {
         void handleCopy();
       },
       openUrl: () => {
-        window.open(url, '_blank');
+        window.open(url || activeImage.url, '_blank');
       },
       delete: onDeleteImage
         ? () => {
@@ -336,10 +358,10 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
     }
     return next;
   }, [
+    activeImage,
     handleCopy,
     handleDelete,
     handleShare,
-    image,
     kind,
     onDeleteImage,
     onShareImage,
@@ -461,12 +483,12 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
 
   const body =
     batchBody ??
-    (image ? (
+    (activeImage ? (
       <>
         <section className="asset-inspector-section">
           <h3>{t('image.inspector.sectionContent')}</h3>
           <FileContent
-            image={image}
+            image={activeImage}
             onPreview={() => setShowPreview(true)}
             t={t}
           />
@@ -477,7 +499,7 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
           <dl className="asset-inspector-dl">
             <div>
               <dt>{t('image.inspector.name')}</dt>
-              <dd title={image.name}>{image.name}</dd>
+              <dd title={activeImage.name}>{activeImage.name}</dd>
             </div>
             {kind === 'image' ? (
               <div>
@@ -487,25 +509,27 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
             ) : null}
             <div>
               <dt>{t('image.inspector.size')}</dt>
-              <dd>{image.size > 0 ? formatFileSize(image.size) : '—'}</dd>
+              <dd>
+                {activeImage.size > 0 ? formatFileSize(activeImage.size) : '—'}
+              </dd>
             </div>
             <div>
               <dt>{t('image.inspector.date')}</dt>
               <dd>
-                {image.createdAt
-                  ? new Date(image.createdAt).toLocaleString()
+                {activeImage.createdAt
+                  ? new Date(activeImage.createdAt).toLocaleString()
                   : '—'}
               </dd>
             </div>
             <div>
               <dt>{t('image.inspector.folder')}</dt>
-              <dd>{folderLabel(image.localPath)}</dd>
+              <dd>{folderLabel(activeImage.localPath)}</dd>
             </div>
             <div>
               <dt>{t('image.inspector.sync')}</dt>
               <dd>
-                {image.linkKind === 'remote-raw' ||
-                hasPublishableRemoteUrl(image)
+                {activeImage.linkKind === 'remote-raw' ||
+                hasPublishableRemoteUrl(activeImage)
                   ? t('image.inspector.syncRemote')
                   : t('image.inspector.syncLocal')}
               </dd>
@@ -518,16 +542,16 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
                   : t('image.inspector.accessLocalOnly')}
               </dd>
             </div>
-            {image.tags.length > 0 ? (
+            {(activeImage.tags?.length ?? 0) > 0 ? (
               <div>
                 <dt>{t('image.inspector.tags')}</dt>
-                <dd>{image.tags.join('、')}</dd>
+                <dd>{(activeImage.tags ?? []).join('、')}</dd>
               </div>
             ) : null}
-            {image.description ? (
+            {activeImage.description ? (
               <div>
                 <dt>{t('image.inspector.description')}</dt>
-                <dd>{image.description}</dd>
+                <dd>{activeImage.description}</dd>
               </div>
             ) : null}
           </dl>
@@ -546,7 +570,7 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
             <button
               type="button"
               className="asset-inspector-extra-btn"
-              onClick={() => openAccessModal(image.id)}
+              onClick={() => openAccessModal(activeImage.id)}
             >
               <Shield size={16} aria-hidden />
               {t('image.inspector.openAccess')}
@@ -609,8 +633,19 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
   const panel = (
     <aside
       className={`asset-inspector ${isSheet ? 'asset-inspector--sheet' : 'asset-inspector--dock'}${isSheet && sheetExpanded ? ' is-expanded' : ''}`}
+      style={isSheet ? undefined : { width: inspectorWidth }}
       aria-label={t('image.inspector.title')}
     >
+      {!isSheet ? (
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label={t('image.inspector.resize')}
+          tabIndex={0}
+          className="asset-inspector-resize"
+          onPointerDown={resizeHandlers.onPointerDown}
+        />
+      ) : null}
       <header className="asset-inspector-header">
         {isSheet ? (
           <button
@@ -638,18 +673,14 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
                 )
               : t('image.inspector.title')}
           </h2>
-          {isSheet || image || selectedImages.length > 0 ? (
-            <button
-              type="button"
-              className="asset-inspector-close"
-              onClick={onClose}
-              aria-label={t('image.inspector.close')}
-            >
-              <X size={18} />
-            </button>
-          ) : (
-            <span />
-          )}
+          <button
+            type="button"
+            className="asset-inspector-close"
+            onClick={onClose}
+            aria-label={t('image.inspector.close')}
+          >
+            <X size={18} />
+          </button>
         </div>
       </header>
       <div className="asset-inspector-body">{body}</div>
@@ -658,7 +689,7 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
 
   return (
     <>
-      {isSheet && (image || selectedImages.length > 0) ? (
+      {isSheet ? (
         <div className="asset-inspector-overlay">
           <button
             type="button"
@@ -668,13 +699,13 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
           />
           {panel}
         </div>
-      ) : isSheet ? null : (
+      ) : (
         panel
       )}
 
-      {image && onUpdateImage ? (
+      {activeImage && onUpdateImage ? (
         <ImageEditModal
-          image={image}
+          image={activeImage}
           isOpen={showEdit}
           onClose={() => setShowEdit(false)}
           onUpdateImage={onUpdateImage}

--- a/app/src/features/library/AssetLibrary.tsx
+++ b/app/src/features/library/AssetLibrary.tsx
@@ -70,7 +70,7 @@ interface AssetLibraryProps {
   onRetry?: () => void;
   onOpenFolders?: () => void;
   selectedIds: string[];
-  onSelectedIdsChange: (ids: string[]) => void;
+  onSelectedIdsChange: (ids: string[], items?: ImageItem[]) => void;
   onDeleteImage?: (id: string, name: string) => Promise<void>;
   onDeleteMultipleImages?: (ids: string[], names: string[]) => Promise<void>;
   onSync?: () => void;
@@ -192,10 +192,13 @@ export const AssetLibrary: React.FC<AssetLibraryProps> = ({
   useEffect(() => {
     const next = pruneSelectedIds(selectedIds, visibleIds);
     if (next !== selectedIds) {
-      onSelectedIdsChange(next);
+      const selectedItems = next
+        .map(id => files.find(file => file.id === id))
+        .filter((item): item is ImageItem => Boolean(item));
+      onSelectedIdsChange(next, selectedItems);
       if (next.length <= 1) setMultiMode(false);
     }
-  }, [onSelectedIdsChange, selectedIds, visibleIds]);
+  }, [files, onSelectedIdsChange, selectedIds, visibleIds]);
 
   const applySelection = useCallback(
     (
@@ -215,7 +218,10 @@ export const AssetLibrary: React.FC<AssetLibraryProps> = ({
         multiMode: enterMulti || multiMode,
       });
       anchorIdRef.current = next.anchorId;
-      onSelectedIdsChange(next.selectedIds);
+      const selectedItems = next.selectedIds
+        .map(id => files.find(file => file.id === id))
+        .filter((item): item is ImageItem => Boolean(item));
+      onSelectedIdsChange(next.selectedIds, selectedItems);
       if (next.selectedIds.length <= 1 && !enterMulti && !additive && !range) {
         setMultiMode(false);
       }
@@ -225,7 +231,7 @@ export const AssetLibrary: React.FC<AssetLibraryProps> = ({
           ?.scrollIntoView({ block: 'nearest' });
       });
     },
-    [multiMode, onSelectedIdsChange, selectedIds, visibleIds],
+    [files, multiMode, onSelectedIdsChange, selectedIds, visibleIds],
   );
 
   const selectedIndex = useMemo(() => {

--- a/app/src/features/workspace/WorkspaceFolderTree.css
+++ b/app/src/features/workspace/WorkspaceFolderTree.css
@@ -1,12 +1,52 @@
 .workspace-explorer {
+  position: relative;
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
   width: 14rem;
   min-width: 12rem;
-  max-width: 18rem;
+  max-width: 30rem;
   border-right: 1px solid #e5e7eb;
   background: #fff;
+}
+
+.workspace-explorer-resize {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 5;
+  width: 10px;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  cursor: col-resize;
+  touch-action: none;
+  transform: translateX(50%);
+}
+
+.workspace-explorer-resize::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
+  background: transparent;
+  transition: background-color 0.15s ease;
+}
+
+.workspace-explorer-resize:hover::after,
+.workspace-explorer-resize:focus-visible::after,
+.workspace-explorer-resize:active::after {
+  background: var(--pix-violet);
+}
+
+.workspace-explorer-resize:focus-visible {
+  outline: none;
 }
 
 .workspace-explorer-header {

--- a/app/src/features/workspace/WorkspaceFolderTree.tsx
+++ b/app/src/features/workspace/WorkspaceFolderTree.tsx
@@ -1,6 +1,11 @@
 import { ChevronDown, ChevronRight, Folder, FolderOpen, X } from 'lucide-react';
 import React, { useMemo, useState } from 'react';
 import { useI18n } from '@/i18n/useI18n';
+import {
+  EXPLORER_WIDTH_MAX,
+  EXPLORER_WIDTH_MIN,
+  usePanelResize,
+} from '@/hooks/usePanelResize';
 import { useImageStore } from '@/stores/imageStore';
 import { useUIStore } from '@/stores/uiStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
@@ -101,10 +106,22 @@ export const WorkspaceFolderTree: React.FC<{ overlay?: boolean }> = ({
   const setWorkspaceExplorerOpen = useUIStore(
     state => state.setWorkspaceExplorerOpen,
   );
+  const explorerWidth = useUIStore(state => state.workspaceExplorerWidth);
+  const setWorkspaceExplorerWidth = useUIStore(
+    state => state.setWorkspaceExplorerWidth,
+  );
   const openWorkspaceModal = useUIStore(state => state.openWorkspaceModal);
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(
     () => new Set(['__root__', 'images']),
   );
+
+  const resizeHandlers = usePanelResize({
+    width: explorerWidth,
+    min: EXPLORER_WIDTH_MIN,
+    max: EXPLORER_WIDTH_MAX,
+    edge: 'right',
+    onWidthChange: setWorkspaceExplorerWidth,
+  });
 
   const tree = useMemo(() => {
     const paths = images
@@ -135,6 +152,7 @@ export const WorkspaceFolderTree: React.FC<{ overlay?: boolean }> = ({
   return (
     <aside
       className={`workspace-explorer ${overlay ? 'workspace-explorer--overlay' : ''}`}
+      style={overlay ? undefined : { width: explorerWidth }}
       aria-modal={overlay || undefined}
     >
       <div className="workspace-explorer-header">
@@ -179,6 +197,17 @@ export const WorkspaceFolderTree: React.FC<{ overlay?: boolean }> = ({
           {t('workspace.manageExplorer')}
         </button>
       </div>
+
+      {!overlay ? (
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label={t('workspace.resizeExplorer')}
+          tabIndex={0}
+          className="workspace-explorer-resize"
+          onPointerDown={resizeHandlers.onPointerDown}
+        />
+      ) : null}
     </aside>
   );
 };

--- a/app/src/hooks/__tests__/usePanelResize.test.ts
+++ b/app/src/hooks/__tests__/usePanelResize.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EXPLORER_WIDTH_MAX,
+  EXPLORER_WIDTH_MIN,
+  clampPanelWidth,
+} from '../usePanelResize';
+
+describe('clampPanelWidth', () => {
+  it('clamps to min and max', () => {
+    expect(clampPanelWidth(100, EXPLORER_WIDTH_MIN, EXPLORER_WIDTH_MAX)).toBe(
+      EXPLORER_WIDTH_MIN,
+    );
+    expect(clampPanelWidth(999, EXPLORER_WIDTH_MIN, EXPLORER_WIDTH_MAX)).toBe(
+      EXPLORER_WIDTH_MAX,
+    );
+    expect(clampPanelWidth(250.6, EXPLORER_WIDTH_MIN, EXPLORER_WIDTH_MAX)).toBe(
+      251,
+    );
+  });
+});

--- a/app/src/hooks/usePanelResize.ts
+++ b/app/src/hooks/usePanelResize.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useRef } from 'react';
+import {
+  clampPanelWidth,
+  EXPLORER_WIDTH_DEFAULT,
+  EXPLORER_WIDTH_MAX,
+  EXPLORER_WIDTH_MIN,
+  INSPECTOR_WIDTH_DEFAULT,
+  INSPECTOR_WIDTH_MAX,
+  INSPECTOR_WIDTH_MIN,
+} from '@/constants/panelWidth';
+
+export {
+  clampPanelWidth,
+  EXPLORER_WIDTH_DEFAULT,
+  EXPLORER_WIDTH_MAX,
+  EXPLORER_WIDTH_MIN,
+  INSPECTOR_WIDTH_DEFAULT,
+  INSPECTOR_WIDTH_MAX,
+  INSPECTOR_WIDTH_MIN,
+};
+
+interface UsePanelResizeOptions {
+  width: number;
+  min: number;
+  max: number;
+  /** 拖动右缘向右增大；拖动左缘向左增大 */
+  edge: 'left' | 'right';
+  onWidthChange: (width: number) => void;
+}
+
+/**
+ * 水平面板拖拽改宽：在 pointerdown 后挂到 window，避免手柄过窄丢事件。
+ */
+export function usePanelResize({
+  width,
+  min,
+  max,
+  edge,
+  onWidthChange,
+}: UsePanelResizeOptions) {
+  const widthRef = useRef(width);
+  const edgeRef = useRef(edge);
+  const minRef = useRef(min);
+  const maxRef = useRef(max);
+  const onWidthChangeRef = useRef(onWidthChange);
+
+  useEffect(() => {
+    widthRef.current = width;
+  }, [width]);
+  useEffect(() => {
+    edgeRef.current = edge;
+  }, [edge]);
+  useEffect(() => {
+    minRef.current = min;
+    maxRef.current = max;
+  }, [min, max]);
+  useEffect(() => {
+    onWidthChangeRef.current = onWidthChange;
+  }, [onWidthChange]);
+
+  const onPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      event.stopPropagation();
+
+      const startX = event.clientX;
+      const startWidth = widthRef.current;
+      const pointerId = event.pointerId;
+
+      const onMove = (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerId) return;
+        const delta = ev.clientX - startX;
+        const next =
+          edgeRef.current === 'right' ? startWidth + delta : startWidth - delta;
+        onWidthChangeRef.current(
+          clampPanelWidth(next, minRef.current, maxRef.current),
+        );
+      };
+
+      const onUp = (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerId) return;
+        window.removeEventListener('pointermove', onMove);
+        window.removeEventListener('pointerup', onUp);
+        window.removeEventListener('pointercancel', onUp);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+      };
+
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+      window.addEventListener('pointermove', onMove);
+      window.addEventListener('pointerup', onUp);
+      window.addEventListener('pointercancel', onUp);
+    },
+    [],
+  );
+
+  return { onPointerDown };
+}

--- a/app/src/i18n/locales/en-US.json
+++ b/app/src/i18n/locales/en-US.json
@@ -143,7 +143,8 @@
     "activityBar": "Main menu",
     "allImages": "All images",
     "manageExplorer": "Manage workspace…",
-    "closeExplorer": "Close folder panel"
+    "closeExplorer": "Close folder panel",
+    "resizeExplorer": "Drag to resize explorer"
   },
   "access": {
     "title": "Access",

--- a/app/src/i18n/locales/zh-CN.json
+++ b/app/src/i18n/locales/zh-CN.json
@@ -143,7 +143,8 @@
     "activityBar": "主菜单",
     "allImages": "全部图片",
     "manageExplorer": "管理工作区…",
-    "closeExplorer": "关闭文件夹面板"
+    "closeExplorer": "关闭文件夹面板",
+    "resizeExplorer": "拖拽调整资源浏览器宽度"
   },
   "access": {
     "title": "访问",

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,8 +1,8 @@
+@import './ui/brand/pix-ui.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import './ui/brand/pix-ui.css';
 
 :root {
   --pix-violet: #7c6cf0;

--- a/app/src/stores/uiStore.ts
+++ b/app/src/stores/uiStore.ts
@@ -11,6 +11,15 @@ import type { GiteeConfig, GitHubConfig } from '@pixuli/core/types';
 import { create } from 'zustand';
 import type { ConnectionPurpose } from '@/features/source-type/connectionPurpose';
 import type { SettingsSection } from '@/features/settings/settingsTypes';
+import {
+  EXPLORER_WIDTH_DEFAULT,
+  EXPLORER_WIDTH_MAX,
+  EXPLORER_WIDTH_MIN,
+  INSPECTOR_WIDTH_DEFAULT,
+  INSPECTOR_WIDTH_MAX,
+  INSPECTOR_WIDTH_MIN,
+  clampPanelWidth,
+} from '../constants/panelWidth';
 import { isStoragePluginRegistered } from '../storage/registry';
 import { useImageStore } from './imageStore';
 import { useSourceStore } from './sourceStore';
@@ -59,6 +68,12 @@ interface UIState {
   selectedFolderPath: string;
   /** 窄屏是否展开文件夹面板 */
   workspaceExplorerOpen: boolean;
+  /** 宽屏资源浏览器宽度（px） */
+  workspaceExplorerWidth: number;
+  /** 宽屏 Inspector 宽度（px） */
+  inspectorWidth: number;
+  /** 宽屏/中屏 dock Inspector 是否折叠 */
+  inspectorCollapsed: boolean;
 
   // Actions - 模态框
   setShowConfigModal: (show: boolean) => void;
@@ -84,6 +99,9 @@ interface UIState {
   setSelectedFolderPath: (path: string) => void;
   setWorkspaceExplorerOpen: (open: boolean) => void;
   toggleWorkspaceExplorer: () => void;
+  setWorkspaceExplorerWidth: (width: number) => void;
+  setInspectorWidth: (width: number) => void;
+  setInspectorCollapsed: (collapsed: boolean) => void;
 
   // Actions - 模态框
   setShowWorkspaceModal: (show: boolean) => void;
@@ -141,6 +159,9 @@ export const useUIStore = create<UIState>(set => ({
   currentUtilityTool: null,
   selectedFolderPath: '',
   workspaceExplorerOpen: false,
+  workspaceExplorerWidth: EXPLORER_WIDTH_DEFAULT,
+  inspectorWidth: INSPECTOR_WIDTH_DEFAULT,
+  inspectorCollapsed: false,
   showWorkspaceModal: false,
   accessTargetImageId: null,
   accessTargetImageIds: [],
@@ -172,6 +193,24 @@ export const useUIStore = create<UIState>(set => ({
     set({ workspaceExplorerOpen: open }),
   toggleWorkspaceExplorer: () =>
     set(state => ({ workspaceExplorerOpen: !state.workspaceExplorerOpen })),
+  setWorkspaceExplorerWidth: (width: number) =>
+    set({
+      workspaceExplorerWidth: clampPanelWidth(
+        width,
+        EXPLORER_WIDTH_MIN,
+        EXPLORER_WIDTH_MAX,
+      ),
+    }),
+  setInspectorWidth: (width: number) =>
+    set({
+      inspectorWidth: clampPanelWidth(
+        width,
+        INSPECTOR_WIDTH_MIN,
+        INSPECTOR_WIDTH_MAX,
+      ),
+    }),
+  setInspectorCollapsed: (collapsed: boolean) =>
+    set({ inspectorCollapsed: collapsed }),
 
   openConfigModalForEdit: (sourceId: string) => {
     const source = useSourceStore.getState().getSourceById(sourceId);

--- a/app/src/ui/image/image-browser/locales/en-US.json
+++ b/app/src/ui/image/image-browser/locales/en-US.json
@@ -52,7 +52,8 @@
       "aiDesktopOnly": "Desktop only",
       "aiReadyHint": "Edit opens so you can add tags and description. Local models are Desktop-only and must be configured first.",
       "expandSheet": "Expand to full screen",
-      "collapseSheet": "Collapse details"
+      "collapseSheet": "Collapse details",
+      "resize": "Drag to resize details panel"
     },
     "filter": {
       "title": "Image Filter",

--- a/app/src/ui/image/image-browser/locales/zh-CN.json
+++ b/app/src/ui/image/image-browser/locales/zh-CN.json
@@ -52,7 +52,8 @@
       "aiDesktopOnly": "仅桌面可用",
       "aiReadyHint": "将打开编辑，便于写入标签与描述。本地模型仅 Desktop 可用，需自行配置。",
       "expandSheet": "上拉全屏",
-      "collapseSheet": "收起详情"
+      "collapseSheet": "收起详情",
+      "resize": "拖拽调整详情栏宽度"
     },
     "filter": {
       "title": "图片筛选",


### PR DESCRIPTION
## Summary
- 宽屏资源浏览器右缘、Inspector 左缘支持拖拽改宽（宽度写入 `uiStore`）
- 点选表格行时同步选中实体到右栏，修复仅靠 id 反查失败导致详情/操作不出现
- 宽屏常驻 Inspector 空态；有选中时中屏打开 dock、窄屏打开 sheet；关闭即清空选中

## Test plan
- [ ] `pnpm test`（含 `usePanelResize` / selection 相关用例）
- [ ] 宽屏：右栏常驻；点表格一行出现预览、信息与操作按钮
- [ ] 拖拽左栏右缘、Inspector 左缘可改宽，刷新后宽度仍在本次会话有效
- [ ] 关闭 Inspector 后再次点选可重新打开
- [ ] 窄屏：点选后底部详情 sheet 出现并可关闭


Made with [Cursor](https://cursor.com)