### PR TITLE
feat(ui): Inspector 操作改为底部紧凑网格

### DIFF
--- a/app/src/features/inspector/AssetInspector.css
+++ b/app/src/features/inspector/AssetInspector.css
@@ -241,42 +241,98 @@
   word-break: break-word;
 }
 
-.asset-inspector-actions {
-  justify-content: flex-start;
+.asset-inspector-actions-footer {
+  flex-shrink: 0;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid #e5e7eb;
+  background: #fff;
 }
 
-.asset-inspector-actions .image-action-menu__labeled-button {
-  min-width: 0;
-  min-height: 2.75rem;
+.asset-inspector-actions-title {
+  margin: 0 0 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6b7280;
 }
 
-.asset-inspector-extra {
+.asset-inspector-actions-block {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  margin-top: 0.75rem;
 }
 
-.asset-inspector-extra-btn {
+.asset-inspector-action-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.375rem;
+}
+
+.asset-inspector-action-btn {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.2rem;
+  min-height: 2.75rem;
+  padding: 0.35rem 0.25rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  background: #f9fafb;
+  color: #374151;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  line-height: 1.15;
+  cursor: pointer;
+  text-align: center;
+}
+
+.asset-inspector-action-btn:hover:not(:disabled) {
+  background: var(--pix-violet-soft, #ede9fe);
+  border-color: var(--pix-lilac, #c4b5fd);
+  color: var(--pix-violet-deep, #5b4fe0);
+}
+
+.asset-inspector-action-btn:focus-visible {
+  outline: 2px solid var(--pix-violet, #7c6cf0);
+  outline-offset: 1px;
+}
+
+.asset-inspector-action-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.asset-inspector-action-btn span {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.asset-inspector-action-danger {
   display: inline-flex;
   min-height: 2.75rem;
   align-items: center;
-  gap: 0.5rem;
+  justify-content: center;
+  gap: 0.375rem;
+  width: 100%;
   padding: 0.5rem 0.75rem;
-  border: 1px solid #d1d5db;
+  border: 1px solid #fecaca;
   border-radius: 0.5rem;
-  background: #fff;
-  color: #374151;
+  background: #fef2f2;
+  color: #b91c1c;
   font-size: 0.8125rem;
+  font-weight: 500;
   cursor: pointer;
-  text-align: left;
 }
 
-.asset-inspector-extra-btn:hover:not(:disabled) {
-  background: #f9fafb;
+.asset-inspector-action-danger:hover:not(:disabled) {
+  background: #fee2e2;
 }
 
-.asset-inspector-extra-btn:disabled {
+.asset-inspector-action-danger:disabled {
   opacity: 0.45;
   cursor: not-allowed;
 }
@@ -294,7 +350,7 @@
 }
 
 .asset-inspector-batch-list {
-  margin: 0 0 1rem;
+  margin: 0 0 0.25rem;
   padding-left: 1.25rem;
   font-size: 0.8125rem;
   color: #374151;
@@ -309,5 +365,24 @@
 @media (max-width: 767px) {
   .asset-inspector-overlay {
     bottom: calc(3.75rem + env(safe-area-inset-bottom, 0px));
+  }
+
+  .asset-inspector-action-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.5rem;
+  }
+
+  .asset-inspector-actions-footer {
+    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
+  }
+
+  .asset-inspector--sheet .asset-inspector-actions-footer {
+    box-shadow: 0 -6px 16px rgba(15, 23, 42, 0.06);
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+  .asset-inspector-action-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }

--- a/app/src/features/inspector/AssetInspector.tsx
+++ b/app/src/features/inspector/AssetInspector.tsx
@@ -7,11 +7,6 @@ import {
   updateLoadingToError,
   updateLoadingToSuccess,
 } from '@/ui/feedback/toast';
-import {
-  ImageActionMenu,
-  type ImageActionHandlers,
-  type ImageActionId,
-} from '@/ui/image/image-actions/web';
 import ImageEditModal from '@/ui/image/image-browser/web/ImageEditModal';
 import { ImagePreviewModal } from '@/ui/image/image-preview-modal/web';
 import { hasPublishableRemoteUrl } from '@/features/access/accessCapabilities';
@@ -24,7 +19,20 @@ import type { ImageEditData, ImageItem } from '@pixuli/core/types';
 import { formatFileSize } from '@pixuli/core/utils';
 import { getAssetKind } from '@/utils/assetKind';
 import { isDesktop } from '@/platforms';
-import { Shield, SlidersHorizontal, Sparkles, Wand2, X } from 'lucide-react';
+import {
+  Edit,
+  ExternalLink,
+  Link,
+  type LucideIcon,
+  RefreshCw,
+  Share2,
+  Shield,
+  SlidersHorizontal,
+  Sparkles,
+  Trash2,
+  Wand2,
+  X,
+} from 'lucide-react';
 import React, {
   useCallback,
   useEffect,
@@ -40,14 +48,60 @@ import {
 } from '@/hooks/usePanelResize';
 import './AssetInspector.css';
 
-const INSPECTOR_ACTIONS: ImageActionId[] = [
-  'preview',
-  'edit',
-  'copyUrl',
-  'openUrl',
-  'share',
-  'delete',
-];
+interface CompactAction {
+  id: string;
+  label: string;
+  title?: string;
+  icon: LucideIcon;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+function InspectorActionGrid({
+  actions,
+  danger,
+}: {
+  actions: CompactAction[];
+  danger?: CompactAction | null;
+}) {
+  const DangerIcon = danger?.icon;
+  return (
+    <div className="asset-inspector-actions-block">
+      <div className="asset-inspector-action-grid" role="group">
+        {actions.map(action => {
+          const Icon = action.icon;
+          return (
+            <button
+              key={action.id}
+              type="button"
+              className="asset-inspector-action-btn"
+              title={action.title ?? action.label}
+              aria-label={action.title ?? action.label}
+              disabled={action.disabled}
+              onClick={action.onClick}
+            >
+              <Icon size={18} aria-hidden />
+              <span>{action.label}</span>
+            </button>
+          );
+        })}
+      </div>
+      {danger && DangerIcon ? (
+        <button
+          type="button"
+          className="asset-inspector-action-danger"
+          title={danger.title ?? danger.label}
+          aria-label={danger.title ?? danger.label}
+          disabled={danger.disabled}
+          onClick={danger.onClick}
+        >
+          <DangerIcon size={16} aria-hidden />
+          <span>{danger.label}</span>
+        </button>
+      ) : null}
+    </div>
+  );
+}
 
 interface AssetInspectorProps {
   image: ImageItem | null;
@@ -328,47 +382,6 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
     [navigate, setActiveMenu, setCurrentUtilityTool, setCurrentView],
   );
 
-  const handlers = useMemo<ImageActionHandlers>(() => {
-    if (!activeImage) return {};
-    const url = resolveRemoteCopyUrl(activeImage);
-    const next: ImageActionHandlers = {
-      preview: kind === 'image' ? () => setShowPreview(true) : undefined,
-      edit: onUpdateImage
-        ? () => {
-            setShowEdit(true);
-            showInfo(`${t('image.grid.editing')} "${activeImage.name}"`);
-          }
-        : undefined,
-      copyUrl: () => {
-        void handleCopy();
-      },
-      openUrl: () => {
-        window.open(url || activeImage.url, '_blank');
-      },
-      delete: onDeleteImage
-        ? () => {
-            void handleDelete();
-          }
-        : undefined,
-    };
-    if (onShareImage) {
-      next.share = () => {
-        void handleShare();
-      };
-    }
-    return next;
-  }, [
-    activeImage,
-    handleCopy,
-    handleDelete,
-    handleShare,
-    kind,
-    onDeleteImage,
-    onShareImage,
-    onUpdateImage,
-    t,
-  ]);
-
   const handleBatchDelete = useCallback(async () => {
     if (selectedImages.length === 0) return;
     if (
@@ -396,6 +409,196 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
     item => getAssetKind(item) === 'image',
   );
 
+  const singleActions = useMemo((): {
+    grid: CompactAction[];
+    danger: CompactAction | null;
+  } => {
+    if (!activeImage) return { grid: [], danger: null };
+    const url = resolveRemoteCopyUrl(activeImage);
+    const grid: CompactAction[] = [];
+
+    if (onUpdateImage) {
+      grid.push({
+        id: 'edit',
+        label: t('image.inspector.actionEdit'),
+        title: t('image.actions.edit'),
+        icon: Edit,
+        onClick: () => {
+          setShowEdit(true);
+          showInfo(`${t('image.grid.editing')} "${activeImage.name}"`);
+        },
+      });
+    }
+    grid.push({
+      id: 'copy',
+      label: t('image.inspector.actionCopy'),
+      title: t('image.actions.copyUrl'),
+      icon: Link,
+      onClick: () => {
+        void handleCopy();
+      },
+    });
+    grid.push({
+      id: 'open',
+      label: t('image.inspector.actionOpen'),
+      title: t('image.actions.openUrl'),
+      icon: ExternalLink,
+      onClick: () => {
+        window.open(url || activeImage.url, '_blank');
+      },
+    });
+    if (onShareImage) {
+      grid.push({
+        id: 'share',
+        label: t('image.inspector.actionShare'),
+        title: t('image.actions.share'),
+        icon: Share2,
+        onClick: () => {
+          void handleShare();
+        },
+      });
+    }
+    grid.push({
+      id: 'access',
+      label: t('image.inspector.actionAccess'),
+      title: t('image.inspector.openAccess'),
+      icon: Shield,
+      onClick: () => openAccessModal(activeImage.id),
+    });
+    grid.push({
+      id: 'compress',
+      label: t('image.inspector.actionCompress'),
+      title:
+        kind === 'image'
+          ? t('image.inspector.sendCompress')
+          : t('image.inspector.toolImageOnly'),
+      icon: SlidersHorizontal,
+      disabled: kind !== 'image',
+      onClick: () => openTool('compress'),
+    });
+    grid.push({
+      id: 'convert',
+      label: t('image.inspector.actionConvert'),
+      title:
+        kind === 'image'
+          ? t('image.inspector.sendConvert')
+          : t('image.inspector.toolImageOnly'),
+      icon: Wand2,
+      disabled: kind !== 'image',
+      onClick: () => openTool('convert'),
+    });
+    grid.push({
+      id: 'ai',
+      label: t('image.inspector.actionAi'),
+      title: !isDesktop()
+        ? t('image.inspector.aiDesktopOnly')
+        : kind !== 'image'
+          ? t('image.inspector.toolImageOnly')
+          : t('image.inspector.sendAi'),
+      icon: Sparkles,
+      disabled: !isDesktop() || kind !== 'image',
+      onClick: () => {
+        if (!isDesktop() || kind !== 'image') return;
+        showInfo(t('image.inspector.aiReadyHint'));
+        if (onUpdateImage) setShowEdit(true);
+      },
+    });
+
+    const danger: CompactAction | null = onDeleteImage
+      ? {
+          id: 'delete',
+          label: t('image.inspector.actionDelete'),
+          title: t('image.actions.delete'),
+          icon: Trash2,
+          onClick: () => {
+            void handleDelete();
+          },
+        }
+      : null;
+
+    return { grid, danger };
+  }, [
+    activeImage,
+    handleCopy,
+    handleDelete,
+    handleShare,
+    kind,
+    onDeleteImage,
+    onShareImage,
+    onUpdateImage,
+    openAccessModal,
+    openTool,
+    t,
+  ]);
+
+  const batchActions = useMemo((): {
+    grid: CompactAction[];
+    danger: CompactAction | null;
+  } => {
+    if (selectedImages.length < 2) return { grid: [], danger: null };
+    const grid: CompactAction[] = [
+      {
+        id: 'sync',
+        label: t('image.inspector.actionSync'),
+        title: t('image.toolbar.sync'),
+        icon: RefreshCw,
+        disabled: !onSync,
+        onClick: () => onSync?.(),
+      },
+      {
+        id: 'access',
+        label: t('image.inspector.actionAccess'),
+        title: t('image.inspector.openAccess'),
+        icon: Shield,
+        onClick: () =>
+          openAccessModal(
+            selectedImages[0]?.id,
+            selectedImages.map(item => item.id),
+          ),
+      },
+      {
+        id: 'compress',
+        label: t('image.inspector.actionCompress'),
+        title: allSelectedImages
+          ? t('image.inspector.sendCompress')
+          : t('image.inspector.toolImageOnly'),
+        icon: SlidersHorizontal,
+        disabled: !allSelectedImages,
+        onClick: () => openTool('compress'),
+      },
+      {
+        id: 'convert',
+        label: t('image.inspector.actionConvert'),
+        title: allSelectedImages
+          ? t('image.inspector.sendConvert')
+          : t('image.inspector.toolImageOnly'),
+        icon: Wand2,
+        disabled: !allSelectedImages,
+        onClick: () => openTool('convert'),
+      },
+    ];
+    return {
+      grid,
+      danger: {
+        id: 'delete',
+        label: t('image.inspector.actionDelete'),
+        title: t('image.library.deleteSelected'),
+        icon: Trash2,
+        onClick: () => {
+          void handleBatchDelete();
+        },
+      },
+    };
+  }, [
+    allSelectedImages,
+    handleBatchDelete,
+    onSync,
+    openAccessModal,
+    openTool,
+    selectedImages,
+    t,
+  ]);
+
   const batchBody =
     selectedImages.length >= 2 ? (
       <>
@@ -418,217 +621,94 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
           ))}
           {selectedImages.length > 8 ? <li>…</li> : null}
         </ul>
-        <section className="asset-inspector-section">
-          <h3>{t('image.inspector.sectionActions')}</h3>
-          <div className="asset-inspector-extra">
-            <button
-              type="button"
-              className="asset-inspector-extra-btn"
-              onClick={onSync}
-              disabled={!onSync}
-            >
-              {t('image.toolbar.sync')}
-            </button>
-            <button
-              type="button"
-              className="asset-inspector-extra-btn"
-              onClick={() =>
-                openAccessModal(
-                  selectedImages[0]?.id,
-                  selectedImages.map(item => item.id),
-                )
-              }
-            >
-              {t('image.inspector.openAccess')}
-            </button>
-            <button
-              type="button"
-              className="asset-inspector-extra-btn"
-              disabled={!allSelectedImages}
-              title={
-                allSelectedImages
-                  ? undefined
-                  : t('image.inspector.toolImageOnly')
-              }
-              onClick={() => openTool('compress')}
-            >
-              {t('image.inspector.sendCompress')}
-            </button>
-            <button
-              type="button"
-              className="asset-inspector-extra-btn"
-              disabled={!allSelectedImages}
-              title={
-                allSelectedImages
-                  ? undefined
-                  : t('image.inspector.toolImageOnly')
-              }
-              onClick={() => openTool('convert')}
-            >
-              {t('image.inspector.sendConvert')}
-            </button>
-            <button
-              type="button"
-              className="asset-inspector-extra-btn"
-              onClick={() => {
-                void handleBatchDelete();
-              }}
-            >
-              {t('image.library.deleteSelected')}
-            </button>
-          </div>
-        </section>
       </>
     ) : null;
 
-  const body =
-    batchBody ??
-    (activeImage ? (
-      <>
-        <section className="asset-inspector-section">
-          <h3>{t('image.inspector.sectionContent')}</h3>
-          <FileContent
-            image={activeImage}
-            onPreview={() => setShowPreview(true)}
-            t={t}
-          />
-        </section>
+  const singleBody = activeImage ? (
+    <>
+      <section className="asset-inspector-section">
+        <h3>{t('image.inspector.sectionContent')}</h3>
+        <FileContent
+          image={activeImage}
+          onPreview={() => setShowPreview(true)}
+          t={t}
+        />
+      </section>
 
-        <section className="asset-inspector-section">
-          <h3>{t('image.inspector.sectionInfo')}</h3>
-          <dl className="asset-inspector-dl">
-            <div>
-              <dt>{t('image.inspector.name')}</dt>
-              <dd title={activeImage.name}>{activeImage.name}</dd>
-            </div>
-            {kind === 'image' ? (
-              <div>
-                <dt>{t('image.inspector.dimensions')}</dt>
-                <dd>{dimensions}</dd>
-              </div>
-            ) : null}
-            <div>
-              <dt>{t('image.inspector.size')}</dt>
-              <dd>
-                {activeImage.size > 0 ? formatFileSize(activeImage.size) : '—'}
-              </dd>
-            </div>
-            <div>
-              <dt>{t('image.inspector.date')}</dt>
-              <dd>
-                {activeImage.createdAt
-                  ? new Date(activeImage.createdAt).toLocaleString()
-                  : '—'}
-              </dd>
-            </div>
-            <div>
-              <dt>{t('image.inspector.folder')}</dt>
-              <dd>{folderLabel(activeImage.localPath)}</dd>
-            </div>
-            <div>
-              <dt>{t('image.inspector.sync')}</dt>
-              <dd>
-                {activeImage.linkKind === 'remote-raw' ||
-                hasPublishableRemoteUrl(activeImage)
-                  ? t('image.inspector.syncRemote')
-                  : t('image.inspector.syncLocal')}
-              </dd>
-            </div>
-            <div>
-              <dt>{t('image.inspector.access')}</dt>
-              <dd>
-                {published
-                  ? t('image.inspector.accessPublic')
-                  : t('image.inspector.accessLocalOnly')}
-              </dd>
-            </div>
-            {(activeImage.tags?.length ?? 0) > 0 ? (
-              <div>
-                <dt>{t('image.inspector.tags')}</dt>
-                <dd>{(activeImage.tags ?? []).join('、')}</dd>
-              </div>
-            ) : null}
-            {activeImage.description ? (
-              <div>
-                <dt>{t('image.inspector.description')}</dt>
-                <dd>{activeImage.description}</dd>
-              </div>
-            ) : null}
-          </dl>
-        </section>
-
-        <section className="asset-inspector-section">
-          <h3>{t('image.inspector.sectionActions')}</h3>
-          <ImageActionMenu
-            variant="labeled-bar"
-            actions={INSPECTOR_ACTIONS}
-            handlers={handlers}
-            t={t}
-            className="asset-inspector-actions"
-          />
-          <div className="asset-inspector-extra">
-            <button
-              type="button"
-              className="asset-inspector-extra-btn"
-              onClick={() => openAccessModal(activeImage.id)}
-            >
-              <Shield size={16} aria-hidden />
-              {t('image.inspector.openAccess')}
-            </button>
-            <button
-              type="button"
-              className="asset-inspector-extra-btn"
-              disabled={kind !== 'image'}
-              title={
-                kind === 'image'
-                  ? undefined
-                  : t('image.inspector.toolImageOnly')
-              }
-              onClick={() => openTool('compress')}
-            >
-              <SlidersHorizontal size={16} aria-hidden />
-              {t('image.inspector.sendCompress')}
-            </button>
-            <button
-              type="button"
-              className="asset-inspector-extra-btn"
-              disabled={kind !== 'image'}
-              title={
-                kind === 'image'
-                  ? undefined
-                  : t('image.inspector.toolImageOnly')
-              }
-              onClick={() => openTool('convert')}
-            >
-              <Wand2 size={16} aria-hidden />
-              {t('image.inspector.sendConvert')}
-            </button>
-            <button
-              type="button"
-              className="asset-inspector-extra-btn"
-              disabled={!isDesktop() || kind !== 'image'}
-              title={
-                !isDesktop()
-                  ? t('image.inspector.aiDesktopOnly')
-                  : kind !== 'image'
-                    ? t('image.inspector.toolImageOnly')
-                    : undefined
-              }
-              onClick={() => {
-                if (!isDesktop() || kind !== 'image') return;
-                showInfo(t('image.inspector.aiReadyHint'));
-                if (onUpdateImage) setShowEdit(true);
-              }}
-            >
-              <Sparkles size={16} aria-hidden />
-              {t('image.inspector.sendAi')}
-            </button>
+      <section className="asset-inspector-section">
+        <h3>{t('image.inspector.sectionInfo')}</h3>
+        <dl className="asset-inspector-dl">
+          <div>
+            <dt>{t('image.inspector.name')}</dt>
+            <dd title={activeImage.name}>{activeImage.name}</dd>
           </div>
-        </section>
-      </>
-    ) : (
-      <p className="asset-inspector-empty">{t('image.inspector.empty')}</p>
-    ));
+          {kind === 'image' ? (
+            <div>
+              <dt>{t('image.inspector.dimensions')}</dt>
+              <dd>{dimensions}</dd>
+            </div>
+          ) : null}
+          <div>
+            <dt>{t('image.inspector.size')}</dt>
+            <dd>
+              {activeImage.size > 0 ? formatFileSize(activeImage.size) : '—'}
+            </dd>
+          </div>
+          <div>
+            <dt>{t('image.inspector.date')}</dt>
+            <dd>
+              {activeImage.createdAt
+                ? new Date(activeImage.createdAt).toLocaleString()
+                : '—'}
+            </dd>
+          </div>
+          <div>
+            <dt>{t('image.inspector.folder')}</dt>
+            <dd>{folderLabel(activeImage.localPath)}</dd>
+          </div>
+          <div>
+            <dt>{t('image.inspector.sync')}</dt>
+            <dd>
+              {activeImage.linkKind === 'remote-raw' ||
+              hasPublishableRemoteUrl(activeImage)
+                ? t('image.inspector.syncRemote')
+                : t('image.inspector.syncLocal')}
+            </dd>
+          </div>
+          <div>
+            <dt>{t('image.inspector.access')}</dt>
+            <dd>
+              {published
+                ? t('image.inspector.accessPublic')
+                : t('image.inspector.accessLocalOnly')}
+            </dd>
+          </div>
+          {(activeImage.tags?.length ?? 0) > 0 ? (
+            <div>
+              <dt>{t('image.inspector.tags')}</dt>
+              <dd>{(activeImage.tags ?? []).join('、')}</dd>
+            </div>
+          ) : null}
+          {activeImage.description ? (
+            <div>
+              <dt>{t('image.inspector.description')}</dt>
+              <dd>{activeImage.description}</dd>
+            </div>
+          ) : null}
+        </dl>
+      </section>
+    </>
+  ) : (
+    <p className="asset-inspector-empty">{t('image.inspector.empty')}</p>
+  );
+
+  const body = batchBody ?? singleBody;
+  const actions =
+    selectedImages.length >= 2
+      ? batchActions
+      : activeImage
+        ? singleActions
+        : null;
 
   const panel = (
     <aside
@@ -684,6 +764,14 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
         </div>
       </header>
       <div className="asset-inspector-body">{body}</div>
+      {actions && (actions.grid.length > 0 || actions.danger) ? (
+        <footer className="asset-inspector-actions-footer">
+          <h3 className="asset-inspector-actions-title">
+            {t('image.inspector.sectionActions')}
+          </h3>
+          <InspectorActionGrid actions={actions.grid} danger={actions.danger} />
+        </footer>
+      ) : null}
     </aside>
   );
 

--- a/app/src/ui/image/image-browser/locales/en-US.json
+++ b/app/src/ui/image/image-browser/locales/en-US.json
@@ -53,7 +53,17 @@
       "aiReadyHint": "Edit opens so you can add tags and description. Local models are Desktop-only and must be configured first.",
       "expandSheet": "Expand to full screen",
       "collapseSheet": "Collapse details",
-      "resize": "Drag to resize details panel"
+      "resize": "Drag to resize details panel",
+      "actionEdit": "Edit",
+      "actionCopy": "Copy",
+      "actionOpen": "Open",
+      "actionShare": "Share",
+      "actionAccess": "Access",
+      "actionCompress": "Compress",
+      "actionConvert": "Convert",
+      "actionAi": "AI",
+      "actionDelete": "Delete",
+      "actionSync": "Sync"
     },
     "filter": {
       "title": "Image Filter",

--- a/app/src/ui/image/image-browser/locales/zh-CN.json
+++ b/app/src/ui/image/image-browser/locales/zh-CN.json
@@ -53,7 +53,17 @@
       "aiReadyHint": "将打开编辑，便于写入标签与描述。本地模型仅 Desktop 可用，需自行配置。",
       "expandSheet": "上拉全屏",
       "collapseSheet": "收起详情",
-      "resize": "拖拽调整详情栏宽度"
+      "resize": "拖拽调整详情栏宽度",
+      "actionEdit": "编辑",
+      "actionCopy": "复制",
+      "actionOpen": "打开",
+      "actionShare": "分享",
+      "actionAccess": "访问",
+      "actionCompress": "压缩",
+      "actionConvert": "转换",
+      "actionAi": "AI",
+      "actionDelete": "删除",
+      "actionSync": "同步"
     },
     "filter": {
       "title": "图片筛选",


### PR DESCRIPTION
## Summary
- Inspector 单选/批量操作改为四列图标 + 短文案网格，删除单独危险行
- 操作栏固定在面板底部（不进滚动区），窄屏 sheet 更易触控（≥44px）
- 预览不再占操作位（点内容区即可）；补充短文案 i18n

## Test plan
- [ ] 宽屏：点选文件后右栏底部出现紧凑操作网格，可滚动查看详情且操作栏仍可见
- [ ] 窄屏 sheet：操作在底部固定，按钮可点、文案不溢出
- [ ] 单选：编辑/复制/打开/分享/访问/压缩/转换/AI；删除为全宽红色按钮
- [ ] 多选：同步/访问/压缩/转换 + 删除；非图时压缩转换禁用并有 title 说明
- [ ] 非桌面端 AI 禁用并提示「仅桌面可用」


Made with [Cursor](https://cursor.com)