### PR TITLE
feat(ui): 资源库查询语法过滤（回车确认）

### DIFF
--- a/app/src/contexts/SearchContext.tsx
+++ b/app/src/contexts/SearchContext.tsx
@@ -1,6 +1,6 @@
 /**
  * 搜索上下文
- * 用于资源库中的搜索与筛选
+ * 输入框为草稿；回车后才提交为生效查询并过滤资源库。
  */
 
 import React, {
@@ -22,8 +22,15 @@ import {
 } from '../utils/searchHistory';
 
 interface SearchContextValue {
+  /** 输入框草稿（未回车） */
+  draftQuery: string;
+  setDraftQuery: (query: string) => void;
+  /** 已确认、用于过滤的查询 */
   searchQuery: string;
+  /** 同时更新草稿与已确认查询（清空 / 选历史等） */
   setSearchQuery: (query: string) => void;
+  /** 回车确认：以当前草稿（或传入值）生效并写入历史 */
+  commitSearch: (query?: string) => void;
   filters: FilterOptions;
   setFilters: (
     filters: FilterOptions | ((prev: FilterOptions) => FilterOptions),
@@ -32,6 +39,7 @@ interface SearchContextValue {
   handleSelectHistory: (query: string) => void;
   handleDeleteHistory: (query: string) => void;
   handleClearHistory: () => void;
+  /** @deprecated 使用 commitSearch；保留别名供旧调用 */
   handleSaveHistory: (query: string) => void;
 }
 
@@ -45,9 +53,6 @@ export const useSearchContext = () => {
   return context;
 };
 
-/**
- * 安全地使用搜索上下文，如果不存在则返回 null
- */
 export const useSearchContextSafe = () => {
   return useContext(SearchContext);
 };
@@ -57,44 +62,45 @@ interface SearchProviderProps {
 }
 
 export const SearchProvider: React.FC<SearchProviderProps> = ({ children }) => {
-  const [searchQuery, setSearchQuery] = useState('');
+  const [draftQuery, setDraftQuery] = useState('');
+  const [searchQuery, setSearchQueryState] = useState('');
   const [filters, setFilters] = useState<FilterOptions>(createDefaultFilters());
   const [history, setHistory] = useState<SearchHistoryItem[]>([]);
 
-  // 加载历史记录
   useEffect(() => {
     setHistory(getSearchHistory());
   }, []);
 
-  // 处理搜索查询变化
-  const handleSearchQueryChange = useCallback((query: string) => {
-    setSearchQuery(query);
+  const setSearchQuery = useCallback((query: string) => {
+    setDraftQuery(query);
+    setSearchQueryState(query);
   }, []);
 
-  // 手动保存搜索历史记录（在用户按下 Enter 或执行搜索时调用）
-  const handleSaveHistory = useCallback((query: string) => {
-    if (!query || query.trim().length === 0) {
-      return;
-    }
-    addSearchHistory(query.trim());
-    setHistory(getSearchHistory());
-  }, []);
+  const commitSearch = useCallback(
+    (query?: string) => {
+      const q = (query ?? draftQuery).trim();
+      setDraftQuery(q);
+      setSearchQueryState(q);
+      if (q.length > 0) {
+        addSearchHistory(q);
+        setHistory(getSearchHistory());
+      }
+    },
+    [draftQuery],
+  );
 
-  // 选择历史记录
   const handleSelectHistory = useCallback((query: string) => {
-    setSearchQuery(query);
-    // 选择历史记录时也保存（更新到最新）
+    setDraftQuery(query);
+    setSearchQueryState(query);
     addSearchHistory(query);
     setHistory(getSearchHistory());
   }, []);
 
-  // 删除单条历史记录
   const handleDeleteHistory = useCallback((query: string) => {
     removeSearchHistory(query);
     setHistory(getSearchHistory());
   }, []);
 
-  // 清空所有历史记录
   const handleClearHistory = useCallback(() => {
     clearSearchHistory();
     setHistory([]);
@@ -103,15 +109,18 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({ children }) => {
   return (
     <SearchContext.Provider
       value={{
+        draftQuery,
+        setDraftQuery,
         searchQuery,
-        setSearchQuery: handleSearchQueryChange,
+        setSearchQuery,
+        commitSearch,
         filters,
         setFilters,
         history,
         handleSelectHistory,
         handleDeleteHistory,
         handleClearHistory,
-        handleSaveHistory,
+        handleSaveHistory: commitSearch,
       }}
     >
       {children}

--- a/app/src/features/library/AssetLibrary.tsx
+++ b/app/src/features/library/AssetLibrary.tsx
@@ -11,25 +11,20 @@ import type { NativeImagePickers } from '@/ui/image/image-upload/common/nativePi
 import { isAssetPublished } from '@/features/access/accessPolicyStore';
 import { hasPublishableRemoteUrl } from '@/features/access/accessCapabilities';
 import { useSourceStore } from '@/stores/sourceStore';
-import { filterAssetsByKinds, getAssetKind } from '@/utils/assetKind';
+import { getAssetKind } from '@/utils/assetKind';
+import { filterByLibraryQuery } from '@/utils/libraryQuery';
 import { nextSelectedIds, pruneSelectedIds } from '@/utils/librarySelection';
 import { BrandPixelMark } from '@/ui/brand/BrandPixelMark';
 import { getVirtualWindow, LIBRARY_ROW_HEIGHT } from '@/utils/virtualWindow';
 import type {
-  AssetKind,
   BatchUploadProgress,
-  FilterOptions,
   ImageItem,
   ImageUploadData,
   MultiImageUploadData,
   SortField,
   SortOrder,
 } from '@pixuli/core/types';
-import {
-  filterImages,
-  formatFileSize,
-  getSortedImages,
-} from '@pixuli/core/utils';
+import { formatFileSize, getSortedImages } from '@pixuli/core/utils';
 import {
   Folder,
   Cloud,
@@ -38,7 +33,6 @@ import {
   RefreshCw,
   Trash2,
   Wand2,
-  X,
 } from 'lucide-react';
 import React, {
   useCallback,
@@ -90,13 +84,6 @@ function sortIndicator(active: boolean, order: SortOrder): string {
   return order === 'asc' ? ' ↑' : ' ↓';
 }
 
-function kindChipLabel(kind: AssetKind, t: (key: string) => string): string {
-  if (kind === 'video') return t('image.kind.video');
-  if (kind === 'pdf') return t('image.kind.pdf');
-  if (kind === 'other') return t('image.kind.other');
-  return t('image.kind.image');
-}
-
 export const AssetLibrary: React.FC<AssetLibraryProps> = ({
   images,
   hasConfig = true,
@@ -141,24 +128,23 @@ export const AssetLibrary: React.FC<AssetLibraryProps> = ({
 
   useEffect(() => {
     if (!search) return;
+    // 保持 filters.searchTerm 与查询框同步（历史兼容）；实际过滤走 libraryQuery
     search.onFiltersChange(prev => {
       if (prev.searchTerm === search.searchQuery) return prev;
-      return { ...prev, searchTerm: search.searchQuery };
+      return {
+        ...prev,
+        searchTerm: search.searchQuery,
+        selectedTypes: [],
+        selectedTags: [],
+        selectedKinds: [],
+      };
     });
   }, [search?.searchQuery, search?.onFiltersChange]);
 
-  const filteredImages = useMemo(() => {
-    if (!search?.filters) return images;
-    return filterImages(images, search.filters);
-  }, [images, search?.filters]);
-
   const files = useMemo(() => {
-    const byKind = filterAssetsByKinds(
-      filteredImages,
-      search?.filters.selectedKinds ?? [],
-    );
+    const filtered = filterByLibraryQuery(images, search?.searchQuery ?? '');
     const unique = new Map<string, ImageItem>();
-    for (const item of byKind) {
+    for (const item of filtered) {
       const existing = unique.get(item.id);
       if (
         !existing ||
@@ -169,7 +155,7 @@ export const AssetLibrary: React.FC<AssetLibraryProps> = ({
       }
     }
     return getSortedImages([...unique.values()], sortField, sortOrder);
-  }, [filteredImages, search?.filters.selectedKinds, sortField, sortOrder]);
+  }, [images, search?.searchQuery, sortField, sortOrder]);
 
   const visibleIds = useMemo(() => files.map(file => file.id), [files]);
 
@@ -276,13 +262,6 @@ export const AssetLibrary: React.FC<AssetLibraryProps> = ({
     [sortField],
   );
 
-  const patchFilters = useCallback(
-    (patch: (prev: FilterOptions) => FilterOptions) => {
-      search?.onFiltersChange(patch);
-    },
-    [search],
-  );
-
   const handleBatchDelete = useCallback(async () => {
     const selected = files.filter(file => selectedIds.includes(file.id));
     if (selected.length === 0) return;
@@ -368,58 +347,6 @@ export const AssetLibrary: React.FC<AssetLibraryProps> = ({
     observer.observe(el);
     return () => observer.disconnect();
   }, [showEmpty, loading, files.length]);
-  const filters = search?.filters;
-  const filterChips = useMemo(() => {
-    const chips: Array<{ key: string; label: string; clear: () => void }> = [];
-    if (!filters) return chips;
-    const searchTerm = (search?.searchQuery || filters.searchTerm || '').trim();
-    if (searchTerm) {
-      chips.push({
-        key: 'search',
-        label: searchTerm,
-        clear: () => {
-          search?.onSearchChange('');
-          patchFilters(prev => ({ ...prev, searchTerm: '' }));
-        },
-      });
-    }
-    for (const kind of filters.selectedKinds ?? []) {
-      chips.push({
-        key: `kind:${kind}`,
-        label: kindChipLabel(kind, t),
-        clear: () =>
-          patchFilters(prev => ({
-            ...prev,
-            selectedKinds: (prev.selectedKinds ?? []).filter(
-              item => item !== kind,
-            ),
-          })),
-      });
-    }
-    for (const type of filters.selectedTypes) {
-      chips.push({
-        key: `type:${type}`,
-        label: type,
-        clear: () =>
-          patchFilters(prev => ({
-            ...prev,
-            selectedTypes: prev.selectedTypes.filter(item => item !== type),
-          })),
-      });
-    }
-    for (const tag of filters.selectedTags) {
-      chips.push({
-        key: `tag:${tag}`,
-        label: tag,
-        clear: () =>
-          patchFilters(prev => ({
-            ...prev,
-            selectedTags: prev.selectedTags.filter(item => item !== tag),
-          })),
-      });
-    }
-    return chips;
-  }, [filters, patchFilters, search, t]);
 
   const showBatchBar = selectedIds.length >= 2;
   const allImagesSelected =
@@ -472,18 +399,17 @@ export const AssetLibrary: React.FC<AssetLibraryProps> = ({
           <Search
             variant="header"
             searchQuery={search.searchQuery}
+            draftQuery={search.draftQuery}
+            onDraftChange={search.onDraftChange}
+            onCommitSearch={search.onCommitSearch}
             onSearchChange={search.onSearchChange}
             hasConfig={hasConfig}
             images={images}
-            externalFilters={search.filters}
-            onFiltersChange={search.onFiltersChange}
-            showFilter={true}
             showHistory={true}
             history={search.history}
             onSelectHistory={search.onSelectHistory}
             onDeleteHistory={search.onDeleteHistory}
             onClearHistory={search.onClearHistory}
-            onSaveHistory={search.onSaveHistory}
             t={t}
             className="asset-library-search"
           />
@@ -516,41 +442,6 @@ export const AssetLibrary: React.FC<AssetLibraryProps> = ({
           ) : null}
         </div>
       </div>
-
-      {filterChips.length > 0 ? (
-        <div
-          className="asset-library-chips"
-          aria-label={t('image.filter.title')}
-        >
-          {filterChips.map(chip => (
-            <button
-              key={chip.key}
-              type="button"
-              className="asset-library-chip"
-              onClick={chip.clear}
-            >
-              {chip.label}
-              <X size={12} aria-hidden />
-            </button>
-          ))}
-          <button
-            type="button"
-            className="asset-library-chip asset-library-chip--clear"
-            onClick={() => {
-              search?.onSearchChange('');
-              patchFilters(prev => ({
-                ...prev,
-                searchTerm: '',
-                selectedTypes: [],
-                selectedTags: [],
-                selectedKinds: [],
-              }));
-            }}
-          >
-            {t('image.filter.clearFilter')}
-          </button>
-        </div>
-      ) : null}
 
       <div className="asset-library-content">
         {loading && files.length === 0 ? (

--- a/app/src/pages/photos/index.tsx
+++ b/app/src/pages/photos/index.tsx
@@ -43,6 +43,9 @@ export const PhotosPage: React.FC<PhotosPageProps> = ({
     }
     return {
       searchQuery: searchContext.searchQuery,
+      draftQuery: searchContext.draftQuery,
+      onDraftChange: searchContext.setDraftQuery,
+      onCommitSearch: searchContext.commitSearch,
       onSearchChange: searchContext.setSearchQuery,
       filters: searchContext.filters,
       onFiltersChange: searchContext.setFilters,
@@ -50,7 +53,6 @@ export const PhotosPage: React.FC<PhotosPageProps> = ({
       onSelectHistory: searchContext.handleSelectHistory,
       onDeleteHistory: searchContext.handleDeleteHistory,
       onClearHistory: searchContext.handleClearHistory,
-      onSaveHistory: searchContext.handleSaveHistory,
     };
   }, [searchContext]);
 

--- a/app/src/ui/image/image-browser/common/types.ts
+++ b/app/src/ui/image/image-browser/common/types.ts
@@ -9,7 +9,14 @@ export type {
 import type { FilterOptions } from '@pixuli/core/types';
 
 export interface LibrarySearchConfig {
+  /** 已确认查询（用于过滤结果） */
   searchQuery: string;
+  /** 输入框草稿 */
+  draftQuery: string;
+  onDraftChange: (query: string) => void;
+  /** 回车确认查询 */
+  onCommitSearch: (query?: string) => void;
+  /** 同时清空草稿与已确认查询等 */
   onSearchChange: (query: string) => void;
   filters: FilterOptions;
   onFiltersChange: (
@@ -19,5 +26,4 @@ export interface LibrarySearchConfig {
   onSelectHistory?: (query: string) => void;
   onDeleteHistory?: (query: string) => void;
   onClearHistory?: () => void;
-  onSaveHistory?: (query: string) => void;
 }

--- a/app/src/ui/primitives/search/locales/en-US.json
+++ b/app/src/ui/primitives/search/locales/en-US.json
@@ -2,15 +2,27 @@
   "search": {
     "placeholder": "Search...",
     "header": {
-      "placeholder": "Search images...",
-      "placeholderDisabled": "Add a source to search images",
-      "filter": "Filter",
-      "clearFilters": "Clear Filters",
+      "placeholder": "Type a query, then press Enter…",
+      "placeholderDisabled": "Add a repository source to search",
       "expandSearch": "Expand search",
       "collapseSearch": "Collapse search"
     },
+    "help": {
+      "title": "Query syntax help",
+      "intro": "Filter files with a simple query. Press Enter to apply. Space-separated terms are AND.",
+      "exBare": "cover",
+      "descBare": "Filename contains “cover”",
+      "exName": "name:logo",
+      "descName": "Match filename only",
+      "exKind": "kind:pdf",
+      "descKind": "Kind: image / video / pdf / other (alias: type:)",
+      "exSize": "size:>1mb",
+      "descSize": "Size ops: > >= < <= = ; units: b / kb / mb / gb",
+      "exCombo": "kind:image size:<500kb trip",
+      "descCombo": "Combine: images under 500KB whose name contains “trip”"
+    },
     "image": {
-      "placeholder": "Search image names, descriptions or tags...",
+      "placeholder": "Search by name, description, or tags...",
       "filterByTags": "Filter by tags",
       "clearFilters": "Clear filters"
     }

--- a/app/src/ui/primitives/search/locales/zh-CN.json
+++ b/app/src/ui/primitives/search/locales/zh-CN.json
@@ -2,12 +2,24 @@
   "search": {
     "placeholder": "搜索...",
     "header": {
-      "placeholder": "搜索图片...",
-      "placeholderDisabled": "添加仓库源后即可搜索图片",
-      "filter": "筛选",
-      "clearFilters": "清除筛选",
+      "placeholder": "输入查询后按回车…",
+      "placeholderDisabled": "添加仓库源后即可搜索",
       "expandSearch": "展开搜索",
       "collapseSearch": "收起搜索"
+    },
+    "help": {
+      "title": "查询语法帮助",
+      "intro": "在输入框用简单语法过滤文件，输入完成后按 Enter 确认。多个条件之间为空格，表示同时满足（AND）。",
+      "exBare": "封面",
+      "descBare": "文件名包含「封面」",
+      "exName": "name:logo",
+      "descName": "仅按文件名匹配",
+      "exKind": "kind:pdf",
+      "descKind": "类型：image / video / pdf / other（也可用 type:）",
+      "exSize": "size:>1mb",
+      "descSize": "大小：> >= < <= =，单位 b / kb / mb / gb",
+      "exCombo": "kind:image size:<500kb 旅行",
+      "descCombo": "组合：图片且小于 500KB 且文件名含「旅行」"
     },
     "image": {
       "placeholder": "搜索图片名称、描述或标签...",

--- a/app/src/ui/primitives/search/web/Search.css
+++ b/app/src/ui/primitives/search/web/Search.css
@@ -1,13 +1,11 @@
 /* Search 组件统一样式 */
 
-/* 基础包装器 */
 .search-wrapper {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
 }
 
-/* Header variant 样式 */
 .search-wrapper--header {
   flex-direction: row;
   align-items: center;
@@ -16,7 +14,6 @@
   flex: 1;
 }
 
-/* Image variant 样式 */
 .search-wrapper--image {
   margin-bottom: 1rem;
 }
@@ -25,249 +22,87 @@
   position: relative;
 }
 
-/* 筛选功能样式（Header variant） */
-.search-filter-wrapper {
+/* 查询语法帮助 */
+.search-help-wrapper {
   position: relative;
   flex-shrink: 0;
-  overflow: visible;
 }
 
-.search-filter-button {
-  display: flex;
+.search-help-button {
+  display: inline-flex;
   align-items: center;
   justify-content: center;
+  min-width: 2.25rem;
+  height: 2.25rem;
   padding: 0.5rem;
-  min-width: 36px;
-  height: 36px;
-  background: var(--button-bg, #ffffff);
   border: 1px solid var(--border-color, #e5e7eb);
   border-radius: 6px;
+  background: var(--button-bg, #ffffff);
   color: var(--text-secondary, #6b7280);
   cursor: pointer;
-  transition: all 0.2s;
-  position: relative;
 }
 
-.search-filter-button:hover {
-  background: var(--hover-bg, #f3f4f6);
-  color: var(--text-primary, #111827);
-  border-color: var(--pix-violet);
+.search-help-button:hover,
+.search-help-button.is-open {
+  color: var(--pix-violet-deep, #5b4fe0);
+  border-color: var(--pix-lilac, #c4b5fd);
+  background: var(--pix-violet-soft, #ede9fe);
 }
 
-.search-filter-button.active {
-  background: var(--pix-violet);
-  color: white;
-  border-color: var(--pix-violet);
-}
-
-.search-filter-badge {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  width: 8px;
-  height: 8px;
-  background: #ef4444;
-  border-radius: 50%;
-  border: 2px solid white;
-}
-
-.search-filter-panel {
+.search-help-panel {
   position: absolute;
   top: calc(100% + 8px);
   right: 0;
-  background: white;
+  z-index: 1100;
+  width: min(22rem, calc(100vw - 2rem));
+  padding: 0.875rem 1rem 1rem;
   border: 1px solid var(--border-color, #e5e7eb);
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  min-width: 280px;
-  max-width: 400px;
-  max-height: 500px;
-  overflow-y: auto;
-  z-index: 1001;
+  border-radius: 0.75rem;
+  background: #fff;
+  box-shadow: 0 8px 24px rgba(30, 27, 75, 0.12);
 }
 
-.search-filter-panel-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--border-color, #e5e7eb);
-}
-
-.search-filter-panel-title {
+.search-help-title {
+  margin: 0 0 0.35rem;
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--text-primary, #111827);
+  color: var(--pix-ink, #1e1b4b);
 }
 
-.search-filter-clear {
+.search-help-intro {
+  margin: 0 0 0.75rem;
   font-size: 0.75rem;
-  color: var(--pix-violet);
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  transition: background 0.2s;
-}
-
-.search-filter-clear:hover {
-  background: var(--hover-bg, #f3f4f6);
-}
-
-.search-filter-section {
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--border-color, #e5e7eb);
-}
-
-.search-filter-section:last-child {
-  border-bottom: none;
-}
-
-.search-filter-label {
-  display: block;
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--text-secondary, #6b7280);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 0.5rem;
-}
-
-.search-filter-options {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.search-filter-option {
-  display: flex;
-  align-items: center;
-  gap: 0.375rem;
-  font-size: 0.875rem;
-  color: var(--text-primary, #111827);
-  cursor: pointer;
-  padding: 0.375rem 0.75rem;
-  background: var(--button-bg, #f9fafb);
-  border: 1px solid var(--border-color, #e5e7eb);
-  border-radius: 6px;
-  transition: all 0.2s;
-}
-
-.search-filter-option:hover {
-  background: var(--hover-bg, #f3f4f6);
-  border-color: var(--pix-violet);
-}
-
-.search-filter-option input[type='checkbox'] {
-  margin: 0;
-  cursor: pointer;
-}
-
-.search-filter-option input[type='checkbox']:checked + span {
-  color: var(--pix-violet);
-  font-weight: 500;
-}
-
-.search-filter-option:has(input[type='checkbox']:checked) {
-  background: var(--pix-violet-soft);
-  border-color: var(--pix-violet);
-}
-
-/* 标签筛选样式（Image variant） */
-.search-tags-container {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-@media (min-width: 640px) {
-  .search-tags-container {
-    flex-direction: row;
-    align-items: center;
-    gap: 0.5rem;
-  }
-}
-
-.search-tags-label {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.search-tags-icon {
-  width: 1rem;
-  height: 1rem;
-  color: #9ca3af;
-}
-
-.search-tags-text {
-  font-size: 0.875rem;
+  line-height: 1.45;
   color: #6b7280;
 }
 
-.search-tags {
+.search-help-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+  flex-direction: column;
+  gap: 0.55rem;
 }
 
-/* 清除筛选按钮 */
-.search-tags-clear-button {
-  padding: 0.25rem 0.75rem;
+.search-help-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
   font-size: 0.75rem;
-  background-color: #fee2e2;
-  color: #b91c1c;
-  border-radius: 9999px;
-  border: none;
-  cursor: pointer;
-  transition: background-color 0.2s ease-in-out;
+  line-height: 1.4;
+  color: #4b5563;
 }
 
-.search-tags-clear-button:hover {
-  background-color: #fecaca;
-}
-
-/* 标签按钮 */
-.search-tag-button {
-  padding: 0.25rem 0.75rem;
-  font-size: 0.75rem;
-  border-radius: 9999px;
-  border: none;
-  cursor: pointer;
-  transition: all 0.2s ease-in-out;
-  outline: none;
-}
-
-.search-tag-button:focus {
-  box-shadow: 0 0 0 2px rgba(var(--pix-violet-rgb), 0.1);
-}
-
-.search-tag-button.selected {
-  background-color: var(--pix-violet-deep);
-  color: white;
-}
-
-.search-tag-button.unselected {
-  background-color: #f3f4f6;
-  color: #374151;
-}
-
-.search-tag-button.unselected:hover {
-  background-color: #e5e7eb;
-}
-
-@keyframes search-filter-sheet-up {
-  from {
-    transform: translateY(100%);
-  }
-  to {
-    transform: translateY(0);
-  }
-}
-
-.search-filter-backdrop {
-  display: none;
+.search-help-list code {
+  display: inline-block;
+  width: fit-content;
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.25rem;
+  background: var(--pix-violet-soft, #ede9fe);
+  color: var(--pix-violet-deep, #5b4fe0);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.7rem;
 }
 
 .search-compact-toggle {
@@ -300,20 +135,7 @@
   }
 }
 
-/* 窄屏：筛选面板底部 sheet（REF-512 #150） */
 @media (max-width: 767px) {
-  .search-filter-backdrop {
-    display: block;
-    position: fixed;
-    inset: 0;
-    z-index: 999;
-    margin: 0;
-    padding: 0;
-    border: none;
-    background: rgba(0, 0, 0, 0.4);
-    cursor: pointer;
-  }
-
   .search-wrapper--header {
     flex: 1;
     flex-wrap: nowrap;
@@ -326,38 +148,75 @@
     min-width: 0;
   }
 
-  .search-filter-wrapper {
-    flex-shrink: 0;
-  }
-
-  .search-filter-button {
+  .search-help-button {
     min-width: 2.75rem;
     min-height: 2.75rem;
   }
 
-  .search-filter-panel {
+  .search-help-panel {
     position: fixed;
-    left: 0;
-    right: 0;
-    bottom: calc(3.75rem + env(safe-area-inset-bottom, 0px));
+    left: 0.75rem;
+    right: 0.75rem;
     top: auto;
-    min-width: 0;
-    max-width: none;
-    max-height: min(72vh, 32rem);
-    border-radius: 1rem 1rem 0 0;
-    padding-bottom: 0.75rem;
-    box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.12);
-    animation: search-filter-sheet-up 0.22s ease-out;
-    z-index: 1000;
+    bottom: calc(3.75rem + env(safe-area-inset-bottom, 0px));
+    width: auto;
+    max-height: min(70vh, 28rem);
+    overflow-y: auto;
   }
+}
 
-  .search-filter-option {
-    min-height: 2.75rem;
-    padding: 0.5rem 0.875rem;
-  }
+/* Image variant 标签（工具页等） */
+.search-tags {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
 
-  .search-tag-button {
-    min-height: 2.25rem;
-    padding: 0.375rem 0.875rem;
-  }
+.search-tags-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.search-tags-label {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: #6b7280;
+}
+
+.search-tags-clear {
+  border: none;
+  background: transparent;
+  color: var(--pix-violet-deep, #5b4fe0);
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.search-tags-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.search-tag-button {
+  padding: 0.25rem 0.625rem;
+  border-radius: 999px;
+  border: 1px solid #e5e7eb;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.search-tag-button.selected {
+  background-color: var(--pix-violet-soft, #ede9fe);
+  border-color: var(--pix-lilac, #c4b5fd);
+  color: var(--pix-violet-deep, #5b4fe0);
+}
+
+.search-tag-button.unselected {
+  background-color: #f3f4f6;
+  color: #374151;
+}
+
+.search-tag-button.unselected:hover {
+  background-color: #e5e7eb;
 }

--- a/app/src/ui/primitives/search/web/Search.test.tsx
+++ b/app/src/ui/primitives/search/web/Search.test.tsx
@@ -1,667 +1,106 @@
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom';
 import Search from './Search';
-import type { ImageItem } from '@pixuli/core/types';
-import type { FilterOptions } from '../../image/image-browser/common/types';
 
-// Mock 依赖
 vi.mock('@/ui/locales', () => ({
   defaultTranslate: (key: string) => {
-    const translations: Record<string, string> = {
-      'search.header.placeholder': '搜索图片...',
-      'search.header.placeholderDisabled': '添加仓库源后即可搜索图片',
-      'search.image.placeholder': '搜索图片名称、描述或标签...',
+    const map: Record<string, string> = {
       'search.placeholder': '搜索...',
-      'search.header.filter': '筛选',
-      'search.header.clearFilters': '清除筛选',
+      'search.header.placeholder': '搜索或输入查询语法…',
+      'search.header.placeholderDisabled': '添加仓库源后即可搜索',
       'search.header.expandSearch': '展开搜索',
       'search.header.collapseSearch': '收起搜索',
+      'search.help.title': '查询语法帮助',
+      'search.help.intro': '介绍',
+      'search.help.exBare': '封面',
+      'search.help.descBare': '文件名包含',
+      'search.help.exName': 'name:logo',
+      'search.help.descName': '仅文件名',
+      'search.help.exKind': 'kind:pdf',
+      'search.help.descKind': '类型',
+      'search.help.exSize': 'size:>1mb',
+      'search.help.descSize': '大小',
+      'search.help.exCombo': 'kind:image size:<500kb',
+      'search.help.descCombo': '组合',
+      'search.image.placeholder': '搜索图片',
       'search.image.filterByTags': '按标签筛选',
       'search.image.clearFilters': '清除筛选',
-      'image.filter.imageType': '图片类型',
-      'image.filter.tags': '标签',
-      'image.kind.label': '资源类型',
-      'image.kind.image': '图片',
-      'image.kind.video': '视频',
-      'image.kind.pdf': 'PDF',
-      'image.kind.other': '其他',
     };
-    return translations[key] || key;
+    return map[key] || key;
   },
 }));
 
 describe('Search', () => {
-  const mockImages: ImageItem[] = [
-    {
-      id: '1',
-      name: 'image1.jpg',
-      url: 'https://example.com/image1.jpg',
-      githubUrl: 'https://github.com/image1.jpg',
-      size: 102400,
-      width: 1920,
-      height: 1080,
-      type: 'image/jpeg',
-      tags: ['tag1', 'tag2'],
-      createdAt: '2024-01-01',
-      updatedAt: '2024-01-01',
-    },
-    {
-      id: '2',
-      name: 'image2.png',
-      url: 'https://example.com/image2.png',
-      githubUrl: 'https://github.com/image2.png',
-      size: 204800,
-      width: 1920,
-      height: 1080,
-      type: 'image/png',
-      tags: ['tag2', 'tag3'],
-      createdAt: '2024-01-02',
-      updatedAt: '2024-01-02',
-    },
-  ];
-
-  const mockFilters: FilterOptions = {
-    searchTerm: '',
-    selectedTypes: [],
-    selectedTags: [],
-  };
-
   const defaultProps = {
     searchQuery: '',
     onSearchChange: vi.fn(),
     variant: 'basic' as const,
     hasConfig: true,
-    images: mockImages,
-    externalFilters: mockFilters,
-    onFiltersChange: vi.fn(),
-    showFilter: false,
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('basic variant', () => {
-    it('应该渲染基础搜索框', () => {
-      const { container } = render(
-        <Search {...defaultProps} variant="basic" />,
-      );
-      const searchBar = container.querySelector('.search-bar');
-      expect(searchBar).toBeInTheDocument();
-    });
-
-    it('应该在禁用时禁用搜索框', () => {
-      const { container } = render(
-        <Search {...defaultProps} variant="basic" disabled={true} />,
-      );
-      const input = container.querySelector('input');
-      expect(input).toBeDisabled();
-    });
-
-    it('应该在 hasConfig 为 false 时禁用搜索框', () => {
-      const { container } = render(
-        <Search {...defaultProps} variant="basic" hasConfig={false} />,
-      );
-      const input = container.querySelector('input');
-      expect(input).toBeDisabled();
-    });
-
-    it('应该使用自定义占位符', () => {
-      const { container } = render(
-        <Search {...defaultProps} variant="basic" placeholder="自定义占位符" />,
-      );
-      const input = container.querySelector('input') as HTMLInputElement;
-      expect(input.placeholder).toBe('自定义占位符');
-    });
+  it('renders basic search', () => {
+    const { container } = render(<Search {...defaultProps} />);
+    expect(container.querySelector('.search-bar')).toBeInTheDocument();
   });
 
-  describe('header variant', () => {
-    it('应该渲染 header 变体', () => {
-      const { container } = render(
-        <Search {...defaultProps} variant="header" />,
-      );
-      const wrapper = container.querySelector('.search-wrapper--header');
-      expect(wrapper).toBeInTheDocument();
-    });
-
-    it('应该显示搜索框', () => {
-      const { container } = render(
-        <Search {...defaultProps} variant="header" />,
-      );
-      const searchBar = container.querySelector('.search-bar');
-      expect(searchBar).toBeInTheDocument();
-    });
-
-    it('应该在 showFilter 为 true 时显示筛选按钮', () => {
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          variant="header"
-          showFilter={true}
-          hasConfig={true}
-        />,
-      );
-      const filterButton = container.querySelector('.search-filter-button');
-      expect(filterButton).toBeInTheDocument();
-    });
-
-    it('应该点击筛选按钮时显示筛选面板', () => {
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          variant="header"
-          showFilter={true}
-          hasConfig={true}
-        />,
-      );
-      const filterButton = container.querySelector(
-        '.search-filter-button',
-      ) as HTMLButtonElement;
-      fireEvent.click(filterButton);
-
-      const filterPanel = container.querySelector('.search-filter-panel');
-      expect(filterPanel).toBeInTheDocument();
-    });
-
-    it('打开筛选面板时派发 pixuli:openFilterPanel', () => {
-      const onOpen = vi.fn();
-      window.addEventListener('pixuli:openFilterPanel', onOpen);
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          variant="header"
-          showFilter={true}
-          hasConfig={true}
-        />,
-      );
-      const filterButton = container.querySelector(
-        '.search-filter-button',
-      ) as HTMLButtonElement;
-      fireEvent.click(filterButton);
-      expect(onOpen).toHaveBeenCalledTimes(1);
-      window.removeEventListener('pixuli:openFilterPanel', onOpen);
-    });
-
-    it('header 变体包含中屏搜索展开按钮', () => {
-      const { container } = render(
-        <Search {...defaultProps} variant="header" />,
-      );
-      expect(
-        container.querySelector('.search-compact-toggle'),
-      ).toBeInTheDocument();
-    });
-
-    it('应该显示可用的图片类型', () => {
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          variant="header"
-          showFilter={true}
-          hasConfig={true}
-        />,
-      );
-      const filterButton = container.querySelector(
-        '.search-filter-button',
-      ) as HTMLButtonElement;
-      fireEvent.click(filterButton);
-
-      expect(screen.getByText('资源类型')).toBeInTheDocument();
-      expect(screen.getByText('图片')).toBeInTheDocument();
-      expect(screen.getByText('视频')).toBeInTheDocument();
-      expect(screen.getByText('PDF')).toBeInTheDocument();
-      expect(screen.getByText('image/jpeg')).toBeInTheDocument();
-      expect(screen.getByText('image/png')).toBeInTheDocument();
-    });
-
-    it('应该显示可用的标签', () => {
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          variant="header"
-          showFilter={true}
-          hasConfig={true}
-        />,
-      );
-      const filterButton = container.querySelector(
-        '.search-filter-button',
-      ) as HTMLButtonElement;
-      fireEvent.click(filterButton);
-
-      expect(screen.getByText('tag1')).toBeInTheDocument();
-      expect(screen.getByText('tag2')).toBeInTheDocument();
-      expect(screen.getByText('tag3')).toBeInTheDocument();
-    });
-
-    it('应该可以选择图片类型', () => {
-      const onFiltersChange = vi.fn();
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          variant="header"
-          showFilter={true}
-          hasConfig={true}
-          onFiltersChange={onFiltersChange}
-        />,
-      );
-      const filterButton = container.querySelector(
-        '.search-filter-button',
-      ) as HTMLButtonElement;
-      fireEvent.click(filterButton);
-
-      const imageKind = screen.getByLabelText('图片') as HTMLInputElement;
-      fireEvent.click(imageKind);
-
-      expect(onFiltersChange).toHaveBeenCalled();
-    });
-
-    it('应该可以选择标签', () => {
-      const onFiltersChange = vi.fn();
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          variant="header"
-          showFilter={true}
-          hasConfig={true}
-          onFiltersChange={onFiltersChange}
-        />,
-      );
-      const filterButton = container.querySelector(
-        '.search-filter-button',
-      ) as HTMLButtonElement;
-      fireEvent.click(filterButton);
-
-      const tag1Checkbox = screen.getByLabelText('tag1') as HTMLInputElement;
-      fireEvent.click(tag1Checkbox);
-
-      expect(onFiltersChange).toHaveBeenCalled();
-    });
-
-    it('应该在有活动筛选条件时显示清除按钮', () => {
-      const filtersWithSelection: FilterOptions = {
-        searchTerm: '',
-        selectedTypes: ['image/jpeg'],
-        selectedTags: [],
-      };
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          variant="header"
-          showFilter={true}
-          hasConfig={true}
-          externalFilters={filtersWithSelection}
-        />,
-      );
-      const filterButton = container.querySelector(
-        '.search-filter-button',
-      ) as HTMLButtonElement;
-      fireEvent.click(filterButton);
-
-      const clearButton = screen.getByText('清除筛选');
-      expect(clearButton).toBeInTheDocument();
-    });
-
-    it('应该点击清除按钮时清除所有筛选条件', () => {
-      const onFiltersChange = vi.fn();
-      const filtersWithSelection: FilterOptions = {
-        searchTerm: '',
-        selectedTypes: ['image/jpeg'],
-        selectedTags: ['tag1'],
-      };
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          variant="header"
-          showFilter={true}
-          hasConfig={true}
-          externalFilters={filtersWithSelection}
-          onFiltersChange={onFiltersChange}
-        />,
-      );
-      const filterButton = container.querySelector(
-        '.search-filter-button',
-      ) as HTMLButtonElement;
-      fireEvent.click(filterButton);
-
-      const clearButton = screen.getByText('清除筛选');
-      fireEvent.click(clearButton);
-
-      expect(onFiltersChange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          selectedTypes: [],
-          selectedTags: [],
-          selectedKinds: [],
-        }),
-      );
-    });
-
-    it('应该在有活动筛选条件时高亮筛选按钮', () => {
-      const filtersWithSelection: FilterOptions = {
-        searchTerm: '',
-        selectedTypes: ['image/jpeg'],
-        selectedTags: [],
-      };
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          variant="header"
-          showFilter={true}
-          hasConfig={true}
-          externalFilters={filtersWithSelection}
-        />,
-      );
-      const filterButton = container.querySelector(
-        '.search-filter-button.active',
-      );
-      expect(filterButton).toBeInTheDocument();
-    });
-
-    it('应该点击外部时关闭筛选面板', () => {
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          variant="header"
-          showFilter={true}
-          hasConfig={true}
-        />,
-      );
-      const filterButton = container.querySelector(
-        '.search-filter-button',
-      ) as HTMLButtonElement;
-      fireEvent.click(filterButton);
-
-      expect(
-        container.querySelector('.search-filter-panel'),
-      ).toBeInTheDocument();
-
-      // 点击外部
-      fireEvent.mouseDown(document.body);
-
-      waitFor(() => {
-        expect(
-          container.querySelector('.search-filter-panel'),
-        ).not.toBeInTheDocument();
-      });
-    });
+  it('renders header search with help button', () => {
+    const { container } = render(
+      <Search {...defaultProps} variant="header" hasConfig={true} />,
+    );
+    expect(
+      container.querySelector('.search-wrapper--header'),
+    ).toBeInTheDocument();
+    expect(container.querySelector('.search-help-button')).toBeInTheDocument();
+    expect(
+      container.querySelector('.search-filter-button'),
+    ).not.toBeInTheDocument();
   });
 
-  describe('image variant', () => {
-    it('应该渲染 image 变体', () => {
-      const { container } = render(
-        <Search {...defaultProps} variant="image" />,
-      );
-      const wrapper = container.querySelector('.search-wrapper--image');
-      expect(wrapper).toBeInTheDocument();
-    });
-
-    it('应该显示搜索框', () => {
-      const { container } = render(
-        <Search {...defaultProps} variant="image" />,
-      );
-      const searchBar = container.querySelector('.search-bar');
-      expect(searchBar).toBeInTheDocument();
-    });
-
-    it('应该在提供标签时显示标签容器', () => {
-      const allTags = ['tag1', 'tag2', 'tag3'];
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          variant="image"
-          allTags={allTags}
-          onTagsChange={vi.fn()}
-        />,
-      );
-      const tagsContainer = container.querySelector('.search-tags-container');
-      expect(tagsContainer).toBeInTheDocument();
-    });
-
-    it('应该显示所有标签', () => {
-      const allTags = ['tag1', 'tag2', 'tag3'];
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          variant="image"
-          allTags={allTags}
-          onTagsChange={vi.fn()}
-        />,
-      );
-      expect(screen.getByText('tag1')).toBeInTheDocument();
-      expect(screen.getByText('tag2')).toBeInTheDocument();
-      expect(screen.getByText('tag3')).toBeInTheDocument();
-    });
-
-    it('应该可以切换标签选择', () => {
-      const onTagsChange = vi.fn();
-      const allTags = ['tag1', 'tag2'];
-      render(
-        <Search
-          {...defaultProps}
-          variant="image"
-          allTags={allTags}
-          onTagsChange={onTagsChange}
-        />,
-      );
-
-      const tag1Button = screen.getByText('tag1');
-      fireEvent.click(tag1Button);
-
-      expect(onTagsChange).toHaveBeenCalledWith(['tag1']);
-    });
-
-    it('应该可以取消选择标签', () => {
-      const onTagsChange = vi.fn();
-      const allTags = ['tag1', 'tag2'];
-      render(
-        <Search
-          {...defaultProps}
-          variant="image"
-          allTags={allTags}
-          selectedTags={['tag1']}
-          onTagsChange={onTagsChange}
-        />,
-      );
-
-      const tag1Button = screen.getByText('tag1');
-      fireEvent.click(tag1Button);
-
-      expect(onTagsChange).toHaveBeenCalledWith([]);
-    });
-
-    it('应该高亮显示选中的标签', () => {
-      const allTags = ['tag1', 'tag2'];
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          variant="image"
-          allTags={allTags}
-          selectedTags={['tag1']}
-          onTagsChange={vi.fn()}
-        />,
-      );
-      const tag1Button = container.querySelector('.search-tag-button.selected');
-      expect(tag1Button).toBeInTheDocument();
-      expect(tag1Button).toHaveTextContent('tag1');
-    });
-
-    it('应该在选中标签时显示清除按钮', () => {
-      const onTagsChange = vi.fn();
-      const allTags = ['tag1', 'tag2'];
-      render(
-        <Search
-          {...defaultProps}
-          variant="image"
-          allTags={allTags}
-          selectedTags={['tag1', 'tag2']}
-          onTagsChange={onTagsChange}
-        />,
-      );
-
-      const clearButton = screen.getByText(/清除筛选.*2/);
-      expect(clearButton).toBeInTheDocument();
-    });
-
-    it('应该点击清除按钮时清除所有标签', () => {
-      const onTagsChange = vi.fn();
-      const allTags = ['tag1', 'tag2'];
-      render(
-        <Search
-          {...defaultProps}
-          variant="image"
-          allTags={allTags}
-          selectedTags={['tag1', 'tag2']}
-          onTagsChange={onTagsChange}
-        />,
-      );
-
-      const clearButton = screen.getByText(/清除筛选.*2/);
-      fireEvent.click(clearButton);
-
-      expect(onTagsChange).toHaveBeenCalledWith([]);
-    });
-
-    it('应该在没有提供 allTags 时使用从图片中提取的标签', () => {
-      const { container } = render(
-        <Search {...defaultProps} variant="image" onTagsChange={vi.fn()} />,
-      );
-      const tagsContainer = container.querySelector('.search-tags-container');
-      expect(tagsContainer).toBeInTheDocument();
-    });
+  it('opens help panel on help click', () => {
+    const { container } = render(
+      <Search {...defaultProps} variant="header" hasConfig={true} />,
+    );
+    fireEvent.click(container.querySelector('.search-help-button')!);
+    expect(screen.getByText('查询语法帮助')).toBeInTheDocument();
+    expect(screen.getByText('kind:pdf')).toBeInTheDocument();
   });
 
-  describe('搜索功能', () => {
-    it('应该调用 onSearchChange 当搜索词改变时', () => {
-      const onSearchChange = vi.fn();
-      const { container } = render(
-        <Search {...defaultProps} onSearchChange={onSearchChange} />,
-      );
-      const input = container.querySelector('input') as HTMLInputElement;
-
-      fireEvent.change(input, { target: { value: 'test' } });
-
-      expect(onSearchChange).toHaveBeenCalledWith('test');
-    });
-
-    it('应该显示当前的搜索词', () => {
-      const { container } = render(
-        <Search {...defaultProps} searchQuery="test query" />,
-      );
-      const input = container.querySelector('input') as HTMLInputElement;
-      expect(input.value).toBe('test query');
-    });
+  it('updates draft while typing without requiring commit props', () => {
+    const onDraftChange = vi.fn();
+    const onSearchChange = vi.fn();
+    const { container } = render(
+      <Search
+        {...defaultProps}
+        variant="header"
+        draftQuery=""
+        onDraftChange={onDraftChange}
+        onSearchChange={onSearchChange}
+        onCommitSearch={vi.fn()}
+      />,
+    );
+    const input = container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'kind:pdf' } });
+    expect(onDraftChange).toHaveBeenCalledWith('kind:pdf');
+    expect(onSearchChange).not.toHaveBeenCalled();
   });
 
-  describe('占位符', () => {
-    it('应该使用 header variant 的默认占位符', () => {
-      const { container } = render(
-        <Search {...defaultProps} variant="header" hasConfig={true} />,
-      );
-      const input = container.querySelector('input') as HTMLInputElement;
-      expect(input.placeholder).toBe('搜索图片...');
-    });
-
-    it('应该在 hasConfig 为 false 时使用禁用占位符', () => {
-      const { container } = render(
-        <Search {...defaultProps} variant="header" hasConfig={false} />,
-      );
-      const input = container.querySelector('input') as HTMLInputElement;
-      expect(input.placeholder).toBe('添加仓库源后即可搜索图片');
-    });
-
-    it('应该使用 image variant 的默认占位符', () => {
-      const { container } = render(
-        <Search {...defaultProps} variant="image" />,
-      );
-      const input = container.querySelector('input') as HTMLInputElement;
-      expect(input.placeholder).toBe('搜索图片名称、描述或标签...');
-    });
-
-    it('应该使用 basic variant 的默认占位符', () => {
-      const { container } = render(
-        <Search {...defaultProps} variant="basic" />,
-      );
-      const input = container.querySelector('input') as HTMLInputElement;
-      expect(input.placeholder).toBe('搜索...');
-    });
-
-    it('应该优先使用自定义占位符', () => {
-      const { container } = render(
-        <Search {...defaultProps} variant="header" placeholder="自定义" />,
-      );
-      const input = container.querySelector('input') as HTMLInputElement;
-      expect(input.placeholder).toBe('自定义');
-    });
-  });
-
-  describe('边界情况', () => {
-    it('应该处理空图片列表', () => {
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          images={[]}
-          variant="header"
-          showFilter={true}
-        />,
-      );
-      const filterButton = container.querySelector(
-        '.search-filter-button',
-      ) as HTMLButtonElement;
-      fireEvent.click(filterButton);
-
-      // 不应该显示任何类型或标签
-      expect(screen.queryByText('image/jpeg')).not.toBeInTheDocument();
-    });
-
-    it('应该处理没有标签的图片', () => {
-      const imagesWithoutTags: ImageItem[] = [
-        {
-          ...mockImages[0],
-          tags: [],
-        },
-      ];
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          images={imagesWithoutTags}
-          variant="header"
-          showFilter={true}
-        />,
-      );
-      const filterButton = container.querySelector(
-        '.search-filter-button',
-      ) as HTMLButtonElement;
-      fireEvent.click(filterButton);
-
-      // 不应该显示标签部分
-      expect(screen.queryByText('标签')).not.toBeInTheDocument();
-    });
-
-    it('应该处理没有 onFiltersChange 的情况', () => {
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          variant="header"
-          showFilter={true}
-          onFiltersChange={undefined}
-        />,
-      );
-      // 当没有 onFiltersChange 时，筛选按钮不应该显示
-      const filterButton = container.querySelector('.search-filter-button');
-      expect(filterButton).not.toBeInTheDocument();
-    });
-
-    it('应该处理没有 onTagsChange 的情况', () => {
-      const { container } = render(
-        <Search
-          {...defaultProps}
-          variant="image"
-          allTags={['tag1']}
-          onTagsChange={undefined}
-        />,
-      );
-      // 不应该显示标签容器
-      const tagsContainer = container.querySelector('.search-tags-container');
-      expect(tagsContainer).not.toBeInTheDocument();
-    });
+  it('commits query on Enter', () => {
+    const onCommitSearch = vi.fn();
+    const { container } = render(
+      <Search
+        {...defaultProps}
+        variant="header"
+        draftQuery="kind:pdf"
+        onDraftChange={vi.fn()}
+        onCommitSearch={onCommitSearch}
+      />,
+    );
+    const input = container.querySelector('input') as HTMLInputElement;
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onCommitSearch).toHaveBeenCalledWith('kind:pdf');
   });
 });

--- a/app/src/ui/primitives/search/web/Search.tsx
+++ b/app/src/ui/primitives/search/web/Search.tsx
@@ -1,17 +1,8 @@
-import { Filter, Search as SearchIcon } from 'lucide-react';
-import React, {
-  useCallback,
-  useMemo,
-  useState,
-  useRef,
-  useEffect,
-} from 'react';
+import { CircleHelp, Search as SearchIcon } from 'lucide-react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { defaultTranslate } from '@/ui/locales';
 import type { ImageItem } from '@pixuli/core/types';
-import type {
-  AssetKind,
-  FilterOptions,
-} from '../../../image/image-browser/common/types';
+import type { FilterOptions } from '../../../image/image-browser/common/types';
 import SearchBar from './SearchBar';
 import './SearchBar.css';
 import './Search.css';
@@ -24,59 +15,48 @@ export interface SearchHistoryItem {
 }
 
 export interface SearchProps {
-  /** 搜索关键词 */
   searchQuery: string;
-  /** 搜索关键词变化回调 */
   onSearchChange: (query: string) => void;
-  /** 组件变体：header（Header中使用）、image（图片搜索）、basic（仅搜索框） */
+  /** 输入草稿；未传则与 searchQuery 同步（兼容旧用法） */
+  draftQuery?: string;
+  onDraftChange?: (query: string) => void;
+  /** 回车确认查询 */
+  onCommitSearch?: (query?: string) => void;
   variant?: SearchVariant;
-  /** 是否有配置（用于控制搜索框是否禁用） */
   hasConfig?: boolean;
-  /** 图片列表（用于筛选功能） */
+  /** @deprecated 查询语法已取代面板筛选；保留以免破坏调用方类型 */
   images?: ImageItem[];
-  /** 外部筛选条件（用于与Header筛选同步） */
+  /** @deprecated */
   externalFilters?: FilterOptions;
-  /** 筛选条件变化回调 */
+  /** @deprecated */
   onFiltersChange?: (
     filters: FilterOptions | ((prev: FilterOptions) => FilterOptions),
   ) => void;
-  /** 是否显示筛选功能 */
+  /** @deprecated 已忽略 */
   showFilter?: boolean;
-  /** 标签相关（仅 image variant 使用） */
   selectedTags?: string[];
   onTagsChange?: (tags: string[]) => void;
   allTags?: string[];
-  /** 占位符文本 */
   placeholder?: string;
-  /** 是否禁用 */
   disabled?: boolean;
-  /** 翻译函数 */
   t?: (key: string) => string;
-  /** 自定义 CSS 类名 */
   className?: string;
-  /** 是否显示历史记录 */
   showHistory?: boolean;
-  /** 历史记录数据 */
   history?: SearchHistoryItem[];
-  /** 选择历史记录回调 */
   onSelectHistory?: (query: string) => void;
-  /** 删除历史记录回调 */
   onDeleteHistory?: (query: string) => void;
-  /** 清空历史记录回调 */
   onClearHistory?: () => void;
-  /** 保存历史记录回调（按下 Enter 时调用） */
   onSaveHistory?: (query: string) => void;
 }
 
 const Search: React.FC<SearchProps> = ({
   searchQuery,
   onSearchChange,
+  draftQuery,
+  onDraftChange,
+  onCommitSearch,
   variant = 'basic',
   hasConfig = true,
-  images = [],
-  externalFilters,
-  onFiltersChange,
-  showFilter = false,
   selectedTags = [],
   onTagsChange,
   allTags = [],
@@ -92,166 +72,81 @@ const Search: React.FC<SearchProps> = ({
   onSaveHistory,
 }) => {
   const translate = t || defaultTranslate;
-  const [showFilterPanel, setShowFilterPanel] = useState(false);
+  const inputValue = draftQuery ?? searchQuery;
+  const handleInputChange = (value: string) => {
+    if (onDraftChange) {
+      onDraftChange(value);
+      // 清空输入时立即取消已确认查询
+      if (value === '') onSearchChange('');
+      return;
+    }
+    onSearchChange(value);
+  };
+  const handleCommit = (query?: string) => {
+    const q = (query ?? inputValue).trim();
+    if (onCommitSearch) {
+      onCommitSearch(q);
+      return;
+    }
+    onSaveHistory?.(q);
+    onSearchChange(q);
+  };
   const [searchExpanded, setSearchExpanded] = useState(
-    () => searchQuery.trim().length > 0,
+    () => inputValue.trim().length > 0,
   );
-  const filterPanelRef = useRef<HTMLDivElement>(null);
+  const [showHelp, setShowHelp] = useState(false);
+  const [helpStyle, setHelpStyle] = useState<React.CSSProperties | undefined>();
+  const helpRef = useRef<HTMLDivElement>(null);
+  const helpButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    if (searchQuery.trim()) setSearchExpanded(true);
-  }, [searchQuery]);
+    if (inputValue.trim()) setSearchExpanded(true);
+  }, [inputValue]);
 
-  // 获取所有可用的图片类型
-  const availableTypes = useMemo(() => {
-    const types = new Set<string>();
-    images.forEach(image => {
-      if (image.type) {
-        types.add(image.type);
+  useLayoutEffect(() => {
+    if (!showHelp) {
+      setHelpStyle(undefined);
+      return;
+    }
+    const update = () => {
+      const button = helpButtonRef.current;
+      if (!button) return;
+      const narrow =
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia('(max-width: 767px)').matches;
+      if (narrow) {
+        setHelpStyle(undefined);
+        return;
       }
-    });
-    return Array.from(types).sort();
-  }, [images]);
-
-  // 获取所有可用的标签
-  const availableTags = useMemo(() => {
-    const tags = new Set<string>();
-    images.forEach(image => {
-      if (image.tags && image.tags.length > 0) {
-        image.tags.forEach(tag => tags.add(tag));
-      }
-    });
-    return Array.from(tags).sort();
-  }, [images]);
-
-  // 处理资源类型筛选
-  const handleKindChange = useCallback(
-    (kind: AssetKind, isSelected: boolean) => {
-      if (!onFiltersChange) return;
-      onFiltersChange((prev: FilterOptions) => {
-        const current = prev.selectedKinds ?? [];
-        const selectedKinds = isSelected
-          ? [...current, kind]
-          : current.filter(item => item !== kind);
-        return {
-          ...prev,
-          selectedKinds,
-        };
+      const rect = button.getBoundingClientRect();
+      setHelpStyle({
+        position: 'fixed',
+        top: rect.bottom + 8,
+        right: Math.max(8, window.innerWidth - rect.right),
+        left: 'auto',
+        zIndex: 1100,
       });
-    },
-    [onFiltersChange],
-  );
-
-  // 处理类型筛选变化
-  const handleTypeChange = useCallback(
-    (type: string, isSelected: boolean) => {
-      if (!onFiltersChange || !externalFilters) return;
-      onFiltersChange((prev: FilterOptions) => {
-        const newSelectedTypes = isSelected
-          ? [...prev.selectedTypes, type]
-          : prev.selectedTypes.filter((t: string) => t !== type);
-        return {
-          ...prev,
-          selectedTypes: newSelectedTypes,
-        };
-      });
-    },
-    [onFiltersChange, externalFilters],
-  );
-
-  // 处理标签筛选变化
-  const handleTagChange = useCallback(
-    (tag: string, isSelected: boolean) => {
-      if (!onFiltersChange || !externalFilters) return;
-      onFiltersChange((prev: FilterOptions) => {
-        const newSelectedTags = isSelected
-          ? [...prev.selectedTags, tag]
-          : prev.selectedTags.filter((t: string) => t !== tag);
-        return {
-          ...prev,
-          selectedTags: newSelectedTags,
-        };
-      });
-    },
-    [onFiltersChange, externalFilters],
-  );
-
-  // 清除所有筛选条件（保留搜索词）
-  const handleClearAll = useCallback(() => {
-    if (!onFiltersChange || !externalFilters) return;
-    onFiltersChange({
-      ...externalFilters,
-      selectedTypes: [],
-      selectedTags: [],
-      selectedKinds: [],
-    });
-  }, [onFiltersChange, externalFilters]);
-
-  // 处理标签切换（image variant 使用）
-  const handleTagToggle = useCallback(
-    (tag: string) => {
-      if (!onTagsChange) return;
-      onTagsChange(
-        selectedTags.includes(tag)
-          ? selectedTags.filter(t => t !== tag)
-          : [...selectedTags, tag],
-      );
-    },
-    [selectedTags, onTagsChange],
-  );
-
-  const handleClearTags = useCallback(() => {
-    if (!onTagsChange) return;
-    onTagsChange([]);
-  }, [onTagsChange]);
-
-  // 点击外部关闭筛选面板
-  useEffect(() => {
-    if (!showFilterPanel) return;
-
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        filterPanelRef.current &&
-        !filterPanelRef.current.contains(event.target as Node)
-      ) {
-        setShowFilterPanel(false);
-      }
     };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [showFilterPanel]);
-
-  // Capacitor 硬件返回键关闭筛选（REF-512 #150）
-  useEffect(() => {
-    const onCloseFilter = () => setShowFilterPanel(false);
-    window.addEventListener('pixuli:closeFilterPanel', onCloseFilter);
-    return () =>
-      window.removeEventListener('pixuli:closeFilterPanel', onCloseFilter);
-  }, []);
-
-  // 窄屏筛选 sheet：锁定背景滚动（REF-512 #150）
-  useEffect(() => {
-    if (!showFilterPanel) return;
-    if (typeof window.matchMedia !== 'function') return;
-    const mq = window.matchMedia('(max-width: 767px)');
-    if (!mq.matches) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update, true);
     return () => {
-      document.body.style.overflow = prev;
+      window.removeEventListener('resize', update);
+      window.removeEventListener('scroll', update, true);
     };
-  }, [showFilterPanel]);
+  }, [showHelp]);
 
-  // 检查是否有活动的筛选条件
-  const selectedKinds = externalFilters?.selectedKinds ?? [];
-  const hasActiveFilters =
-    externalFilters &&
-    (externalFilters.selectedTypes.length > 0 ||
-      externalFilters.selectedTags.length > 0 ||
-      selectedKinds.length > 0);
+  useEffect(() => {
+    if (!showHelp) return;
+    const onPointerDown = (event: MouseEvent) => {
+      if (helpRef.current && !helpRef.current.contains(event.target as Node)) {
+        setShowHelp(false);
+      }
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    return () => document.removeEventListener('mousedown', onPointerDown);
+  }, [showHelp]);
 
-  // 获取占位符文本
   const getPlaceholder = () => {
     if (placeholder) return placeholder;
     if (variant === 'header') {
@@ -265,12 +160,46 @@ const Search: React.FC<SearchProps> = ({
     return translate('search.placeholder') || 'Search...';
   };
 
-  // 基础搜索框（basic variant）
+  const helpPanel = showHelp ? (
+    <div
+      className="search-help-panel"
+      style={helpStyle}
+      role="dialog"
+      aria-label={translate('search.help.title')}
+    >
+      {' '}
+      <div className="search-help-title">{translate('search.help.title')}</div>
+      <p className="search-help-intro">{translate('search.help.intro')}</p>
+      <ul className="search-help-list">
+        <li>
+          <code>{translate('search.help.exBare')}</code>
+          <span>{translate('search.help.descBare')}</span>
+        </li>
+        <li>
+          <code>{translate('search.help.exName')}</code>
+          <span>{translate('search.help.descName')}</span>
+        </li>
+        <li>
+          <code>{translate('search.help.exKind')}</code>
+          <span>{translate('search.help.descKind')}</span>
+        </li>
+        <li>
+          <code>{translate('search.help.exSize')}</code>
+          <span>{translate('search.help.descSize')}</span>
+        </li>
+        <li>
+          <code>{translate('search.help.exCombo')}</code>
+          <span>{translate('search.help.descCombo')}</span>
+        </li>
+      </ul>
+    </div>
+  ) : null;
+
   if (variant === 'basic') {
     return (
       <SearchBar
-        value={searchQuery}
-        onChange={onSearchChange}
+        value={inputValue}
+        onChange={handleInputChange}
         placeholder={getPlaceholder()}
         disabled={disabled || !hasConfig}
         showHistory={showHistory}
@@ -278,12 +207,11 @@ const Search: React.FC<SearchProps> = ({
         onSelectHistory={onSelectHistory}
         onDeleteHistory={onDeleteHistory}
         onClearHistory={onClearHistory}
-        onSaveHistory={onSaveHistory}
+        onSaveHistory={handleCommit}
       />
     );
   }
 
-  // Header variant：搜索框 + 筛选面板
   if (variant === 'header') {
     return (
       <div
@@ -308,8 +236,8 @@ const Search: React.FC<SearchProps> = ({
           <SearchIcon size={18} aria-hidden />
         </button>
         <SearchBar
-          value={searchQuery}
-          onChange={onSearchChange}
+          value={inputValue}
+          onChange={handleInputChange}
           placeholder={getPlaceholder()}
           disabled={!hasConfig}
           showHistory={showHistory}
@@ -317,193 +245,84 @@ const Search: React.FC<SearchProps> = ({
           onSelectHistory={onSelectHistory}
           onDeleteHistory={onDeleteHistory}
           onClearHistory={onClearHistory}
-          onSaveHistory={onSaveHistory}
+          onSaveHistory={handleCommit}
         />
-        {showFilter && hasConfig && onFiltersChange && (
-          <div className="search-filter-wrapper" ref={filterPanelRef}>
+        {hasConfig ? (
+          <div className="search-help-wrapper" ref={helpRef}>
             <button
               type="button"
-              onClick={() =>
-                setShowFilterPanel(open => {
-                  const next = !open;
-                  if (next) {
-                    window.dispatchEvent(
-                      new CustomEvent('pixuli:openFilterPanel'),
-                    );
-                  }
-                  return next;
-                })
-              }
-              className={`search-filter-button ${hasActiveFilters ? 'active' : ''}`}
-              title={translate('search.header.filter') || '筛选'}
+              ref={helpButtonRef}
+              className={`search-help-button${showHelp ? ' is-open' : ''}`}
+              title={translate('search.help.title')}
+              aria-label={translate('search.help.title')}
+              aria-expanded={showHelp}
+              onClick={() => setShowHelp(open => !open)}
             >
-              <Filter size={18} />
-              {hasActiveFilters && <span className="search-filter-badge" />}
+              <CircleHelp size={18} aria-hidden />
             </button>
-            {showFilterPanel && (
-              <>
-                <button
-                  type="button"
-                  className="search-filter-backdrop"
-                  aria-label={translate('common.cancel') || '关闭'}
-                  onClick={() => setShowFilterPanel(false)}
-                />
-                <div className="search-filter-panel">
-                  <div className="search-filter-panel-header">
-                    <span className="search-filter-panel-title">
-                      {translate('search.header.filter') || '筛选'}
-                    </span>
-                    {hasActiveFilters && (
-                      <button
-                        onClick={handleClearAll}
-                        className="search-filter-clear"
-                      >
-                        {translate('search.header.clearFilters') || '清除'}
-                      </button>
-                    )}
-                  </div>
-                  <div className="search-filter-section">
-                    <label className="search-filter-label">
-                      {translate('image.kind.label')}
-                    </label>
-                    <div className="search-filter-options">
-                      {(
-                        [
-                          ['image', 'image.kind.image'],
-                          ['video', 'image.kind.video'],
-                          ['pdf', 'image.kind.pdf'],
-                          ['other', 'image.kind.other'],
-                        ] as const
-                      ).map(([kind, labelKey]) => (
-                        <label key={kind} className="search-filter-option">
-                          <input
-                            type="checkbox"
-                            checked={selectedKinds.includes(kind)}
-                            onChange={e =>
-                              handleKindChange(kind, e.target.checked)
-                            }
-                          />
-                          <span>{translate(labelKey)}</span>
-                        </label>
-                      ))}
-                    </div>
-                  </div>
-                  {availableTypes.length > 0 && (
-                    <div className="search-filter-section">
-                      <label className="search-filter-label">
-                        {translate('image.filter.imageType') || '图片类型'}
-                      </label>
-                      <div className="search-filter-options">
-                        {availableTypes.map(type => (
-                          <label key={type} className="search-filter-option">
-                            <input
-                              type="checkbox"
-                              checked={
-                                externalFilters?.selectedTypes.includes(type) ||
-                                false
-                              }
-                              onChange={e =>
-                                handleTypeChange(type, e.target.checked)
-                              }
-                            />
-                            <span>{type}</span>
-                          </label>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                  {availableTags.length > 0 && (
-                    <div className="search-filter-section">
-                      <label className="search-filter-label">
-                        {translate('image.filter.tags') || '标签'}
-                      </label>
-                      <div className="search-filter-options">
-                        {availableTags.map(tag => (
-                          <label key={tag} className="search-filter-option">
-                            <input
-                              type="checkbox"
-                              checked={
-                                externalFilters?.selectedTags.includes(tag) ||
-                                false
-                              }
-                              onChange={e =>
-                                handleTagChange(tag, e.target.checked)
-                              }
-                            />
-                            <span>{tag}</span>
-                          </label>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </>
-            )}
+            {helpPanel}
           </div>
-        )}
+        ) : null}
       </div>
     );
   }
 
-  // Image variant：搜索框 + 标签筛选（内联显示）
-  if (variant === 'image') {
-    const displayTags = allTags.length > 0 ? allTags : availableTags;
-    return (
-      <div className={`search-wrapper search-wrapper--image ${className}`}>
-        {/* 搜索框 */}
-        <div className="search-input-container">
-          <SearchBar
-            value={searchQuery}
-            onChange={onSearchChange}
-            placeholder={getPlaceholder()}
-            disabled={disabled}
-            showHistory={showHistory}
-            history={history}
-            onSelectHistory={onSelectHistory}
-            onDeleteHistory={onDeleteHistory}
-            onClearHistory={onClearHistory}
-            onSaveHistory={onSaveHistory}
-          />
-        </div>
-
-        {/* 标签过滤 */}
-        {displayTags.length > 0 && onTagsChange && (
-          <div className="search-tags-container">
-            <div className="search-tags-label">
-              <Filter className="search-tags-icon" />
-              <span className="search-tags-text">
-                {translate('search.image.filterByTags')}:
-              </span>
-            </div>
-            <div className="search-tags">
-              {selectedTags.length > 0 && (
+  // image variant：保留简易标签筛选（工具页等）
+  return (
+    <div className={`search-wrapper search-wrapper--image ${className}`.trim()}>
+      <SearchBar
+        value={inputValue}
+        onChange={handleInputChange}
+        placeholder={getPlaceholder()}
+        disabled={disabled}
+        showHistory={showHistory}
+        history={history}
+        onSelectHistory={onSelectHistory}
+        onDeleteHistory={onDeleteHistory}
+        onClearHistory={onClearHistory}
+        onSaveHistory={handleCommit}
+      />
+      {onTagsChange && allTags.length > 0 ? (
+        <div className="search-tags">
+          <div className="search-tags-header">
+            <span className="search-tags-label">
+              {translate('search.image.filterByTags') || '按标签筛选'}
+            </span>
+            {selectedTags.length > 0 ? (
+              <button
+                type="button"
+                className="search-tags-clear"
+                onClick={() => onTagsChange([])}
+              >
+                {translate('search.image.clearFilters') || '清除筛选'}
+              </button>
+            ) : null}
+          </div>
+          <div className="search-tags-list">
+            {allTags.map(tag => {
+              const selected = selectedTags.includes(tag);
+              return (
                 <button
-                  onClick={handleClearTags}
-                  className="search-tags-clear-button"
-                >
-                  {translate('search.image.clearFilters')} (
-                  {selectedTags.length})
-                </button>
-              )}
-              {displayTags.map((tag, index) => (
-                <button
-                  key={`search-tag-${index}`}
-                  onClick={() => handleTagToggle(tag)}
-                  className={`search-tag-button ${
-                    selectedTags.includes(tag) ? 'selected' : 'unselected'
-                  }`}
+                  key={tag}
+                  type="button"
+                  className={`search-tag-button ${selected ? 'selected' : 'unselected'}`}
+                  onClick={() =>
+                    onTagsChange(
+                      selected
+                        ? selectedTags.filter(item => item !== tag)
+                        : [...selectedTags, tag],
+                    )
+                  }
                 >
                   {tag}
                 </button>
-              ))}
-            </div>
+              );
+            })}
           </div>
-        )}
-      </div>
-    );
-  }
-
-  return null;
+        </div>
+      ) : null}
+    </div>
+  );
 };
 
 export default Search;

--- a/app/src/ui/primitives/search/web/SearchBar.tsx
+++ b/app/src/ui/primitives/search/web/SearchBar.tsx
@@ -104,8 +104,8 @@ const SearchBar: React.FC<SearchBarProps> = ({
             setShowHistoryPanel(false);
             setSelectedHistoryIndex(-1);
           }
-        } else if (value && value.trim().length > 0) {
-          // 没有选中项，保存当前输入的历史记录
+        } else {
+          // 确认当前输入为查询
           e.preventDefault();
           if (onSaveHistory) {
             onSaveHistory(value.trim());
@@ -226,16 +226,11 @@ const SearchBar: React.FC<SearchBarProps> = ({
     [onClearHistory],
   );
 
-  // 处理 Enter 键：当历史记录面板未打开时保存历史记录
+  // 处理 Enter 键：确认查询（历史面板未打开时）
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      // 按下 Enter 键时，如果历史记录面板未打开，保存历史记录
-      if (
-        e.key === 'Enter' &&
-        !showHistoryPanel &&
-        value &&
-        value.trim().length > 0
-      ) {
+      if (e.key === 'Enter' && !showHistoryPanel) {
+        e.preventDefault();
         if (onSaveHistory) {
           onSaveHistory(value.trim());
         }

--- a/app/src/utils/__tests__/libraryQuery.test.ts
+++ b/app/src/utils/__tests__/libraryQuery.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  filterByLibraryQuery,
+  parseLibraryQuery,
+  parseSizeValue,
+  tokenizeLibraryQuery,
+} from '../libraryQuery';
+
+describe('libraryQuery', () => {
+  it('tokenizes quoted phrases and bare words', () => {
+    expect(tokenizeLibraryQuery('foo "bar baz" kind:pdf')).toEqual([
+      'foo',
+      'bar baz',
+      'kind:pdf',
+    ]);
+  });
+
+  it('parses name, kind, and size terms', () => {
+    const q = parseLibraryQuery('cover kind:image size:>1mb name:logo');
+    expect(q.nameTerms).toEqual(['cover', 'logo']);
+    expect(q.kinds).toEqual(['image']);
+    expect(q.sizeRules).toEqual([{ op: 'gt', bytes: 1024 * 1024 }]);
+  });
+
+  it('parses size units', () => {
+    expect(parseSizeValue('500kb')).toBe(500 * 1024);
+    expect(parseSizeValue('1.5mb')).toBe(Math.round(1.5 * 1024 * 1024));
+    expect(parseSizeValue('10')).toBe(10);
+  });
+
+  it('filters items by combined query', () => {
+    const items = [
+      { name: 'a.jpg', type: 'image/jpeg', size: 2 * 1024 * 1024 },
+      { name: 'notes.pdf', type: 'application/pdf', size: 100 * 1024 },
+      { name: 'clip.mp4', type: 'video/mp4', size: 8 * 1024 * 1024 },
+    ];
+
+    expect(filterByLibraryQuery(items, 'kind:pdf').map(i => i.name)).toEqual([
+      'notes.pdf',
+    ]);
+
+    expect(
+      filterByLibraryQuery(items, 'kind:image size:>1mb').map(i => i.name),
+    ).toEqual(['a.jpg']);
+
+    expect(filterByLibraryQuery(items, 'clip').map(i => i.name)).toEqual([
+      'clip.mp4',
+    ]);
+  });
+
+  it('treats multiple kinds as OR', () => {
+    const items = [
+      { name: 'a.jpg', type: 'image/jpeg', size: 10 },
+      { name: 'b.pdf', type: 'application/pdf', size: 10 },
+      { name: 'c.mp4', type: 'video/mp4', size: 10 },
+    ];
+    expect(
+      filterByLibraryQuery(items, 'kind:image kind:pdf').map(i => i.name),
+    ).toEqual(['a.jpg', 'b.pdf']);
+  });
+});

--- a/app/src/utils/libraryQuery.ts
+++ b/app/src/utils/libraryQuery.ts
@@ -1,0 +1,190 @@
+import type { AssetKind, ImageItem } from '@pixuli/core/types';
+import { getAssetKind } from '@/utils/assetKind';
+
+export type SizeCompare = 'eq' | 'gt' | 'gte' | 'lt' | 'lte';
+
+export interface LibraryQuery {
+  /** 裸词与 name: 合并后的文件名子串（全部需匹配，AND） */
+  nameTerms: string[];
+  /** kind: 条件；多项为 OR（任一匹配即可） */
+  kinds: AssetKind[];
+  /** size: 条件；多项为 AND */
+  sizeRules: Array<{ op: SizeCompare; bytes: number }>;
+}
+
+const KIND_VALUES = new Set<AssetKind>(['image', 'video', 'pdf', 'other']);
+
+const UNIT_BYTES: Record<string, number> = {
+  b: 1,
+  kb: 1024,
+  k: 1024,
+  mb: 1024 * 1024,
+  m: 1024 * 1024,
+  gb: 1024 * 1024 * 1024,
+  g: 1024 * 1024 * 1024,
+};
+
+/** 按空白分词，保留引号内短语 */
+export function tokenizeLibraryQuery(input: string): string[] {
+  const tokens: string[] = [];
+  const re = /"([^"]*)"|'([^']*)'|(\S+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(input)) !== null) {
+    const token = match[1] ?? match[2] ?? match[3] ?? '';
+    if (token.length > 0) tokens.push(token);
+  }
+  return tokens;
+}
+
+export function parseSizeValue(raw: string): number | null {
+  const m = raw
+    .trim()
+    .toLowerCase()
+    .match(/^(\d+(?:\.\d+)?)\s*(b|kb|k|mb|m|gb|g)?$/);
+  if (!m) return null;
+  const n = Number(m[1]);
+  if (!Number.isFinite(n) || n < 0) return null;
+  const unit = m[2] || 'b';
+  return Math.round(n * (UNIT_BYTES[unit] ?? 1));
+}
+
+function parseSizeToken(
+  value: string,
+): { op: SizeCompare; bytes: number } | null {
+  const trimmed = value.trim();
+  const m = trimmed.match(/^(>=|<=|>|<|=)?\s*(.+)$/);
+  if (!m) return null;
+  const opToken = m[1] || '=';
+  const bytes = parseSizeValue(m[2]);
+  if (bytes === null) return null;
+  const op: SizeCompare =
+    opToken === '>'
+      ? 'gt'
+      : opToken === '>='
+        ? 'gte'
+        : opToken === '<'
+          ? 'lt'
+          : opToken === '<='
+            ? 'lte'
+            : 'eq';
+  return { op, bytes };
+}
+
+function parseKindValue(value: string): AssetKind | null {
+  const v = value.trim().toLowerCase();
+  if (KIND_VALUES.has(v as AssetKind)) return v as AssetKind;
+  // 中文别名
+  if (v === '图片' || v === '图像') return 'image';
+  if (v === '视频') return 'video';
+  if (v === 'pdf') return 'pdf';
+  if (v === '其它' || v === '其他') return 'other';
+  return null;
+}
+
+/**
+ * 解析资源库查询语法（Anki 风格子集）。
+ * - 裸词 / name:xxx → 文件名包含
+ * - kind:image|video|pdf|other → 类型
+ * - size:>1mb / size:<=500kb → 大小
+ * 多个条件默认 AND；多个 kind 为 OR。
+ */
+export function parseLibraryQuery(input: string): LibraryQuery {
+  const query: LibraryQuery = {
+    nameTerms: [],
+    kinds: [],
+    sizeRules: [],
+  };
+
+  for (const token of tokenizeLibraryQuery(input)) {
+    const colon = token.indexOf(':');
+    if (colon <= 0) {
+      query.nameTerms.push(token);
+      continue;
+    }
+
+    const key = token.slice(0, colon).toLowerCase();
+    const value = token.slice(colon + 1);
+    if (!value) continue;
+
+    if (key === 'name' || key === 'filename') {
+      query.nameTerms.push(value);
+      continue;
+    }
+
+    if (key === 'kind' || key === 'type') {
+      const kind = parseKindValue(value);
+      if (kind && !query.kinds.includes(kind)) {
+        query.kinds.push(kind);
+      }
+      continue;
+    }
+
+    if (key === 'size') {
+      const rule = parseSizeToken(value);
+      if (rule) query.sizeRules.push(rule);
+      continue;
+    }
+
+    // 未知 key:value 当作文件名子串，避免静默丢弃用户输入
+    query.nameTerms.push(token);
+  }
+
+  return query;
+}
+
+function matchSize(
+  size: number,
+  rule: { op: SizeCompare; bytes: number },
+): boolean {
+  switch (rule.op) {
+    case 'gt':
+      return size > rule.bytes;
+    case 'gte':
+      return size >= rule.bytes;
+    case 'lt':
+      return size < rule.bytes;
+    case 'lte':
+      return size <= rule.bytes;
+    case 'eq':
+    default:
+      return size === rule.bytes;
+  }
+}
+
+export function matchesLibraryQuery(
+  item: Pick<ImageItem, 'name' | 'type' | 'size'>,
+  query: LibraryQuery,
+): boolean {
+  for (const term of query.nameTerms) {
+    if (!item.name.toLowerCase().includes(term.toLowerCase())) {
+      return false;
+    }
+  }
+
+  if (query.kinds.length > 0) {
+    const kind = getAssetKind(item);
+    if (!query.kinds.includes(kind)) return false;
+  }
+
+  for (const rule of query.sizeRules) {
+    if (!matchSize(item.size ?? 0, rule)) return false;
+  }
+
+  return true;
+}
+
+export function filterByLibraryQuery<
+  T extends Pick<ImageItem, 'name' | 'type' | 'size'>,
+>(items: T[], input: string): T[] {
+  const trimmed = input.trim();
+  if (!trimmed) return items;
+  const query = parseLibraryQuery(trimmed);
+  if (
+    query.nameTerms.length === 0 &&
+    query.kinds.length === 0 &&
+    query.sizeRules.length === 0
+  ) {
+    return items;
+  }
+  return items.filter(item => matchesLibraryQuery(item, query));
+}


### PR DESCRIPTION
## Summary
- 用 Anki 风格基础查询语法替换筛选面板：`name:` / `kind:` / `size:`，裸词匹配文件名
- 输入为草稿，**Enter 后**才生效并写入历史；搜索旁提供 `?` 语法帮助
- 去掉筛选摘要 chip /「清除筛选」条；清空可用输入框 ×

## Test plan
- [ ] 输入 `kind:pdf` 不回车 → 列表不变；回车后只显示 PDF
- [ ] `size:>1mb`、`name:logo`、组合查询按预期过滤
- [ ] 点 `?` 可见中文/英文帮助示例
- [ ] 无筛选面板与下方清除筛选 UI；× 可清空并恢复全部结果
- [ ] 选历史记录立即生效


Made with [Cursor](https://cursor.com)