### PR TITLE
feat(ui): 添加不阻塞关浮层，并修复同步误删与 pull 重复

### DIFF
--- a/app/src/features/library/AssetLibrary.css
+++ b/app/src/features/library/AssetLibrary.css
@@ -137,6 +137,27 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
+  position: relative;
+}
+
+.asset-library-content.is-drag-over {
+  outline: 2px dashed #6366f1;
+  outline-offset: -6px;
+  background: rgba(99, 102, 241, 0.04);
+}
+
+.asset-library-drop-hint {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: #4338ca;
+  background: rgba(238, 242, 255, 0.72);
 }
 
 .asset-library-table-wrap {

--- a/app/src/features/library/AssetLibrary.tsx
+++ b/app/src/features/library/AssetLibrary.tsx
@@ -6,6 +6,7 @@ import {
   COMMON_SHORTCUTS,
   SHORTCUT_CATEGORIES,
 } from '@/ui';
+import type { UploadButtonHandle } from '@/ui/primitives/upload-button/web';
 import type { LibrarySearchConfig } from '@/ui';
 import type { NativeImagePickers } from '@/ui/image/image-upload/common/nativePickers';
 import { isAssetPublished } from '@/features/access/accessPolicyStore';
@@ -124,6 +125,8 @@ export const AssetLibrary: React.FC<AssetLibraryProps> = ({
   const longPressRef = useRef<number | null>(null);
   const longPressFiredRef = useRef(false);
   const tableWrapRef = useRef<HTMLDivElement>(null);
+  const uploadButtonRef = useRef<UploadButtonHandle>(null);
+  const [libraryDragOver, setLibraryDragOver] = useState(false);
   const [scrollTop, setScrollTop] = useState(0);
   const [viewportHeight, setViewportHeight] = useState(480);
 
@@ -261,6 +264,50 @@ export const AssetLibrary: React.FC<AssetLibraryProps> = ({
       setSortOrder(field === 'name' ? 'asc' : 'desc');
     },
     [sortField],
+  );
+
+  const canAcceptLibraryDrop = Boolean(onUploadImage && onUploadMultipleImages);
+
+  const handleLibraryDragEnter = useCallback(
+    (event: React.DragEvent) => {
+      if (!canAcceptLibraryDrop) return;
+      if (![...event.dataTransfer.types].includes('Files')) return;
+      event.preventDefault();
+      setLibraryDragOver(true);
+    },
+    [canAcceptLibraryDrop],
+  );
+
+  const handleLibraryDragOver = useCallback(
+    (event: React.DragEvent) => {
+      if (!canAcceptLibraryDrop) return;
+      if (![...event.dataTransfer.types].includes('Files')) return;
+      event.preventDefault();
+      event.dataTransfer.dropEffect = 'copy';
+    },
+    [canAcceptLibraryDrop],
+  );
+
+  const handleLibraryDragLeave = useCallback(
+    (event: React.DragEvent) => {
+      if (!canAcceptLibraryDrop) return;
+      const next = event.relatedTarget as Node | null;
+      if (next && event.currentTarget.contains(next)) return;
+      setLibraryDragOver(false);
+    },
+    [canAcceptLibraryDrop],
+  );
+
+  const handleLibraryDrop = useCallback(
+    (event: React.DragEvent) => {
+      if (!canAcceptLibraryDrop) return;
+      event.preventDefault();
+      setLibraryDragOver(false);
+      const files = Array.from(event.dataTransfer.files);
+      if (files.length === 0) return;
+      uploadButtonRef.current?.openWithFiles(files);
+    },
+    [canAcceptLibraryDrop],
   );
 
   const handleBatchDelete = useCallback(async () => {
@@ -435,6 +482,7 @@ export const AssetLibrary: React.FC<AssetLibraryProps> = ({
 
           {onUploadImage && onUploadMultipleImages ? (
             <UploadButton
+              ref={uploadButtonRef}
               onUploadImage={onUploadImage}
               onUploadMultipleImages={onUploadMultipleImages}
               loading={uploadLoading}
@@ -448,7 +496,18 @@ export const AssetLibrary: React.FC<AssetLibraryProps> = ({
         </div>
       </div>
 
-      <div className="asset-library-content">
+      <div
+        className={`asset-library-content${libraryDragOver ? ' is-drag-over' : ''}`}
+        onDragEnter={handleLibraryDragEnter}
+        onDragOver={handleLibraryDragOver}
+        onDragLeave={handleLibraryDragLeave}
+        onDrop={handleLibraryDrop}
+      >
+        {libraryDragOver ? (
+          <div className="asset-library-drop-hint" aria-hidden>
+            {t('image.upload.dragActive')}
+          </div>
+        ) : null}
         {loading && files.length === 0 ? (
           <div className="asset-library-loading" aria-busy="true">
             <BrandPixelMark variant="loading" size={72} />

--- a/app/src/stores/imageStore.ts
+++ b/app/src/stores/imageStore.ts
@@ -71,11 +71,15 @@ function isLocalListMode(): boolean {
 
 async function refreshLocalIntoImageStore(
   set: (partial: Partial<ImageState>) => void,
+  options?: { quiet?: boolean },
 ): Promise<void> {
   const workspace = useWorkspaceStore.getState();
-  set({ loading: true, error: null });
+  const quiet = options?.quiet === true;
+  if (!quiet) {
+    set({ loading: true, error: null });
+  }
   try {
-    await workspace.refreshLocalImages();
+    await workspace.refreshLocalImages(quiet ? { quiet: true } : undefined);
     set({
       images: useWorkspaceStore.getState().localImages,
       loading: false,
@@ -242,7 +246,7 @@ export const useImageStore = create<ImageState>((set, get) => {
     uploadImage: async (uploadData: ImageUploadData) => {
       if (isLocalListMode()) {
         await useWorkspaceStore.getState().importLocalImage(uploadData);
-        await refreshLocalIntoImageStore(set);
+        await refreshLocalIntoImageStore(set, { quiet: true });
         return;
       }
 
@@ -314,8 +318,8 @@ export const useImageStore = create<ImageState>((set, get) => {
           message: '等待导入...',
         }));
 
+        // 批量添加不锁壳层：进度走 batchUploadProgress / toast，不置 loading（§5.1）
         set({
-          loading: true,
           error: null,
           batchUploadProgress: {
             total,
@@ -400,7 +404,7 @@ export const useImageStore = create<ImageState>((set, get) => {
             }
           }
 
-          await refreshLocalIntoImageStore(set);
+          await refreshLocalIntoImageStore(set, { quiet: true });
           set({ batchUploadProgress: null });
           useLogStore
             .getState()
@@ -413,7 +417,6 @@ export const useImageStore = create<ImageState>((set, get) => {
             error instanceof Error ? error.message : '批量导入失败';
           set({
             error: errorMsg,
-            loading: false,
             batchUploadProgress: null,
           });
           useLogStore

--- a/app/src/stores/workspaceStore.ts
+++ b/app/src/stores/workspaceStore.ts
@@ -76,7 +76,8 @@ interface WorkspaceState {
   clearWorkspace: () => Promise<void>;
   resumeLocalWorkspace: () => Promise<boolean>;
   syncBindingsFromSources: () => Promise<void>;
-  refreshLocalImages: () => Promise<void>;
+  /** quiet：添加/写入时静默刷新，避免锁住资源库壳层（§5.1） */
+  refreshLocalImages: (options?: { quiet?: boolean }) => Promise<void>;
   refreshSyncStatus: () => Promise<void>;
   scanWorkspace: () => Promise<void>;
   importLocalImage: (uploadData: ImageUploadData) => Promise<void>;
@@ -446,12 +447,15 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     useImageStore.setState({ images: [], loading: false, error: null });
   },
 
-  refreshLocalImages: async () => {
+  refreshLocalImages: async options => {
     if (get().mode !== 'local') {
       return;
     }
 
-    set({ loading: true, error: null });
+    const quiet = options?.quiet === true;
+    if (!quiet) {
+      set({ loading: true, error: null });
+    }
     try {
       const vault = getVault();
       const entries = await vault.list();
@@ -627,7 +631,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       return;
     }
 
-    set({ loading: true, error: null });
+    // 添加不锁壳层：不置 loading，列表静默刷新（§5.1）
+    set({ error: null });
     try {
       const fileName = sanitizeFileName(
         getUploadFileName(uploadData.file, uploadData.name),
@@ -677,14 +682,14 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         relativePath: targetPath,
       });
 
-      await get().refreshLocalImages();
+      await get().refreshLocalImages({ quiet: true });
       await get().refreshSyncStatus();
-      set({ loading: false, syncMessage: '已保存到本地工作区' });
+      set({ syncMessage: '已保存到本地工作区' });
     } catch (error) {
       set({
-        loading: false,
         error: error instanceof Error ? error.message : '保存到本地工作区失败',
       });
+      throw error;
     }
   },
 

--- a/app/src/ui/image/image-upload/locales/en-US.json
+++ b/app/src/ui/image/image-upload/locales/en-US.json
@@ -1,7 +1,7 @@
 {
   "image": {
     "upload": {
-      "selectedSingle": "Selected image",
+      "selectedSingle": "Selected file",
       "selectedMultiple": "Selected",
       "uploadingSingle": "Adding to workspace",
       "uploadingMultiple": "Adding files to workspace",
@@ -19,9 +19,9 @@
       "file": "File",
       "batchUploadTitle": "Add files",
       "addNewImage": "Add files to workspace",
-      "namePrefix": "Image Name Prefix",
+      "namePrefix": "Name prefix",
       "imageName": "File name",
-      "namePrefixPlaceholder": "Add a unified prefix name for all images",
+      "namePrefixPlaceholder": "Shared name prefix for all files",
       "imageNamePlaceholder": "Name for search and management",
       "description": "Description",
       "descriptionPlaceholder": "Optional: content, purpose, or notes",
@@ -35,7 +35,7 @@
       "dragActive": "Drop files to add",
       "dragInactive": "Drag files here or click to select",
       "dragInactiveWithCrop": "Drag files here or click to select (crop supported)",
-      "supportedFormats": "Supports mainstream image formats like JPG, PNG, GIF, BMP, WebP, SVG • Can select multiple images at once",
+      "supportedFormats": "Supports images, video, PDF and common files • Multiple selection allowed",
       "cropHint": "with crop support",
       "cropComplete": "Crop completed",
       "skipCrop": "Skip crop",
@@ -54,7 +54,11 @@
       "cancel": "Cancel",
       "selectedCount": "{count} files selected",
       "previewUnavailable": "No preview",
-      "localOnlyBadge": "Local only"
+      "localOnlyBadge": "Local only",
+      "typeImage": "Image",
+      "typeVideo": "Video",
+      "typePdf": "PDF",
+      "typeOther": "Other"
     },
     "crop": {
       "title": "Crop Image",

--- a/app/src/ui/image/image-upload/locales/zh-CN.json
+++ b/app/src/ui/image/image-upload/locales/zh-CN.json
@@ -1,7 +1,7 @@
 {
   "image": {
     "upload": {
-      "selectedSingle": "已选择图片",
+      "selectedSingle": "已选择文件",
       "selectedMultiple": "已选择",
       "uploadingSingle": "正在添加到工作区",
       "uploadingMultiple": "正在批量添加到工作区",
@@ -19,9 +19,9 @@
       "file": "文件",
       "batchUploadTitle": "批量添加文件",
       "addNewImage": "添加文件到工作区",
-      "namePrefix": "图片名称前缀",
+      "namePrefix": "名称前缀",
       "imageName": "文件名",
-      "namePrefixPlaceholder": "为所有图片添加统一的前缀名称",
+      "namePrefixPlaceholder": "为所有文件添加统一的前缀名称",
       "imageNamePlaceholder": "便于搜索和管理的名称",
       "description": "描述",
       "descriptionPlaceholder": "可选：内容、用途或备注",
@@ -35,7 +35,7 @@
       "dragActive": "释放文件以添加",
       "dragInactive": "拖拽文件到此处或点击选择",
       "dragInactiveWithCrop": "拖拽文件到此处或点击选择（支持裁剪）",
-      "supportedFormats": "支持 JPG, PNG, GIF, BMP, WebP, SVG 等主流图片格式 • 可同时选择多张图片",
+      "supportedFormats": "支持图片、视频、PDF 及其它常见文件 • 可同时选择多个",
       "cropHint": "支持裁剪",
       "cropComplete": "裁剪完成",
       "skipCrop": "跳过裁剪",
@@ -54,7 +54,11 @@
       "cancel": "取消",
       "selectedCount": "已选择 {count} 个文件",
       "previewUnavailable": "无可预览缩略",
-      "localOnlyBadge": "仅本机"
+      "localOnlyBadge": "仅本机",
+      "typeImage": "图片",
+      "typeVideo": "视频",
+      "typePdf": "PDF",
+      "typeOther": "其它"
     },
     "crop": {
       "title": "裁剪图片",

--- a/app/src/ui/image/image-upload/web/ImageUpload.css
+++ b/app/src/ui/image/image-upload/web/ImageUpload.css
@@ -318,6 +318,7 @@
 }
 
 .image-upload-file-item {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 1rem;
@@ -327,6 +328,20 @@
   border: 1.5px solid #e2e8f0;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.image-upload-type-badge {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.4rem;
+  z-index: 1;
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.25rem;
+  background: #eef2ff;
+  color: #3730a3;
+  font-size: 0.625rem;
+  font-weight: 600;
+  line-height: 1.2;
 }
 
 .image-upload-file-item:hover {

--- a/app/src/ui/image/image-upload/web/ImageUpload.tsx
+++ b/app/src/ui/image/image-upload/web/ImageUpload.tsx
@@ -46,6 +46,9 @@ interface ImageUploadProps {
   nativePickers?: NativeImagePickers;
   /** 默认目标文件夹（当前资源库范围） */
   defaultFolder?: string;
+  /** 外部预填文件（主视图拖入打开确认） */
+  initialFiles?: File[];
+  onInitialFilesConsumed?: () => void;
 }
 
 function resolveDefaultFolder(folder?: string): string {
@@ -63,6 +66,22 @@ function needsRichConfirm(files: File[]): boolean {
   );
 }
 
+function fileTypeLabel(file: File, translate: (key: string) => string): string {
+  if (file.type.startsWith('image/')) {
+    return translate('image.upload.typeImage');
+  }
+  if (file.type.startsWith('video/')) {
+    return translate('image.upload.typeVideo');
+  }
+  if (
+    file.type === 'application/pdf' ||
+    file.name.toLowerCase().endsWith('.pdf')
+  ) {
+    return translate('image.upload.typePdf');
+  }
+  return translate('image.upload.typeOther');
+}
+
 const ImageUpload: React.FC<ImageUploadProps> = ({
   onUploadImage,
   onUploadMultipleImages,
@@ -75,9 +94,18 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
   compressionOptions,
   nativePickers,
   defaultFolder,
+  initialFiles,
+  onInitialFilesConsumed,
 }) => {
   // 使用传入的翻译函数或默认中文翻译函数
   const translate = t || defaultTranslate;
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
   const [uploadData, setUploadData] = useState<WebImageUploadData | null>(null);
   const [multiUploadData, setMultiUploadData] =
     useState<MultiImageUploadData | null>(null);
@@ -393,8 +421,29 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
         }
       }
     },
-    [translate, getImageDimensions, defaultFolder, cleanupPreviewUrls, compressionOptions],
+    [
+      translate,
+      getImageDimensions,
+      defaultFolder,
+      cleanupPreviewUrls,
+      compressionOptions,
+    ],
   );
+
+  useEffect(() => {
+    if (!initialFiles || initialFiles.length === 0) return;
+    let cancelled = false;
+    void onDrop(initialFiles).finally(() => {
+      if (!cancelled) {
+        onInitialFilesConsumed?.();
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+    // 仅在外部种子文件变化时预填；避免 onDrop 引用变化导致重复打开确认
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- seed files only
+  }, [initialFiles]);
 
   const handleNativePick = useCallback(
     async (source: 'camera' | 'gallery') => {
@@ -496,17 +545,18 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
             .replace('{name}', fileName)
             .replace('{dims}', dimensionsText),
         );
-        setUploadData(null);
-        setShowForm(false);
-        // 清理尺寸信息
-        setFileDimensions(prev => {
-          const newDims = { ...prev };
-          delete newDims[uploadData.file.name];
-          if (finalFile.name !== uploadData.file.name) {
-            delete newDims[finalFile.name];
-          }
-          return newDims;
-        });
+        if (mountedRef.current) {
+          setUploadData(null);
+          setShowForm(false);
+          setFileDimensions(prev => {
+            const newDims = { ...prev };
+            delete newDims[uploadData.file.name];
+            if (finalFile.name !== uploadData.file.name) {
+              delete newDims[finalFile.name];
+            }
+            return newDims;
+          });
+        }
       } catch (error) {
         updateLoadingToError(
           loadingToast,
@@ -562,7 +612,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
       }
 
       const loadingToast = showLoading(
-        `${translate('image.upload.uploadingMultiple')} ${processedFiles.length} 张图片...`,
+        `${translate('image.upload.uploadingMultiple')} ${processedFiles.length} ${translate('image.upload.file')}...`,
       );
       try {
         // 确保传递完整的 multiUploadData，包括 tags
@@ -572,8 +622,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
           description: multiUploadData.description || '',
           tags: multiUploadData.tags || [],
           targetFolder:
-            multiUploadData.targetFolder ||
-            resolveDefaultFolder(defaultFolder),
+            multiUploadData.targetFolder || resolveDefaultFolder(defaultFolder),
           captureMetadataList: buildCaptureMetadataList(processedFiles),
         };
         await onUploadMultipleImages(completeMultiUploadData);
@@ -584,9 +633,11 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
             String(processedFiles.length),
           ),
         );
-        setMultiUploadData(null);
-        setShowForm(false);
-        setIsMultiple(false);
+        if (mountedRef.current) {
+          setMultiUploadData(null);
+          setShowForm(false);
+          setIsMultiple(false);
+        }
       } catch (error) {
         updateLoadingToError(
           loadingToast,
@@ -670,16 +721,18 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
             .replace('{name}', fileName)
             .replace('{dims}', dimensionsText),
         );
-        setUploadData(null);
-        setShowForm(false);
-        setFileDimensions(prev => {
-          const newDims = { ...prev };
-          if (uploadData?.file.name) delete newDims[uploadData.file.name];
-          if (finalFile.name !== uploadData?.file.name) {
-            delete newDims[finalFile.name];
-          }
-          return newDims;
-        });
+        if (mountedRef.current) {
+          setUploadData(null);
+          setShowForm(false);
+          setFileDimensions(prev => {
+            const newDims = { ...prev };
+            if (uploadData?.file.name) delete newDims[uploadData.file.name];
+            if (finalFile.name !== uploadData?.file.name) {
+              delete newDims[finalFile.name];
+            }
+            return newDims;
+          });
+        }
       } catch (error) {
         updateLoadingToError(
           loadingToast,
@@ -759,9 +812,11 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
               String(processedFiles.length),
             ),
           );
-          setMultiUploadData(null);
-          setShowForm(false);
-          setIsMultiple(false);
+          if (mountedRef.current) {
+            setMultiUploadData(null);
+            setShowForm(false);
+            setIsMultiple(false);
+          }
         } catch (error) {
           updateLoadingToError(
             loadingToast,
@@ -824,16 +879,18 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
             .replace('{name}', fileName)
             .replace('{dims}', dimensionsText),
         );
-        setUploadData(null);
-        setShowForm(false);
-        setFileDimensions(prev => {
-          const newDims = { ...prev };
-          if (uploadData?.file.name) delete newDims[uploadData.file.name];
-          if (finalFile.name !== uploadData?.file.name) {
-            delete newDims[finalFile.name];
-          }
-          return newDims;
-        });
+        if (mountedRef.current) {
+          setUploadData(null);
+          setShowForm(false);
+          setFileDimensions(prev => {
+            const newDims = { ...prev };
+            if (uploadData?.file.name) delete newDims[uploadData.file.name];
+            if (finalFile.name !== uploadData?.file.name) {
+              delete newDims[finalFile.name];
+            }
+            return newDims;
+          });
+        }
       } catch (error) {
         updateLoadingToError(
           loadingToast,
@@ -910,9 +967,11 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
               String(processedFiles.length),
             ),
           );
-          setMultiUploadData(null);
-          setShowForm(false);
-          setIsMultiple(false);
+          if (mountedRef.current) {
+            setMultiUploadData(null);
+            setShowForm(false);
+            setIsMultiple(false);
+          }
         } catch (error) {
           updateLoadingToError(
             loadingToast,
@@ -1015,6 +1074,9 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
               const previewUrl = previewUrls.get(file.name + file.size) ?? null;
               return (
                 <div key={index} className="image-upload-file-item">
+                  <span className="image-upload-type-badge">
+                    {fileTypeLabel(file, translate)}
+                  </span>
                   {previewUrl && file.type.startsWith('image/') ? (
                     <img
                       src={previewUrl}

--- a/app/src/ui/image/image-upload/web/ImageUploadModal.tsx
+++ b/app/src/ui/image/image-upload/web/ImageUploadModal.tsx
@@ -38,6 +38,9 @@ export interface ImageUploadModalProps {
   nativePickers?: NativeImagePickers;
   /** 默认目标文件夹（当前资源库范围） */
   defaultFolder?: string;
+  /** 打开时预填的文件（主视图拖入） */
+  initialFiles?: File[];
+  onInitialFilesConsumed?: () => void;
 }
 
 const ImageUploadModal: React.FC<ImageUploadModalProps> = ({
@@ -54,6 +57,8 @@ const ImageUploadModal: React.FC<ImageUploadModalProps> = ({
   compressionOptions,
   nativePickers,
   defaultFolder,
+  initialFiles,
+  onInitialFilesConsumed,
 }) => {
   if (!isOpen) return null;
 
@@ -91,6 +96,8 @@ const ImageUploadModal: React.FC<ImageUploadModalProps> = ({
             compressionOptions={compressionOptions}
             nativePickers={nativePickers}
             defaultFolder={defaultFolder}
+            initialFiles={initialFiles}
+            onInitialFilesConsumed={onInitialFilesConsumed}
           />
         </div>
       </div>

--- a/app/src/ui/primitives/upload-button/web/UploadButton.test.tsx
+++ b/app/src/ui/primitives/upload-button/web/UploadButton.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import UploadButton from './UploadButton';
 
 // Mock ImageUploadModal
-vi.mock('../../image-upload/ImageUploadModal', () => ({
+vi.mock('../../../image/image-upload/web/ImageUploadModal', () => ({
   default: ({
     isOpen,
     onClose,
@@ -156,7 +156,7 @@ describe('UploadButton', () => {
   });
 
   describe('loading 状态', () => {
-    it('应该在 loading 为 true 时禁用按钮', () => {
+    it('添加进行中仍可再次打开（不锁「添加」按钮）', () => {
       const { container } = render(
         <UploadButton {...defaultProps} loading={true} />,
       );
@@ -164,7 +164,7 @@ describe('UploadButton', () => {
       const button = container.querySelector(
         '.upload-button',
       ) as HTMLButtonElement;
-      expect(button).toBeDisabled();
+      expect(button).not.toBeDisabled();
     });
 
     it('应该在 loading 为 false 时启用按钮', () => {
@@ -176,6 +176,30 @@ describe('UploadButton', () => {
         '.upload-button',
       ) as HTMLButtonElement;
       expect(button).not.toBeDisabled();
+    });
+  });
+
+  describe('关浮层', () => {
+    it('提交后立刻关闭弹窗，不等待写入完成', async () => {
+      let resolveUpload!: () => void;
+      const deferred = new Promise<void>(resolve => {
+        resolveUpload = resolve;
+      });
+      mockUploadImage.mockImplementation(() => deferred);
+
+      render(<UploadButton {...defaultProps} />);
+      fireEvent.click(screen.getByRole('button', { name: /上传/i }));
+      expect(screen.getByTestId('image-upload-modal')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('upload-single'));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId('image-upload-modal'),
+        ).not.toBeInTheDocument();
+      });
+      expect(mockUploadImage).toHaveBeenCalled();
+      resolveUpload();
     });
   });
 
@@ -272,7 +296,8 @@ describe('UploadButton', () => {
       rerender(<UploadButton {...defaultProps} loading={true} />);
 
       button = container.querySelector('.upload-button') as HTMLButtonElement;
-      expect(button).toBeDisabled();
+      // §5.1：添加进行中不禁用按钮
+      expect(button).not.toBeDisabled();
     });
   });
 });

--- a/app/src/ui/primitives/upload-button/web/UploadButton.tsx
+++ b/app/src/ui/primitives/upload-button/web/UploadButton.tsx
@@ -1,5 +1,5 @@
 import { Upload } from 'lucide-react';
-import React, { useState } from 'react';
+import React, { forwardRef, useImperativeHandle, useState } from 'react';
 import { defaultTranslate } from '@/ui/locales';
 import type {
   BatchUploadProgress,
@@ -17,7 +17,7 @@ export interface UploadButtonProps {
   onUploadImage: (data: ImageUploadData) => Promise<void>;
   /** 批量上传图片回调 */
   onUploadMultipleImages: (data: MultiImageUploadData) => Promise<void>;
-  /** 是否正在加载 */
+  /** 是否正在加载（不再禁用「添加」按钮，避免 §5.1 锁壳） */
   loading?: boolean;
   /** 批量上传进度 */
   batchUploadProgress?: BatchUploadProgress | null;
@@ -39,84 +39,105 @@ export interface UploadButtonProps {
   defaultFolder?: string;
 }
 
-const UploadButton: React.FC<UploadButtonProps> = ({
-  onUploadImage,
-  onUploadMultipleImages,
-  loading = false,
-  batchUploadProgress,
-  t,
-  enableCrop = false,
-  cropOptions,
-  enableCompression = false,
-  compressionOptions,
-  className = '',
-  nativePickers,
-  defaultFolder,
-}) => {
-  const translate = t || defaultTranslate;
-  const [isModalOpen, setIsModalOpen] = useState(false);
+export interface UploadButtonHandle {
+  open: () => void;
+  openWithFiles: (files: File[]) => void;
+}
 
-  const handleOpenModal = () => {
-    setIsModalOpen(true);
-  };
+const UploadButton = forwardRef<UploadButtonHandle, UploadButtonProps>(
+  (
+    {
+      onUploadImage,
+      onUploadMultipleImages,
+      batchUploadProgress,
+      t,
+      enableCrop = false,
+      cropOptions,
+      enableCompression = false,
+      compressionOptions,
+      className = '',
+      nativePickers,
+      defaultFolder,
+    },
+    ref,
+  ) => {
+    const translate = t || defaultTranslate;
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [seedFiles, setSeedFiles] = useState<File[] | null>(null);
 
-  const handleCloseModal = () => {
-    setIsModalOpen(false);
-  };
+    useImperativeHandle(ref, () => ({
+      open: () => {
+        setSeedFiles(null);
+        setIsModalOpen(true);
+      },
+      openWithFiles: (files: File[]) => {
+        if (files.length === 0) return;
+        setSeedFiles(files);
+        setIsModalOpen(true);
+      },
+    }));
 
-  // 包装上传回调，成功后关闭弹窗
-  const handleUploadImage = async (data: ImageUploadData) => {
-    try {
+    const handleOpenModal = () => {
+      setSeedFiles(null);
+      setIsModalOpen(true);
+    };
+
+    const handleCloseModal = () => {
+      setIsModalOpen(false);
+      setSeedFiles(null);
+    };
+
+    // §5.1：点「添加到工作区」后立刻关浮层，写入在后台进行
+    const handleUploadImage = async (data: ImageUploadData) => {
+      setIsModalOpen(false);
+      setSeedFiles(null);
       await onUploadImage(data);
-      setIsModalOpen(false);
-    } catch (error) {
-      throw error;
-    }
-  };
+    };
 
-  const handleUploadMultipleImages = async (data: MultiImageUploadData) => {
-    try {
+    const handleUploadMultipleImages = async (data: MultiImageUploadData) => {
+      setIsModalOpen(false);
+      setSeedFiles(null);
       await onUploadMultipleImages(data);
-      setIsModalOpen(false);
-    } catch (error) {
-      throw error;
-    }
-  };
+    };
 
-  const title = translate('header.upload') || '添加';
+    const title = translate('header.upload') || '添加';
 
-  return (
-    <>
-      <button
-        onClick={handleOpenModal}
-        disabled={loading}
-        className={`upload-button ${className}`}
-        title={title}
-        type="button"
-      >
-        <Upload size={18} />
-        <span className="upload-button-label">{title}</span>
-      </button>
+    return (
+      <>
+        <button
+          onClick={handleOpenModal}
+          className={`upload-button ${className}`}
+          title={title}
+          type="button"
+        >
+          <Upload size={18} />
+          <span className="upload-button-label">{title}</span>
+        </button>
 
-      {isModalOpen && (
-        <ImageUploadModal
-          isOpen={isModalOpen}
-          onClose={handleCloseModal}
-          onUploadImage={handleUploadImage}
-          onUploadMultipleImages={handleUploadMultipleImages}
-          loading={loading}
-          batchUploadProgress={batchUploadProgress}
-          t={t}
-          enableCrop={enableCrop}
-          cropOptions={cropOptions}
-          enableCompression={enableCompression}
-          compressionOptions={compressionOptions}
-          nativePickers={nativePickers}
-          defaultFolder={defaultFolder}
-        />
-      )}
-    </>
-  );
-};
+        {isModalOpen && (
+          <ImageUploadModal
+            isOpen={isModalOpen}
+            onClose={handleCloseModal}
+            onUploadImage={handleUploadImage}
+            onUploadMultipleImages={handleUploadMultipleImages}
+            loading={false}
+            batchUploadProgress={batchUploadProgress}
+            t={t}
+            enableCrop={enableCrop}
+            cropOptions={cropOptions}
+            enableCompression={enableCompression}
+            compressionOptions={compressionOptions}
+            nativePickers={nativePickers}
+            defaultFolder={defaultFolder}
+            initialFiles={seedFiles ?? undefined}
+            onInitialFilesConsumed={() => setSeedFiles(null)}
+          />
+        )}
+      </>
+    );
+  },
+);
+
+UploadButton.displayName = 'UploadButton';
 
 export default UploadButton;

--- a/app/src/ui/primitives/upload-button/web/index.ts
+++ b/app/src/ui/primitives/upload-button/web/index.ts
@@ -1,1 +1,2 @@
 export { default as UploadButton } from './UploadButton';
+export type { UploadButtonHandle, UploadButtonProps } from './UploadButton';

--- a/packages/core/src/vault/__tests__/syncApply.test.ts
+++ b/packages/core/src/vault/__tests__/syncApply.test.ts
@@ -214,4 +214,55 @@ describe('syncApply', () => {
     const entry = await vault.getByPath('images/Readuli.png');
     expect(entry?.syncState).toBe('synced');
   });
+
+  it('pull reconciles unbound local-only in custom folder without duplicating', async () => {
+    const adapter = new MemoryWorkspaceAdapter('desktop');
+    await adapter.pickRoot();
+    const vault = createLocalVault(adapter);
+    await vault.open();
+
+    const remoteBytes = new Uint8Array([3, 3, 3]);
+    await vault.importFile(
+      new Uint8Array([1, 1]),
+      '111/1787193114444-Omnivuli.png',
+      {
+        name: 'Omnivuli.png',
+        mimeType: 'image/png',
+        syncState: 'local-only',
+      },
+    );
+
+    const fetchFn = vi.fn(async () => ({
+      ok: true,
+      arrayBuffer: async () => remoteBytes.buffer,
+    })) as unknown as typeof fetch;
+
+    const result = await applySyncPull(
+      vault,
+      'binding-1',
+      {
+        items: [
+          {
+            remotePath: 'Omnivuli.png',
+            action: 'update',
+            metadata: {
+              name: 'Omnivuli.png',
+              updatedAt: new Date().toISOString(),
+              url: 'https://example.test/Omnivuli.png',
+            },
+          },
+        ],
+      },
+      createMockProvider(),
+      { fetchFn },
+    );
+
+    expect(result.pulled).toBe(1);
+    const listed = await vault.list();
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.relativePath).toBe('images/Omnivuli.png');
+    expect(listed[0]?.remotePath).toBe('Omnivuli.png');
+    expect(listed[0]?.syncState).toBe('synced');
+    expect(await adapter.exists('111/1787193114444-Omnivuli.png')).toBe(false);
+  });
 });

--- a/packages/core/src/vault/__tests__/syncEngine.test.ts
+++ b/packages/core/src/vault/__tests__/syncEngine.test.ts
@@ -167,4 +167,54 @@ describe('createSyncEngine', () => {
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]?.message).toContain('network down');
   });
+
+  it('run push skips never-synced tombstones without remote DELETE', async () => {
+    const { engine, vault, syncPush } = await createTestContext();
+    await vault.importFile(new Uint8Array([1]), 'images/gone.png', {
+      name: 'gone.png',
+      syncState: 'local-only',
+    });
+    await vault.softDelete('images/gone.png');
+    await vault.importFile(new Uint8Array([2, 2]), '111/ts-Omnivuli.png', {
+      name: 'Omnivuli.png',
+      syncState: 'local-only',
+    });
+
+    const result = await engine.run({ direction: 'push' });
+    expect(result.errors).toHaveLength(0);
+    expect(result.pushed).toBe(1);
+    expect(syncPush).toHaveBeenCalledOnce();
+    const pushedItems = syncPush.mock.calls[0]?.[0] as Array<{
+      action: string;
+      remotePath: string;
+    }>;
+    expect(pushedItems.every(item => item.action !== 'delete')).toBe(true);
+    expect(pushedItems.some(item => item.remotePath === 'Omnivuli.png')).toBe(
+      true,
+    );
+    expect(await vault.list({ includeDeleted: true })).toHaveLength(1);
+  });
+
+  it('run push removes tombstone after successful remote delete', async () => {
+    const { engine, vault, syncPush } = await createTestContext();
+    await vault.importFile(new Uint8Array([1]), 'images/old.png', {
+      name: 'old.png',
+      syncState: 'synced',
+      remotePath: 'old.png',
+      bindingId: 'binding-1',
+    });
+    await vault.softDelete('images/old.png');
+
+    const result = await engine.run({ direction: 'push' });
+    expect(result.errors).toHaveLength(0);
+    expect(result.pushed).toBe(1);
+    const pushedItems = syncPush.mock.calls[0]?.[0] as Array<{
+      action: string;
+      remotePath: string;
+    }>;
+    expect(pushedItems).toEqual([
+      expect.objectContaining({ action: 'delete', remotePath: 'old.png' }),
+    ]);
+    expect(await vault.list({ includeDeleted: true })).toHaveLength(0);
+  });
 });

--- a/packages/core/src/vault/syncApply.ts
+++ b/packages/core/src/vault/syncApply.ts
@@ -58,19 +58,29 @@ async function findExistingForPullItem(
     return byPath;
   }
 
-  const entries = await vault.list({ bindingId });
-  return (
-    entries.find(entry => {
-      if (entry.deletedAt) {
-        return false;
-      }
-      if (entry.remotePath === remotePath) {
-        return true;
-      }
-      // 兼容：本地 timestamp 路径 + 展示名与远端文件名一致（推送 name 与 remotePath 曾不一致）
-      return entry.name === remotePath;
-    }) ?? null
-  );
+  const matchesRemote = (entry: LocalImageIndexEntry): boolean => {
+    if (entry.deletedAt) {
+      return false;
+    }
+    if (entry.remotePath === remotePath) {
+      return true;
+    }
+    // 兼容：本地 timestamp 路径 / 自定义文件夹 + 展示名与远端文件名一致
+    if (entry.name === remotePath) {
+      return true;
+    }
+    return basename(entry.relativePath) === remotePath;
+  };
+
+  const boundEntries = await vault.list({ bindingId });
+  const fromBound = boundEntries.find(matchesRemote);
+  if (fromBound) {
+    return fromBound;
+  }
+
+  // push 半成功时本地可能仍是 local-only、无 bindingId；仍按名称对账，避免 pull 再写一份
+  const unboundEntries = await vault.list();
+  return unboundEntries.find(matchesRemote) ?? null;
 }
 
 function isRemoteUpToDate(

--- a/packages/core/src/vault/syncEngine.ts
+++ b/packages/core/src/vault/syncEngine.ts
@@ -210,19 +210,44 @@ async function flushPushQueue(
   const pendingPaths = new Set<string>();
   if (options?.overwriteRemote) {
     for (const entry of entries) {
+      if (entry.deletedAt) {
+        // 从未成功上云的 tombstone：只清本地，勿对远端 DELETE（易 404 拖垮整批）
+        if (!entry.remotePath) {
+          await vault.removeEntry(entry.relativePath);
+          continue;
+        }
+        pendingPaths.add(entry.relativePath);
+        continue;
+      }
       pendingPaths.add(entry.relativePath);
     }
   } else {
     for (const entry of entries) {
+      if (entry.deletedAt) {
+        if (!entry.remotePath) {
+          await vault.removeEntry(entry.relativePath);
+          continue;
+        }
+        pendingPaths.add(entry.relativePath);
+        continue;
+      }
       if (
-        !entry.deletedAt &&
-        (entry.syncState === 'local-only' || entry.syncState === 'pending-push')
+        entry.syncState === 'local-only' ||
+        entry.syncState === 'pending-push'
       ) {
         pendingPaths.add(entry.relativePath);
       }
     }
   }
   for (const op of queue) {
+    const entry = await vault.getByPath(op.relativePath);
+    if (!entry) {
+      continue;
+    }
+    if (entry.deletedAt && !entry.remotePath) {
+      await vault.removeEntry(op.relativePath);
+      continue;
+    }
     pendingPaths.add(op.relativePath);
   }
 
@@ -230,18 +255,40 @@ async function flushPushQueue(
     return 0;
   }
 
-  const items = await buildSyncPushItems(
+  const built = await buildSyncPushItems(
     vault,
     binding.bindingId,
     [...pendingPaths],
     readFileBytes,
   );
 
+  // 队列里可能仍指向已无 remotePath 的 delete：再滤一遍
+  const items: Awaited<ReturnType<typeof buildSyncPushItems>> = [];
+  for (const item of built) {
+    if (item.action === 'delete') {
+      const entry = await vault.getByPath(item.localRelativePath);
+      if (!entry?.remotePath) {
+        if (entry) {
+          await vault.removeEntry(item.localRelativePath);
+        }
+        continue;
+      }
+    }
+    items.push(item);
+  }
+
+  if (items.length === 0) {
+    await writePushQueue(vault.adapter, []);
+    memoryQueue.length = 0;
+    return 0;
+  }
+
   await provider.syncPush(items);
 
   let pushed = 0;
   for (const item of items) {
     if (item.action === 'delete') {
+      await vault.removeEntry(item.localRelativePath);
       pushed += 1;
       continue;
     }

--- a/packages/plugin-provider-gitee/src/__tests__/giteeStorageProvider.test.ts
+++ b/packages/plugin-provider-gitee/src/__tests__/giteeStorageProvider.test.ts
@@ -237,9 +237,8 @@ describe('GiteeStorageProvider', () => {
         .fn()
         .mockResolvedValueOnce(createMockResponse(true, null));
 
-      await expect(provider.deleteImage('test.jpg')).rejects.toThrow(
-        '删除图片失败',
-      );
+      // 远端已无文件：幂等成功，避免拖垮 syncPush
+      await expect(provider.deleteImage('test.jpg')).resolves.toBeUndefined();
     });
 
     it('应该处理删除失败的情况', async () => {

--- a/packages/plugin-provider-gitee/src/giteeStorageProvider.ts
+++ b/packages/plugin-provider-gitee/src/giteeStorageProvider.ts
@@ -368,7 +368,9 @@ export class GiteeStorageProvider implements StorageProviderWithMetadata {
       // 获取文件的当前 SHA
       const sha = await this.getFileSha(filePath, this.config.branch);
       if (!sha) {
-        throw new Error('文件不存在');
+        // 远端已无此文件：幂等成功，避免拖垮整批 syncPush
+        this.logger.warn(`Remote image already absent: ${path}`);
+        return;
       }
 
       // 删除文件

--- a/packages/plugin-provider-github/src/__tests__/githubStorageProvider.test.ts
+++ b/packages/plugin-provider-github/src/__tests__/githubStorageProvider.test.ts
@@ -246,9 +246,8 @@ describe('GitHubStorageProvider', () => {
           createMockResponse(false, { message: 'Not Found' }, 404),
         );
 
-      await expect(provider.deleteImage('test.jpg')).rejects.toThrow(
-        '删除图片失败',
-      );
+      // 远端 404：幂等成功，避免拖垮 syncPush
+      await expect(provider.deleteImage('test.jpg')).resolves.toBeUndefined();
     });
 
     it('应该处理删除失败的情况', async () => {

--- a/packages/plugin-provider-github/src/githubStorageProvider.ts
+++ b/packages/plugin-provider-github/src/githubStorageProvider.ts
@@ -291,9 +291,25 @@ export class GitHubStorageProvider implements StorageProviderWithMetadata {
       const filePath = `${this.config.path}/${path}`;
 
       // 首先获取文件的SHA
-      const fileInfo = await this.makeGitHubRequest(
-        `/repos/${this.config.owner}/${this.config.repo}/contents/${filePath}?ref=${this.config.branch}`,
-      );
+      let fileInfo: { sha: string };
+      try {
+        fileInfo = await this.makeGitHubRequest(
+          `/repos/${this.config.owner}/${this.config.repo}/contents/${filePath}?ref=${this.config.branch}`,
+        );
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        const isNotFound =
+          errorMessage.includes('404') ||
+          errorMessage.includes('Not Found') ||
+          errorMessage.includes('not found');
+        if (isNotFound) {
+          // 远端已无此文件：幂等成功，避免拖垮整批 syncPush
+          this.logger.warn(`Remote image already absent: ${path}`);
+          return;
+        }
+        throw error;
+      }
 
       // 删除文件
       await this.makeGitHubRequest(


### PR DESCRIPTION
## Summary
- 对齐资源库 §5.1：点「添加到工作区」后立刻关浮层；主视图可拖入打开短确认；混选带类型角标；添加过程不锁壳层（quiet 刷新 / 不禁用添加按钮）。
- 修复同步：从未上云的 tombstone 不再对远端 DELETE；GitHub/Gitee 删除 404 幂等成功；成功 DELETE 后清理本地 tombstone。
- 修复 pull：对账匹配无 `bindingId` 的 local-only（含自定义文件夹），避免 `111/…` 与 `images/…` 双份。

## Test plan
- [ ] `pnpm exec vitest run packages/core/src/vault/__tests__/syncApply.test.ts packages/core/src/vault/__tests__/syncEngine.test.ts packages/plugin-provider-github/src/__tests__/githubStorageProvider.test.ts packages/plugin-provider-gitee/src/__tests__/giteeStorageProvider.test.ts app/src/ui/primitives/upload-button/web/UploadButton.test.tsx`
- [ ] 本地添加图片到非 `images/` 文件夹 → 同步到 GitHub：不应再出现「删除图片失败 404」
- [ ] 同上后再 pull：列表不应出现同名重复
- [ ] 添加确认后浮层立即关闭，期间仍可搜索 / 换文件夹 / 再点添加
- [ ] 主视图拖入系统文件可打开短确认


Made with [Cursor](https://cursor.com)