### PR TITLE
feat(ui): 文件夹树改为右键菜单，并展示本机工作区路径

### DIFF
--- a/app/src/features/workspace/WorkspaceFolderTree.css
+++ b/app/src/features/workspace/WorkspaceFolderTree.css
@@ -71,6 +71,11 @@
   cursor: pointer;
 }
 
+.workspace-explorer-header-text {
+  min-width: 0;
+  flex: 1;
+}
+
 .workspace-explorer-title {
   margin: 0;
   font-size: 0.8125rem;
@@ -90,6 +95,22 @@
   color: #9ca3af;
 }
 
+.workspace-explorer-path {
+  margin: 0.4rem 0 0;
+  font-size: 0.6875rem;
+  line-height: 1.4;
+  color: #4b5563;
+  word-break: break-all;
+}
+
+.workspace-explorer-path-label {
+  display: block;
+  margin-bottom: 0.125rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: #9ca3af;
+}
+
 .workspace-explorer-tree {
   flex: 1;
   min-height: 0;
@@ -103,7 +124,7 @@
   align-items: center;
   gap: 0.125rem;
   min-height: 1.75rem;
-  padding-right: 0.25rem;
+  padding-right: 0.5rem;
   border: none;
   background: transparent;
   color: #374151;
@@ -120,36 +141,24 @@
   min-height: 1.75rem;
   padding: 0;
   border: none;
+  border-radius: 0;
   background: transparent;
   color: inherit;
   font: inherit;
   text-align: left;
   cursor: pointer;
+  box-shadow: none;
 }
 
-.workspace-tree-more {
-  display: inline-flex;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
-  width: 1.5rem;
-  height: 1.5rem;
-  border: none;
-  border-radius: 0.25rem;
-  background: transparent;
-  color: #9ca3af;
-  opacity: 0;
-  cursor: pointer;
+.workspace-tree-row-main:hover {
+  border-color: transparent;
 }
 
-.workspace-tree-row:hover .workspace-tree-more,
-.workspace-tree-row--active .workspace-tree-more {
-  opacity: 1;
-}
-
-.workspace-tree-more:hover {
-  background: #e5e7eb;
-  color: #374151;
+.workspace-tree-row-main:focus,
+.workspace-tree-row-main:focus-visible {
+  outline: none;
+  box-shadow: none;
+  border-color: transparent;
 }
 
 .workspace-explorer-header-actions {

--- a/app/src/features/workspace/WorkspaceFolderTree.tsx
+++ b/app/src/features/workspace/WorkspaceFolderTree.tsx
@@ -4,7 +4,6 @@ import {
   Folder,
   FolderOpen,
   FolderPlus,
-  MoreHorizontal,
   Pencil,
   Trash2,
   X,
@@ -26,6 +25,39 @@ import {
 } from '@/utils/workspaceFolderTree';
 import './WorkspaceFolderTree.css';
 
+/** 新建子文件夹的父路径：根（全部）→ 工作区顶层；否则用当前选中目录 */
+export function resolveNewFolderParent(selectedOrMenuPath: string): string {
+  const path = selectedOrMenuPath.trim();
+  if (!path || path === '__root__') {
+    return '';
+  }
+  return path.replace(/\/+$/, '');
+}
+
+/** 资源管理器展示的本机位置：真实路径优先，虚拟存储用可读说明 */
+export function formatWorkspaceLocation(
+  rootPath: string | null,
+  displayName: string | null,
+  t: (key: string) => string,
+): string | null {
+  if (!rootPath) {
+    return null;
+  }
+  if (rootPath.startsWith('mobile://')) {
+    return t('workspace.mobileStorage');
+  }
+  if (rootPath.startsWith('opfs://')) {
+    return t('workspace.webStorage');
+  }
+  if (rootPath.startsWith('fsa://')) {
+    const name = displayName?.trim();
+    return name
+      ? `${t('workspace.fsaStorage')} · ${name}`
+      : t('workspace.fsaStorage');
+  }
+  return rootPath;
+}
+
 interface TreeRowProps {
   node: WorkspaceFolderNode;
   depth: number;
@@ -33,7 +65,7 @@ interface TreeRowProps {
   expandedPaths: Set<string>;
   onToggle: (path: string) => void;
   onSelect: (path: string) => void;
-  onMenu: (path: string, event: React.MouseEvent) => void;
+  onContextMenu: (path: string, event: React.MouseEvent) => void;
   allLabel: string;
 }
 
@@ -44,7 +76,7 @@ const TreeRow: React.FC<TreeRowProps> = ({
   expandedPaths,
   onToggle,
   onSelect,
-  onMenu,
+  onContextMenu,
   allLabel,
 }) => {
   const hasChildren = node.children.length > 0;
@@ -58,6 +90,10 @@ const TreeRow: React.FC<TreeRowProps> = ({
       <div
         className={`workspace-tree-row ${isSelected ? 'workspace-tree-row--active' : ''}`}
         style={{ paddingLeft: `${0.5 + depth * 0.75}rem` }}
+        onContextMenu={event => {
+          event.preventDefault();
+          onContextMenu(node.path, event);
+        }}
       >
         <button
           type="button"
@@ -90,17 +126,6 @@ const TreeRow: React.FC<TreeRowProps> = ({
           <span className="workspace-tree-label">{label}</span>
           <span className="workspace-tree-count">{node.imageCount}</span>
         </button>
-        <button
-          type="button"
-          className="workspace-tree-more"
-          aria-label="Folder menu"
-          onClick={event => {
-            event.stopPropagation();
-            onMenu(node.path, event);
-          }}
-        >
-          <MoreHorizontal size={14} aria-hidden />
-        </button>
       </div>
       {hasChildren && isExpanded
         ? node.children.map(child => (
@@ -112,7 +137,7 @@ const TreeRow: React.FC<TreeRowProps> = ({
               expandedPaths={expandedPaths}
               onToggle={onToggle}
               onSelect={onSelect}
-              onMenu={onMenu}
+              onContextMenu={onContextMenu}
               allLabel={allLabel}
             />
           ))
@@ -127,6 +152,7 @@ export const WorkspaceFolderTree: React.FC<{ overlay?: boolean }> = ({
   const { t } = useI18n();
   const images = useImageStore(state => state.images);
   const displayName = useWorkspaceStore(state => state.displayName);
+  const rootPath = useWorkspaceStore(state => state.rootPath);
   const localFolders = useWorkspaceStore(state => state.localFolders);
   const createLocalFolder = useWorkspaceStore(state => state.createLocalFolder);
   const renameLocalFolder = useWorkspaceStore(state => state.renameLocalFolder);
@@ -187,18 +213,26 @@ export const WorkspaceFolderTree: React.FC<{ overlay?: boolean }> = ({
     }
   };
 
-  const parentForNew = (path: string) => path || 'images';
+  const handleFolderContextMenu = (path: string, event: React.MouseEvent) => {
+    setSelectedFolderPath(path);
+    setMenu({ path, x: event.clientX, y: event.clientY });
+  };
+
+  const parentForNew = (path: string) => resolveNewFolderParent(path);
 
   const handleCreate = async (parentPath: string) => {
     setMenu(null);
     const name = window.prompt(t('workspace.newFolderPrompt'));
     if (!name?.trim()) return;
     const safe = name.trim().replace(/[/\\]/g, '_');
-    const target = `${parentForNew(parentPath)}/${safe}`;
+    const parent = parentForNew(parentPath);
+    const target = parent ? `${parent}/${safe}` : safe;
     await createLocalFolder(target);
-    setExpandedPaths(prev =>
-      new Set(prev).add(parentForNew(parentPath) || '__root__'),
-    );
+    setExpandedPaths(prev => {
+      const next = new Set(prev);
+      next.add(parent || '__root__');
+      return next;
+    });
     setSelectedFolderPath(target);
   };
 
@@ -249,6 +283,8 @@ export const WorkspaceFolderTree: React.FC<{ overlay?: boolean }> = ({
     }
   };
 
+  const workspaceLocation = formatWorkspaceLocation(rootPath, displayName, t);
+
   return (
     <aside
       className={`workspace-explorer ${overlay ? 'workspace-explorer--overlay' : ''}`}
@@ -256,25 +292,24 @@ export const WorkspaceFolderTree: React.FC<{ overlay?: boolean }> = ({
       aria-modal={overlay || undefined}
     >
       <div className="workspace-explorer-header">
-        <div>
+        <div className="workspace-explorer-header-text">
           <h2 className="workspace-explorer-title">
             {displayName || t('workspace.unnamed')}
           </h2>
           <p className="workspace-explorer-subtitle">
             {t('workspace.explorer')}
           </p>
+          {workspaceLocation ? (
+            <p className="workspace-explorer-path" title={workspaceLocation}>
+              <span className="workspace-explorer-path-label">
+                {t('workspace.localPath')}
+              </span>
+              {workspaceLocation}
+            </p>
+          ) : null}
         </div>
-        <div className="workspace-explorer-header-actions">
-          <button
-            type="button"
-            className="workspace-explorer-close"
-            aria-label={t('workspace.newFolder')}
-            title={t('workspace.newFolder')}
-            onClick={() => void handleCreate(selectedFolderPath || 'images')}
-          >
-            <FolderPlus size={18} />
-          </button>
-          {overlay ? (
+        {overlay ? (
+          <div className="workspace-explorer-header-actions">
             <button
               type="button"
               className="workspace-explorer-close"
@@ -283,8 +318,8 @@ export const WorkspaceFolderTree: React.FC<{ overlay?: boolean }> = ({
             >
               <X size={20} />
             </button>
-          ) : null}
-        </div>
+          </div>
+        ) : null}
       </div>
 
       <div className="workspace-explorer-tree" role="tree">
@@ -295,9 +330,7 @@ export const WorkspaceFolderTree: React.FC<{ overlay?: boolean }> = ({
           expandedPaths={expandedPaths}
           onToggle={toggleExpanded}
           onSelect={handleSelect}
-          onMenu={(path, event) =>
-            setMenu({ path, x: event.clientX, y: event.clientY })
-          }
+          onContextMenu={handleFolderContextMenu}
           allLabel={t('workspace.allImages')}
         />
       </div>

--- a/app/src/features/workspace/__tests__/resolveNewFolderParent.test.ts
+++ b/app/src/features/workspace/__tests__/resolveNewFolderParent.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatWorkspaceLocation,
+  resolveNewFolderParent,
+} from '../WorkspaceFolderTree';
+
+describe('resolveNewFolderParent', () => {
+  it('maps root / empty to workspace top-level', () => {
+    expect(resolveNewFolderParent('')).toBe('');
+    expect(resolveNewFolderParent('   ')).toBe('');
+    expect(resolveNewFolderParent('__root__')).toBe('');
+  });
+
+  it('keeps the selected folder as parent', () => {
+    expect(resolveNewFolderParent('111')).toBe('111');
+    expect(resolveNewFolderParent('images')).toBe('images');
+    expect(resolveNewFolderParent('images/trip/')).toBe('images/trip');
+  });
+});
+
+describe('formatWorkspaceLocation', () => {
+  const t = (key: string) => key;
+
+  it('returns absolute filesystem paths as-is', () => {
+    expect(formatWorkspaceLocation('/Users/me/Pictures/111', '111', t)).toBe(
+      '/Users/me/Pictures/111',
+    );
+  });
+
+  it('labels virtual storage backends', () => {
+    expect(formatWorkspaceLocation('opfs://abc', null, t)).toBe(
+      'workspace.webStorage',
+    );
+    expect(formatWorkspaceLocation('fsa://abc', '相册', t)).toBe(
+      'workspace.fsaStorage · 相册',
+    );
+    expect(formatWorkspaceLocation('mobile://abc', null, t)).toBe(
+      'workspace.mobileStorage',
+    );
+  });
+});

--- a/app/src/i18n/locales/en-US.json
+++ b/app/src/i18n/locales/en-US.json
@@ -89,6 +89,7 @@
     "picking": "Opening…",
     "current": "Workspace",
     "unnamed": "Unnamed workspace",
+    "localPath": "Local path",
     "pushManual": "Push to remote",
     "pushing": "Pushing…",
     "pushNeedsRemote": "Add a GitHub or Gitee remote source to push",

--- a/app/src/i18n/locales/zh-CN.json
+++ b/app/src/i18n/locales/zh-CN.json
@@ -89,6 +89,7 @@
     "picking": "正在打开…",
     "current": "当前工作区",
     "unnamed": "未命名工作区",
+    "localPath": "本机路径",
     "pushManual": "推送到远端",
     "pushing": "推送中…",
     "pushNeedsRemote": "请先添加 GitHub 或 Gitee 远端源以推送",


### PR DESCRIPTION
## Summary
- 文件夹操作统一为右键菜单（新建子文件夹 / 重命名 / 删除）；移除行内「⋯」与顶栏新建入口。
- 新建文件夹落到当前选中目录下（根「全部」则建在工作区顶层，不再强制 `images/`）。
- 资源管理器标题区展示本机路径（桌面完整路径；FSA/OPFS/Mobile 显示可读说明）。
- 去掉文件夹选中后的蓝色 focus outline。

## Test plan
- [ ] 左键选中文件夹仅高亮，无蓝色 outline
- [ ] 右键文件夹弹出菜单：新建子文件夹 / 重命名 / 删除可用
- [ ] 在非 `images` 文件夹下新建子文件夹，路径落在该目录下
- [ ] 侧栏标题下可见「本机路径」；桌面端为绝对路径
- [ ] 顶栏不再有「添加文件夹」按钮；窄屏 overlay 仍可关闭面板
- [ ] `pnpm exec vitest run app/src/features/workspace/__tests__/resolveNewFolderParent.test.ts`


Made with [Cursor](https://cursor.com)