### PR TITLE
refactor(app): S10–S11 store 服务层拆分与壳层瘦身

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,166 +1,17 @@
-import { useCallback, useEffect, useMemo } from 'react';
 import './App.css';
 import '@/features/access/registerPublishPort';
 import { SearchProvider } from '@/features/library/SearchContext';
-import {
-  useAppInitialization,
-  useCapacitorBackButton,
-  useKeyboardShortcuts,
-} from '@/hooks';
-import { useConfigManagement } from '@/features/settings/useConfigManagement';
-import { useSelectedSourceSync } from '@/features/settings/useSelectedSourceSync';
-import { useSourceManagement } from '@/features/settings/useSourceManagement';
-import { useWorkspaceBindingSync } from '@/features/workspace/useWorkspaceBindingSync';
-import { useI18n } from '@/i18n/useI18n';
+import { useAppOrchestration } from '@/hooks/useAppOrchestration';
 import { MainLayout } from '@/layouts/MainLayout';
-import { isWorkspaceAvailable } from '@/platforms/workspacePlatform';
 import { AppRoutes } from '@/router/routes';
-import { useImageStore } from '@/features/library/imageStore';
-import { useSourceStore } from '@/features/settings/sourceStore';
-import { useUIStore } from '@/stores/uiStore';
-import { useWorkspaceStore } from '@/features/workspace/workspaceStore';
 
-// 主应用组件（统一 Web 和 Desktop）
 function App() {
-  const { t } = useI18n();
-  const { loadImages } = useImageStore();
-  const initializeWorkspace = useWorkspaceStore(state => state.initialize);
-  const localActive = useWorkspaceStore(state => state.isLocalActive());
-
-  useEffect(() => {
-    if (!isWorkspaceAvailable()) {
-      return;
-    }
-    void initializeWorkspace().then(() => {
-      if (useWorkspaceStore.getState().isLocalActive()) {
-        void loadImages();
-      }
-    });
-  }, [initializeWorkspace, loadImages]);
-
-  const { sources, selectedSourceId } = useSourceStore();
-
-  // UI 状态管理（应用级别，使用 zustand）
-  const {
-    showConfigModal,
-    editingSourceId,
-    showSettingsModal,
-    isFullscreenMode,
-    setIsFullscreenMode,
-    openConfigModal,
-    closeConfigModal,
-    openKeyboardHelp,
-    closeSettingsModal,
-    openSettingsModalForAddSource,
-    openConfigModalForEdit,
-    openOperationLog,
-  } = useUIStore();
-
-  // 源管理
-  const sourceManagement = useSourceManagement();
-  const {
-    selectedSource,
-    sidebarSources,
-    handleDeleteSource,
-    handleSourceSelect,
-  } = sourceManagement;
-
-  // 配置管理
-  const { handleSaveConfig, handleClearConfig } = useConfigManagement();
-
-  const hasConfig = isWorkspaceAvailable() ? localActive : sources.length > 0;
-
-  const handleLoadImages = useCallback(async () => {
-    try {
-      await loadImages();
-    } catch (error) {
-      console.error('Failed to load images:', error);
-    }
-  }, [loadImages]);
-
-  // 保存配置（包装以包含 editingSourceId）
-  const handleSaveConfigWithId = useMemo(
-    () => (config: any) => {
-      handleSaveConfig(config, editingSourceId);
-      closeConfigModal();
-    },
-    [handleSaveConfig, editingSourceId, closeConfigModal],
-  );
-
-  // 清除配置（包装以包含 editingSourceId）
-  const handleClearConfigWithId = useMemo(
-    () => () => {
-      handleClearConfig(editingSourceId);
-      closeConfigModal();
-    },
-    [handleClearConfig, editingSourceId, closeConfigModal],
-  );
-
-  // 编辑源（包装以设置 editingSourceId）
-  const handleEditSourceWithId = useMemo(
-    () => (sourceId: string) => {
-      openConfigModalForEdit(sourceId);
-    },
-    [openConfigModalForEdit],
-  );
-
-  // 删除源（包装以包含翻译函数）
-  const handleDeleteSourceWithT = useMemo(
-    () => (sourceId: string) => {
-      handleDeleteSource(sourceId, t);
-    },
-    [handleDeleteSource, t],
-  );
-
-  // 同步选中源到配置（远端源仅用于同步绑定，不触发远端列表加载）
-  useSelectedSourceSync(selectedSource ?? null, () => {
-    if (isWorkspaceAvailable()) {
-      return;
-    }
-    if (sources.length > 0 && selectedSource) {
-      handleLoadImages();
-    }
-  });
-
-  useWorkspaceBindingSync();
-
-  // 应用初始化
-  useAppInitialization(hasConfig, handleLoadImages);
-
-  // Capacitor Android 返回键（REF-512 #150）
-  useCapacitorBackButton();
-
-  // 键盘快捷键
-  useKeyboardShortcuts(
-    t,
-    showConfigModal,
-    showSettingsModal,
-    closeConfigModal,
-    closeSettingsModal,
-    openKeyboardHelp,
-    openOperationLog,
-    handleLoadImages,
-    openConfigModal,
-  );
+  const { mainLayoutProps, routesProps } = useAppOrchestration();
 
   return (
     <SearchProvider>
-      <MainLayout
-        sidebarSources={sidebarSources}
-        selectedSourceId={selectedSourceId}
-        onSourceSelect={handleSourceSelect}
-        onSourceEdit={handleEditSourceWithId}
-        onSourceDelete={handleDeleteSourceWithT}
-        hasConfig={hasConfig}
-        onAddSource={openSettingsModalForAddSource}
-        onSaveConfig={handleSaveConfigWithId}
-        onClearConfig={handleClearConfigWithId}
-      >
-        <AppRoutes
-          onOpenConfigModal={openConfigModal}
-          isFullscreenMode={isFullscreenMode}
-          setIsFullscreenMode={setIsFullscreenMode}
-        />
+      <MainLayout {...mainLayoutProps}>
+        <AppRoutes {...routesProps} />
       </MainLayout>
     </SearchProvider>
   );

--- a/app/src/README.md
+++ b/app/src/README.md
@@ -8,21 +8,20 @@
 ```text
 L1  features/* + stores/     业务与全局状态
 L2  ui/                      薄 primitives / brand（@/ui）
-L3  layouts/ + platforms/ + boot/ + router/ + pages/   壳层与路由
+L3  layouts/ + platforms/ + boot/ + router/   壳层与路由
 ```
 
-| 路径                     | 职责                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------- |
-| `features/library`       | 资源库 SSOT：`LibraryWorkbench`、`AssetLibrary`、上传、`imageStore`、SearchContext |
-| `features/tools`         | 增强工具：`imageProcessor`、压缩/转换 Panel、`UtilityToolOverlay`                  |
-| `features/settings`      | 设置、源管理 hooks、配置 Modal、`sourceStore`                                      |
-| `features/workspace`     | 本地工作区、folderTree、`workspaceStore`                                           |
-| `features/operation-log` | 操作日志 UI + store + service（域内聚）                                            |
-| `stores/`                | **跨 feature** 壳层全局 Zustand                                                    |
-| `pages/library`          | 薄路由入口，挂载 `LibraryWorkbench`                                                |
-| `router/`                | `/library` 主路由、legacy redirect、`navigation` 工具                              |
-| `i18n/`                  | 文案 SSOT；壳层标语见 `brand.json` + `brandCopy.ts`                                |
-| `ui/`                    | 禁止放复合业务 UI                                                                  |
+| 路径                     | 职责                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------- |
+| `features/library`       | 资源库 SSOT：`LibraryPage`、`useLibraryRoute`、`LibraryWorkbench`、`imageStore` |
+| `features/tools`         | 增强工具：`imageProcessor`、压缩/转换 Panel、`UtilityToolOverlay`               |
+| `features/settings`      | 设置、源管理 hooks、配置 Modal、`sourceStore`                                   |
+| `features/workspace`     | 本地工作区、folderTree、`workspaceStore`                                        |
+| `features/operation-log` | 操作日志 UI + store + service（域内聚）                                         |
+| `stores/`                | **跨 feature** 壳层全局 Zustand                                                 |
+| `router/`                | `/library` 主路由、`LibraryPage` lazy 加载、legacy redirect                     |
+| `i18n/`                  | 文案 SSOT；壳层标语见 `brand.json` + `brandCopy.ts`                             |
+| `ui/`                    | 禁止放复合业务 UI                                                               |
 
 ## 路由
 

--- a/app/src/features/library/LibraryPage.tsx
+++ b/app/src/features/library/LibraryPage.tsx
@@ -1,0 +1,46 @@
+import { LibraryWorkbench } from '@/features/library/LibraryWorkbench';
+import { useLibraryRoute } from '@/features/library/useLibraryRoute';
+import React from 'react';
+
+interface LibraryPageProps {
+  onOpenConfigModal: () => void;
+}
+
+export const LibraryPage: React.FC<LibraryPageProps> = ({
+  onOpenConfigModal,
+}) => {
+  const {
+    t,
+    hasConfig,
+    error,
+    clearError,
+    visibleImages,
+    loading,
+    handleDeleteImage,
+    handleDeleteMultipleImages,
+    handleUpdateImage,
+    search,
+  } = useLibraryRoute();
+
+  return (
+    <div className="library-page h-full min-h-0 flex flex-col overflow-hidden">
+      <div className="flex-1 min-h-0 overflow-hidden">
+        <LibraryWorkbench
+          hasConfig={hasConfig}
+          error={error}
+          onClearError={clearError}
+          images={visibleImages}
+          loading={loading}
+          onDeleteImage={handleDeleteImage}
+          onDeleteMultipleImages={handleDeleteMultipleImages}
+          onUpdateImage={handleUpdateImage}
+          onOpenConfigModal={onOpenConfigModal}
+          search={search}
+          t={t}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default LibraryPage;

--- a/app/src/features/library/assetListService.ts
+++ b/app/src/features/library/assetListService.ts
@@ -1,0 +1,73 @@
+import {
+  storagePluginLabel,
+  type StoragePluginId,
+} from '@/storage/createProvider';
+import { isWorkspaceAvailable } from '@/platforms/workspacePlatform';
+import type { ImageItem } from '@pixuli/core/types';
+import type { StorageProvider } from '@pixuli/core/plugins';
+import { getWorkspaceLibraryPort } from '@/features/library/workspaceImageBridge';
+
+export type AssetListPatch = {
+  images?: ImageItem[];
+  loading?: boolean;
+  error?: string | null;
+};
+
+export function isLocalListMode(): boolean {
+  return getWorkspaceLibraryPort().isLocalActive();
+}
+
+export function shouldSkipRemoteListLoad(): boolean {
+  return isWorkspaceAvailable() && !isLocalListMode();
+}
+
+export function dedupeImagesById(images: ImageItem[]): ImageItem[] {
+  return images.reduce((acc: ImageItem[], current) => {
+    const existingIndex = acc.findIndex(img => img.id === current.id);
+    if (existingIndex === -1) {
+      acc.push(current);
+      return acc;
+    }
+    const existing = acc[existingIndex];
+    if (new Date(current.updatedAt) > new Date(existing.updatedAt)) {
+      acc[existingIndex] = current;
+    }
+    return acc;
+  }, []);
+}
+
+export async function refreshLocalImageList(
+  set: (partial: AssetListPatch) => void,
+  options?: { quiet?: boolean },
+): Promise<void> {
+  const workspace = getWorkspaceLibraryPort();
+  const quiet = options?.quiet === true;
+  if (!quiet) {
+    set({ loading: true, error: null });
+  }
+  try {
+    await workspace.refreshLocalImages(quiet ? { quiet: true } : undefined);
+    set({
+      images: workspace.getLocalImages(),
+      loading: false,
+    });
+  } catch (error) {
+    set({
+      loading: false,
+      error: error instanceof Error ? error.message : '加载本地图片失败',
+    });
+  }
+}
+
+export async function loadRemoteImageList(
+  storageProvider: StorageProvider,
+): Promise<ImageItem[]> {
+  const images = await storageProvider.listImages();
+  return dedupeImagesById(images);
+}
+
+export function unconfiguredStorageError(
+  storageType: StoragePluginId | null,
+): string {
+  return `${storagePluginLabel(storageType)} 配置未初始化`;
+}

--- a/app/src/features/library/assetMutationService.ts
+++ b/app/src/features/library/assetMutationService.ts
@@ -1,0 +1,297 @@
+import {
+  LogActionType,
+  LogStatus,
+  useLogStore,
+} from '@/features/operation-log';
+import { getWorkspaceLibraryPort } from '@/features/library/workspaceImageBridge';
+import {
+  isLocalListMode,
+  refreshLocalImageList,
+  unconfiguredStorageError,
+} from '@/features/library/assetListService';
+import type { StoragePluginId } from '@/storage/createProvider';
+import type { ImageEditData, ImageItem } from '@pixuli/core/types';
+import type { StorageProvider } from '@pixuli/core/plugins';
+
+export type AssetMutationContext = {
+  images: ImageItem[];
+  storageProvider: StorageProvider | null;
+  storageType: StoragePluginId | null;
+};
+
+export type AssetMutationSet = (
+  partial: Partial<{
+    images: ImageItem[];
+    loading: boolean;
+    error: string | null;
+  }>,
+) => void;
+
+export async function deleteAssetImage(
+  imageId: string,
+  fileName: string,
+  get: () => AssetMutationContext,
+  set: AssetMutationSet,
+): Promise<void> {
+  const ctx = get();
+  if (isLocalListMode()) {
+    const image = ctx.images.find(img => img.id === imageId);
+    const relativePath = image?.localPath ?? fileName;
+    set({ loading: true, error: null });
+    try {
+      await getWorkspaceLibraryPort().softDeleteLocal(relativePath);
+      await refreshLocalImageList(set);
+    } catch (error) {
+      set({
+        loading: false,
+        error: error instanceof Error ? error.message : '删除图片失败',
+      });
+    }
+    return;
+  }
+
+  const { storageProvider, storageType } = ctx;
+  if (!storageProvider) {
+    set({ error: unconfiguredStorageError(storageType), loading: false });
+    return;
+  }
+
+  set({ loading: true, error: null });
+  const startTime = Date.now();
+  try {
+    await storageProvider.deleteImage(fileName);
+    const duration = Date.now() - startTime;
+    set({
+      images: get().images.filter(img => img.id !== imageId),
+      loading: false,
+    });
+    useLogStore.getState().addLog(LogActionType.DELETE, LogStatus.SUCCESS, {
+      imageId,
+      imageName: fileName,
+      duration,
+    });
+  } catch (error) {
+    const duration = Date.now() - startTime;
+    const errorMsg = error instanceof Error ? error.message : '删除图片失败';
+    set({ error: errorMsg, loading: false });
+    useLogStore.getState().addLog(LogActionType.DELETE, LogStatus.FAILED, {
+      imageId,
+      imageName: fileName,
+      error: errorMsg,
+      duration,
+    });
+  } finally {
+    set({ loading: false });
+  }
+}
+
+export async function deleteMultipleAssetImages(
+  imageIds: string[],
+  fileNames: string[],
+  get: () => AssetMutationContext,
+  set: AssetMutationSet,
+): Promise<void> {
+  const ctx = get();
+  if (imageIds.length === 0) {
+    return;
+  }
+
+  const batchLogDetails = {
+    imageIds,
+    imageNames: fileNames,
+    count: imageIds.length,
+  };
+
+  if (isLocalListMode()) {
+    const startTime = Date.now();
+    set({ loading: true, error: null });
+    try {
+      for (const imageId of imageIds) {
+        const image = ctx.images.find(img => img.id === imageId);
+        if (image?.localPath) {
+          await getWorkspaceLibraryPort().softDeleteLocal(image.localPath);
+        }
+      }
+      await refreshLocalImageList(set);
+      useLogStore
+        .getState()
+        .addLog(LogActionType.BATCH_DELETE, LogStatus.SUCCESS, {
+          details: batchLogDetails,
+          duration: Date.now() - startTime,
+        });
+    } catch (error) {
+      const errorMsg =
+        error instanceof Error ? error.message : '批量删除图片失败';
+      set({ loading: false, error: errorMsg });
+      useLogStore
+        .getState()
+        .addLog(LogActionType.BATCH_DELETE, LogStatus.FAILED, {
+          details: batchLogDetails,
+          error: errorMsg,
+        });
+    }
+    return;
+  }
+
+  const { storageProvider, storageType } = ctx;
+  if (!storageProvider) {
+    set({ error: unconfiguredStorageError(storageType), loading: false });
+    return;
+  }
+
+  set({ loading: true, error: null });
+  const startTime = Date.now();
+  try {
+    await Promise.all(
+      fileNames.map(fileName => storageProvider.deleteImage(fileName)),
+    );
+    const duration = Date.now() - startTime;
+    set({
+      images: get().images.filter(img => !imageIds.includes(img.id)),
+      loading: false,
+    });
+    useLogStore
+      .getState()
+      .addLog(LogActionType.BATCH_DELETE, LogStatus.SUCCESS, {
+        details: batchLogDetails,
+        duration,
+      });
+  } catch (error) {
+    const duration = Date.now() - startTime;
+    const errorMsg =
+      error instanceof Error ? error.message : '批量删除图片失败';
+    set({ error: errorMsg, loading: false });
+    useLogStore
+      .getState()
+      .addLog(LogActionType.BATCH_DELETE, LogStatus.FAILED, {
+        details: batchLogDetails,
+        error: errorMsg,
+        duration,
+      });
+  } finally {
+    set({ loading: false });
+  }
+}
+
+export async function updateAssetImage(
+  editData: ImageEditData,
+  get: () => AssetMutationContext,
+  set: AssetMutationSet,
+): Promise<void> {
+  const ctx = get();
+  const { storageProvider, storageType, images } = ctx;
+  const image = images.find(img => img.id === editData.id);
+  if (!image) {
+    set({ error: '图片不存在', loading: false });
+    return;
+  }
+
+  if (isLocalListMode()) {
+    if (!image.localPath) {
+      set({ error: '本地路径缺失', loading: false });
+      return;
+    }
+    set({ loading: true, error: null });
+    const startTime = Date.now();
+    try {
+      const workspace = getWorkspaceLibraryPort();
+      let relativePath = image.localPath;
+      if (editData.targetFolder !== undefined && relativePath) {
+        const slash = relativePath.lastIndexOf('/');
+        const currentFolder = slash === -1 ? '' : relativePath.slice(0, slash);
+        const nextFolder = editData.targetFolder || 'images';
+        if (nextFolder !== currentFolder) {
+          await workspace.moveLocalFile(relativePath, nextFolder);
+          const fileName = relativePath.slice(slash + 1);
+          relativePath = nextFolder ? `${nextFolder}/${fileName}` : fileName;
+        }
+      }
+      await workspace.updateLocalMetadata(relativePath, {
+        name: editData.name || image.name,
+        description: editData.description ?? image.description,
+        tags: editData.tags ?? image.tags,
+      });
+      await refreshLocalImageList(set);
+      useLogStore.getState().addLog(LogActionType.EDIT, LogStatus.SUCCESS, {
+        imageId: editData.id,
+        imageName: editData.name || image.name,
+        duration: Date.now() - startTime,
+      });
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : '更新图片失败';
+      set({ error: errorMsg, loading: false });
+      useLogStore.getState().addLog(LogActionType.EDIT, LogStatus.FAILED, {
+        imageId: editData.id,
+        imageName: image.name,
+        error: errorMsg,
+        duration: Date.now() - startTime,
+      });
+    }
+    return;
+  }
+
+  if (!storageProvider) {
+    set({ error: unconfiguredStorageError(storageType), loading: false });
+    return;
+  }
+
+  if (!storageProvider.updateImageMetadata) {
+    set({ error: '当前存储插件不支持更新元数据', loading: false });
+    return;
+  }
+
+  set({ loading: true, error: null });
+  const startTime = Date.now();
+  try {
+    const metadata: ImageItem = {
+      ...image,
+      name: editData.name || image.name,
+      description: editData.description ?? image.description,
+      tags: editData.tags ?? image.tags,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await storageProvider.updateImageMetadata(metadata.name, metadata);
+
+    const duration = Date.now() - startTime;
+    set({
+      images: get().images.map(img =>
+        img.id === editData.id ? { ...img, ...metadata } : img,
+      ),
+      loading: false,
+    });
+    useLogStore.getState().addLog(LogActionType.EDIT, LogStatus.SUCCESS, {
+      imageId: editData.id,
+      imageName: metadata.name,
+      duration,
+      details: {
+        changes: {
+          name:
+            editData.name !== image.name
+              ? { old: image.name, new: editData.name }
+              : undefined,
+          description:
+            editData.description !== image.description
+              ? { old: image.description, new: editData.description }
+              : undefined,
+          tags:
+            editData.tags !== image.tags
+              ? { old: image.tags, new: editData.tags }
+              : undefined,
+        },
+      },
+    });
+  } catch (error) {
+    const duration = Date.now() - startTime;
+    const errorMsg = error instanceof Error ? error.message : '更新图片失败';
+    set({ error: errorMsg, loading: false });
+    useLogStore.getState().addLog(LogActionType.EDIT, LogStatus.FAILED, {
+      imageId: editData.id,
+      imageName: image.name,
+      error: errorMsg,
+      duration,
+    });
+  } finally {
+    set({ loading: false });
+  }
+}

--- a/app/src/features/library/assetProviderSession.ts
+++ b/app/src/features/library/assetProviderSession.ts
@@ -1,0 +1,57 @@
+import { loadGiteeConfig } from '@/features/settings/config/gitee';
+import { loadGitHubConfig } from '@/features/settings/config/github';
+import {
+  createConfiguredStorageProvider,
+  type StoragePluginId,
+} from '@/storage/createProvider';
+import type { GiteeConfig, GitHubConfig } from '@pixuli/core/types';
+import type { StorageProvider } from '@pixuli/core/plugins';
+
+export type ProviderSessionState = {
+  githubConfig: GitHubConfig | null;
+  giteeConfig: GiteeConfig | null;
+  storageType: StoragePluginId | null;
+  storageProvider: StorageProvider | null;
+};
+
+export function resolveInitialProviderSession(): ProviderSessionState {
+  const githubConfig = loadGitHubConfig();
+  const giteeConfig = loadGiteeConfig();
+  const storageType: StoragePluginId | null = giteeConfig
+    ? 'gitee'
+    : githubConfig
+      ? 'github'
+      : null;
+  const initialConfig = giteeConfig || githubConfig;
+
+  return {
+    githubConfig,
+    giteeConfig,
+    storageType,
+    storageProvider:
+      initialConfig && storageType
+        ? createConfiguredStorageProvider(storageType, initialConfig)
+        : null,
+  };
+}
+
+export function createStorageProvider(
+  storageType: StoragePluginId,
+  config: GitHubConfig | GiteeConfig,
+): StorageProvider {
+  return createConfiguredStorageProvider(storageType, config);
+}
+
+export function resolveActiveRepoConfig(
+  storageType: StoragePluginId | null,
+  githubConfig: GitHubConfig | null,
+  giteeConfig: GiteeConfig | null,
+): GitHubConfig | GiteeConfig | null {
+  if (storageType === 'gitee') {
+    return giteeConfig;
+  }
+  if (storageType === 'github') {
+    return githubConfig;
+  }
+  return null;
+}

--- a/app/src/features/library/assetUploadService.ts
+++ b/app/src/features/library/assetUploadService.ts
@@ -1,0 +1,346 @@
+import {
+  LogActionType,
+  LogStatus,
+  useLogStore,
+} from '@/features/operation-log';
+import { getWorkspaceLibraryPort } from '@/features/library/workspaceImageBridge';
+import {
+  isLocalListMode,
+  refreshLocalImageList,
+  unconfiguredStorageError,
+} from '@/features/library/assetListService';
+import type { StoragePluginId } from '@/storage/createProvider';
+import type {
+  BatchUploadProgress,
+  ImageItem,
+  ImageUploadData,
+  MultiImageUploadData,
+  UploadProgress,
+} from '@pixuli/core/types';
+import { getUploadFileName } from '@pixuli/core/types';
+import type { StorageProvider } from '@pixuli/core/plugins';
+
+export type AssetUploadContext = {
+  images: ImageItem[];
+  storageProvider: StorageProvider | null;
+  storageType: StoragePluginId | null;
+};
+
+export type AssetUploadSet = (
+  partial:
+    | Partial<{
+        images: ImageItem[];
+        loading: boolean;
+        error: string | null;
+        batchUploadProgress: BatchUploadProgress | null;
+      }>
+    | ((state: {
+        images: ImageItem[];
+        batchUploadProgress: BatchUploadProgress | null;
+      }) => Partial<{
+        images: ImageItem[];
+        loading: boolean;
+        error: string | null;
+        batchUploadProgress: BatchUploadProgress | null;
+      }>),
+) => void;
+
+function updateBatchItem(
+  set: AssetUploadSet,
+  itemId: string,
+  patch: Partial<UploadProgress> & { completed?: number; failed?: number },
+): void {
+  set(state => {
+    if (!state.batchUploadProgress) {
+      return {};
+    }
+    const { completed, failed, ...itemPatch } = patch;
+    return {
+      batchUploadProgress: {
+        ...state.batchUploadProgress,
+        ...(completed !== undefined ? { completed } : {}),
+        ...(failed !== undefined ? { failed } : {}),
+        items: state.batchUploadProgress.items.map(item =>
+          item.id === itemId ? { ...item, ...itemPatch } : item,
+        ),
+      },
+    };
+  });
+}
+
+export async function uploadAssetImage(
+  uploadData: ImageUploadData,
+  get: () => AssetUploadContext,
+  set: AssetUploadSet,
+): Promise<ImageItem | null> {
+  const ctx = get();
+  if (isLocalListMode()) {
+    const imported =
+      await getWorkspaceLibraryPort().importLocalImage(uploadData);
+    await refreshLocalImageList(set, { quiet: true });
+    if (!imported) {
+      return null;
+    }
+    return get().images.find(image => image.id === imported.id) ?? imported;
+  }
+
+  const { storageProvider, storageType } = ctx;
+  if (!storageProvider) {
+    set({
+      error: unconfiguredStorageError(storageType),
+      loading: false,
+    });
+    return null;
+  }
+
+  set({ loading: true, error: null });
+  const startTime = Date.now();
+  try {
+    const newImage = await storageProvider.uploadImage(uploadData);
+    const duration = Date.now() - startTime;
+    set({
+      images: get().images.some(img => img.id === newImage.id)
+        ? get().images.map(img => (img.id === newImage.id ? newImage : img))
+        : [...get().images, newImage],
+      loading: false,
+    });
+    useLogStore.getState().addLog(LogActionType.UPLOAD, LogStatus.SUCCESS, {
+      imageId: newImage.id,
+      imageName: newImage.name,
+      duration,
+      details: {
+        size: newImage.size,
+        type: newImage.type,
+        capture: newImage.captureMetadata,
+      },
+    });
+    return newImage;
+  } catch (error) {
+    const duration = Date.now() - startTime;
+    const errorMsg = error instanceof Error ? error.message : '上传图片失败';
+    set({ error: errorMsg, loading: false });
+    useLogStore.getState().addLog(LogActionType.UPLOAD, LogStatus.FAILED, {
+      imageName: getUploadFileName(uploadData.file, uploadData.name),
+      error: errorMsg,
+      duration,
+    });
+    return null;
+  } finally {
+    set({ loading: false });
+  }
+}
+
+export async function uploadMultipleAssetImages(
+  uploadData: MultiImageUploadData,
+  get: () => AssetUploadContext,
+  set: AssetUploadSet,
+): Promise<ImageItem[]> {
+  const ctx = get();
+  const { files, name, description, tags, captureMetadataList } = uploadData;
+
+  if (isLocalListMode()) {
+    const total = files.length;
+    if (total === 0) {
+      return [];
+    }
+
+    let completed = 0;
+    let failed = 0;
+    const startTime = Date.now();
+    const imported: ImageItem[] = [];
+    const items: UploadProgress[] = files.map((_file, index) => ({
+      id: `${Date.now()}-${index}`,
+      progress: 0,
+      status: 'uploading' as const,
+      message: '等待导入...',
+    }));
+
+    set({
+      error: null,
+      batchUploadProgress: {
+        total,
+        completed: 0,
+        failed: 0,
+        current: files[0]?.name,
+        items,
+      },
+    });
+
+    try {
+      for (let i = 0; i < files.length; i++) {
+        const file = files[i];
+        const itemId = items[i].id;
+        set(state => ({
+          batchUploadProgress: state.batchUploadProgress
+            ? {
+                ...state.batchUploadProgress,
+                current: file.name,
+              }
+            : null,
+        }));
+        updateBatchItem(set, itemId, {
+          status: 'uploading',
+          message: '正在导入...',
+        });
+
+        try {
+          const created = await getWorkspaceLibraryPort().importLocalImage({
+            file,
+            name,
+            description,
+            tags,
+            targetFolder: uploadData.targetFolder,
+            captureMetadata: captureMetadataList?.[i],
+          });
+          if (created) {
+            imported.push(created);
+          }
+          completed++;
+          updateBatchItem(set, itemId, {
+            completed,
+            status: 'success',
+            progress: 100,
+            message: '导入成功',
+          });
+        } catch (error) {
+          failed++;
+          updateBatchItem(set, itemId, {
+            failed,
+            status: 'error',
+            message: error instanceof Error ? error.message : '导入失败',
+          });
+        }
+      }
+
+      await refreshLocalImageList(set, { quiet: true });
+      set({ batchUploadProgress: null });
+      useLogStore
+        .getState()
+        .addLog(LogActionType.BATCH_UPLOAD, LogStatus.SUCCESS, {
+          details: { total, completed, failed },
+          duration: Date.now() - startTime,
+        });
+      const importedIds = new Set(imported.map(item => item.id));
+      return get().images.filter(image => importedIds.has(image.id));
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : '批量导入失败';
+      set({ error: errorMsg, batchUploadProgress: null });
+      useLogStore
+        .getState()
+        .addLog(LogActionType.BATCH_UPLOAD, LogStatus.FAILED, {
+          error: errorMsg,
+          details: { total, completed, failed },
+        });
+      return [];
+    }
+  }
+
+  const { storageProvider, storageType } = ctx;
+  if (!storageProvider) {
+    set({
+      error: unconfiguredStorageError(storageType),
+      loading: false,
+    });
+    return [];
+  }
+
+  const total = files.length;
+  let completed = 0;
+  let failed = 0;
+  const uploadedImages: ImageItem[] = [];
+
+  try {
+    const items: UploadProgress[] = files.map((_file, index) => ({
+      id: `${Date.now()}-${index}`,
+      progress: 0,
+      status: 'uploading' as const,
+      message: '等待上传...',
+    }));
+
+    set({
+      loading: true,
+      error: null,
+      batchUploadProgress: {
+        total,
+        completed: 0,
+        failed: 0,
+        current: files[0]?.name,
+        items,
+      },
+    });
+
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
+      const itemId = items[i].id;
+
+      try {
+        set(state => ({
+          batchUploadProgress: state.batchUploadProgress
+            ? { ...state.batchUploadProgress, current: file.name }
+            : null,
+        }));
+        updateBatchItem(set, itemId, {
+          status: 'uploading',
+          message: '正在上传...',
+        });
+
+        const fileName = name ? `${name}-${i + 1}-${file.name}` : file.name;
+        const singleUploadData: ImageUploadData = {
+          file,
+          name: fileName,
+          description,
+          tags,
+          captureMetadata: captureMetadataList?.[i],
+        };
+
+        const newImage = await storageProvider.uploadImage(singleUploadData);
+        uploadedImages.push(newImage);
+        completed++;
+        updateBatchItem(set, itemId, {
+          completed,
+          status: 'success',
+          progress: 100,
+          message: '上传成功',
+        });
+      } catch (error) {
+        failed++;
+        updateBatchItem(set, itemId, {
+          failed,
+          status: 'error',
+          message: error instanceof Error ? error.message : '上传失败',
+        });
+      }
+    }
+
+    const batchStartTime = Date.now();
+    set({
+      images: [...get().images, ...uploadedImages],
+      loading: false,
+      batchUploadProgress: null,
+    });
+    useLogStore
+      .getState()
+      .addLog(LogActionType.BATCH_UPLOAD, LogStatus.SUCCESS, {
+        details: {
+          total,
+          completed,
+          failed,
+          images: uploadedImages.map(img => ({ id: img.id, name: img.name })),
+        },
+        duration: Date.now() - batchStartTime,
+      });
+    return uploadedImages;
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : '批量上传失败';
+    set({ error: errorMsg, loading: false, batchUploadProgress: null });
+    useLogStore
+      .getState()
+      .addLog(LogActionType.BATCH_UPLOAD, LogStatus.FAILED, {
+        error: errorMsg,
+        details: { total, completed, failed },
+      });
+    return uploadedImages;
+  } finally {
+    set({ loading: false });
+  }
+}

--- a/app/src/features/library/image-upload/ImageUpload.tsx
+++ b/app/src/features/library/image-upload/ImageUpload.tsx
@@ -3,14 +3,12 @@ import { useDropzone } from 'react-dropzone';
 import { defaultTranslate } from '@/i18n/locales';
 import type {
   BatchUploadProgress,
-  ImageCaptureMetadata,
   ImageCompressionOptions,
   ImageCropOptions,
   ImageUploadData,
   MultiImageUploadData,
   WebImageUploadData,
 } from '@pixuli/core/types';
-import { compressImage } from '@pixuli/core/utils';
 import {
   showInfo,
   showLoading,
@@ -23,14 +21,12 @@ import { ImageUploadBatchProgress } from './ImageUploadBatchProgress';
 import { ImageUploadConfirmForm } from './ImageUploadConfirmForm';
 import { ImageUploadDropzone } from './ImageUploadDropzone';
 import {
-  DEFAULT_COMPRESSION_OPTIONS,
-  type CompressionPreviewMap,
-} from './imageUploadTypes';
-import {
   getImageDimensions,
   isPreviewableMedia,
   resolveDefaultFolder,
 } from './imageUploadUtils';
+import { useImageUploadCapture } from './useImageUploadCapture';
+import { useImageUploadCompression } from './useImageUploadCompression';
 import './ImageUpload.css';
 
 interface ImageUploadProps {
@@ -87,189 +83,55 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
   const [fileDimensions, setFileDimensions] = useState<{
     [key: string]: { width: number; height: number };
   }>({});
-  const [userWantsCompress, setUserWantsCompress] = useState(false);
   const [userWantsCrop, setUserWantsCrop] = useState(false);
-  const [compressionPreview, setCompressionPreview] =
-    useState<CompressionPreviewMap>({});
-  const [calculatingCompression, setCalculatingCompression] = useState(false);
-  const [showCompressionConfig, setShowCompressionConfig] = useState(false);
-  const [userCompressionConfig, setUserCompressionConfig] =
-    useState<ImageCompressionOptions>(
-      compressionOptions || DEFAULT_COMPRESSION_OPTIONS,
-    );
   const tagInputRef = useRef<HTMLInputElement>(null);
-  const captureMetadataByFileRef = useRef(
-    new WeakMap<File, ImageCaptureMetadata>(),
-  );
 
-  const rememberCaptureMetadata = useCallback(
-    (file: File, metadata?: ImageCaptureMetadata) => {
-      if (metadata) {
-        captureMetadataByFileRef.current.set(file, metadata);
-      }
-    },
-    [],
-  );
+  const {
+    rememberCaptureMetadata,
+    transferCaptureMetadata,
+    getCaptureMetadata,
+    buildCaptureMetadataList,
+  } = useImageUploadCapture();
 
-  const transferCaptureMetadata = useCallback((from: File, to: File) => {
-    const metadata = captureMetadataByFileRef.current.get(from);
-    if (metadata) {
-      captureMetadataByFileRef.current.set(to, metadata);
-      captureMetadataByFileRef.current.delete(from);
+  const {
+    userWantsCompress,
+    compressionPreview,
+    calculatingCompression,
+    showCompressionConfig,
+    userCompressionConfig,
+    setShowCompressionConfig,
+    compressFileIfNeeded,
+    handleCompressionToggle: toggleCompressionPreview,
+    handleCompressionConfigChange: applyCompressionConfig,
+    resetCompressionState,
+  } = useImageUploadCompression({
+    enableCompression,
+    compressionOptions,
+    fileDimensions,
+  });
+
+  const getPreviewFiles = useCallback((): File[] => {
+    if (uploadData) {
+      return [uploadData.file];
     }
-  }, []);
+    if (multiUploadData) {
+      return multiUploadData.files;
+    }
+    return [];
+  }, [uploadData, multiUploadData]);
 
-  const getCaptureMetadata = useCallback(
-    (file: File): ImageCaptureMetadata | undefined =>
-      captureMetadataByFileRef.current.get(file),
-    [],
-  );
-
-  const buildCaptureMetadataList = useCallback(
-    (files: File[]) => files.map(file => getCaptureMetadata(file)),
-    [getCaptureMetadata],
-  );
-
-  // 使用 ref 存储预览数据，避免依赖变化导致函数重新创建
-  const compressionPreviewRef = useRef(compressionPreview);
-  useEffect(() => {
-    compressionPreviewRef.current = compressionPreview;
-  }, [compressionPreview]);
-
-  // 清理预览URL的辅助函数
-  const cleanupPreviewUrls = useCallback(() => {
-    Object.values(compressionPreviewRef.current).forEach(preview => {
-      if (preview.originalPreviewUrl) {
-        URL.revokeObjectURL(preview.originalPreviewUrl);
-      }
-      if (preview.compressedPreviewUrl) {
-        URL.revokeObjectURL(preview.compressedPreviewUrl);
-      }
-    });
-  }, []);
-
-  // 组件卸载时清理预览URL
-  useEffect(() => {
-    return () => {
-      cleanupPreviewUrls();
-    };
-  }, [cleanupPreviewUrls]);
-
-  // 压缩文件的辅助函数
-  const compressFileIfNeeded = useCallback(
-    async (file: File, shouldCompress: boolean): Promise<File> => {
-      if (!shouldCompress || !enableCompression) {
-        return file;
-      }
-
-      try {
-        const compressionResult = await compressImage(
-          file,
-          userCompressionConfig,
-        );
-        if (compressionResult.compressionRatio > 0) {
-          showInfo(
-            `图片已压缩: ${compressionResult.compressionRatio.toFixed(1)}% (${(compressionResult.originalSize / 1024 / 1024).toFixed(2)}MB → ${(compressionResult.compressedSize / 1024 / 1024).toFixed(2)}MB)`,
-          );
-        }
-        return compressionResult.compressedFile;
-      } catch (error) {
-        console.warn('图片压缩失败，使用原文件:', error);
-        showInfo('图片压缩失败，将使用原文件上传');
-        return file;
-      }
-    },
-    [enableCompression, userCompressionConfig],
-  );
-
-  // 计算压缩预览
-  const calculateCompressionPreview = useCallback(
-    async (files: File[]) => {
-      if (!enableCompression || files.length === 0) {
-        setCompressionPreview({});
-        return;
-      }
-
-      setCalculatingCompression(true);
-      const preview: typeof compressionPreview = {};
-
-      try {
-        await Promise.all(
-          files.map(async file => {
-            try {
-              // 创建原图预览URL
-              const originalPreviewUrl = URL.createObjectURL(file);
-
-              const result = await compressImage(file, userCompressionConfig);
-
-              // 创建压缩后图片预览URL
-              const compressedPreviewUrl = URL.createObjectURL(
-                result.compressedFile,
-              );
-
-              preview[file.name] = {
-                originalSize: result.originalSize,
-                compressedSize: result.compressedSize,
-                compressionRatio: result.compressionRatio,
-                originalDimensions: result.originalDimensions,
-                compressedDimensions: result.compressedDimensions,
-                originalPreviewUrl,
-                compressedPreviewUrl,
-              };
-            } catch (error) {
-              console.warn(`计算压缩预览失败 ${file.name}:`, error);
-              // 如果计算失败，使用原始信息
-              const dimensions = fileDimensions[file.name] || {
-                width: 0,
-                height: 0,
-              };
-              const originalPreviewUrl = URL.createObjectURL(file);
-              preview[file.name] = {
-                originalSize: file.size,
-                compressedSize: file.size,
-                compressionRatio: 0,
-                originalDimensions: dimensions,
-                compressedDimensions: dimensions,
-                originalPreviewUrl,
-              };
-            }
-          }),
-        );
-        setCompressionPreview(preview);
-      } catch (error) {
-        console.error('计算压缩预览时出错:', error);
-      } finally {
-        setCalculatingCompression(false);
-      }
-    },
-    [enableCompression, userCompressionConfig, fileDimensions],
-  );
-
-  // 当用户选择压缩时，计算预览
   const handleCompressionToggle = useCallback(
     (checked: boolean) => {
-      setUserWantsCompress(checked);
-      if (checked) {
-        const files = uploadData
-          ? [uploadData.file]
-          : multiUploadData
-            ? multiUploadData.files
-            : [];
-        if (files.length > 0) {
-          calculateCompressionPreview(files);
-        }
-      } else {
-        // 清理预览URL
-        cleanupPreviewUrls();
-        setCompressionPreview({});
-      }
+      toggleCompressionPreview(checked, getPreviewFiles());
     },
-    [
-      uploadData,
-      multiUploadData,
-      calculateCompressionPreview,
-      cleanupPreviewUrls,
-    ],
+    [toggleCompressionPreview, getPreviewFiles],
+  );
+
+  const handleCompressionConfigChange = useCallback(
+    (config: ImageCompressionOptions) => {
+      applyCompressionConfig(config, getPreviewFiles());
+    },
+    [applyCompressionConfig, getPreviewFiles],
   );
 
   const onDrop = useCallback(
@@ -292,17 +154,8 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
 
         setFileDimensions(dimensionsMap);
 
-        // 重置用户选择
-        setUserWantsCompress(false);
+        resetCompressionState();
         setUserWantsCrop(false);
-        // 清理预览URL
-        cleanupPreviewUrls();
-        setCompressionPreview({});
-        setShowCompressionConfig(false);
-        // 重置为用户配置或默认配置
-        setUserCompressionConfig(
-          compressionOptions || DEFAULT_COMPRESSION_OPTIONS,
-        );
 
         if (acceptedFiles.length === 1) {
           // 单文件短确认
@@ -337,13 +190,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
         }
       }
     },
-    [
-      translate,
-      getImageDimensions,
-      defaultFolder,
-      cleanupPreviewUrls,
-      compressionOptions,
-    ],
+    [translate, getImageDimensions, defaultFolder, resetCompressionState],
   );
 
   useEffect(() => {
@@ -574,8 +421,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
 
   const handleCancel = useCallback(() => {
     showInfo(translate('image.upload.cancelled'));
-    // 清理预览URL
-    cleanupPreviewUrls();
+    resetCompressionState();
     setUploadData(null);
     setMultiUploadData(null);
     setShowForm(false);
@@ -583,8 +429,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
     setShowCropModal(false);
     setCropFile(null);
     setCropFileIndex(-1);
-    setCompressionPreview({});
-  }, [translate, cleanupPreviewUrls]);
+  }, [translate, resetCompressionState]);
 
   // 处理裁剪完成
   const handleCropComplete = async (croppedFile: File) => {
@@ -956,28 +801,6 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
       setUploadData({ ...uploadData, targetFolder: value });
     }
   };
-
-  const handleCompressionConfigChange = useCallback(
-    (config: ImageCompressionOptions) => {
-      setUserCompressionConfig(config);
-      if (userWantsCompress) {
-        const previewFiles = uploadData
-          ? [uploadData.file]
-          : multiUploadData
-            ? multiUploadData.files
-            : [];
-        if (previewFiles.length > 0) {
-          void calculateCompressionPreview(previewFiles);
-        }
-      }
-    },
-    [
-      userWantsCompress,
-      uploadData,
-      multiUploadData,
-      calculateCompressionPreview,
-    ],
-  );
 
   const handleFormFieldChange = (
     field: keyof WebImageUploadData | keyof MultiImageUploadData,

--- a/app/src/features/library/image-upload/useImageUploadCapture.ts
+++ b/app/src/features/library/image-upload/useImageUploadCapture.ts
@@ -1,0 +1,44 @@
+import { useCallback, useRef } from 'react';
+import type { ImageCaptureMetadata } from '@pixuli/core/types';
+
+/** 上传流程中按 File 对象暂存 EXIF/拍摄元数据（WeakMap 避免泄漏） */
+export function useImageUploadCapture() {
+  const captureMetadataByFileRef = useRef(
+    new WeakMap<File, ImageCaptureMetadata>(),
+  );
+
+  const rememberCaptureMetadata = useCallback(
+    (file: File, metadata?: ImageCaptureMetadata) => {
+      if (metadata) {
+        captureMetadataByFileRef.current.set(file, metadata);
+      }
+    },
+    [],
+  );
+
+  const transferCaptureMetadata = useCallback((from: File, to: File) => {
+    const metadata = captureMetadataByFileRef.current.get(from);
+    if (metadata) {
+      captureMetadataByFileRef.current.set(to, metadata);
+      captureMetadataByFileRef.current.delete(from);
+    }
+  }, []);
+
+  const getCaptureMetadata = useCallback(
+    (file: File): ImageCaptureMetadata | undefined =>
+      captureMetadataByFileRef.current.get(file),
+    [],
+  );
+
+  const buildCaptureMetadataList = useCallback(
+    (files: File[]) => files.map(file => getCaptureMetadata(file)),
+    [getCaptureMetadata],
+  );
+
+  return {
+    rememberCaptureMetadata,
+    transferCaptureMetadata,
+    getCaptureMetadata,
+    buildCaptureMetadataList,
+  };
+}

--- a/app/src/features/library/image-upload/useImageUploadCompression.ts
+++ b/app/src/features/library/image-upload/useImageUploadCompression.ts
@@ -1,0 +1,172 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { ImageCompressionOptions } from '@pixuli/core/types';
+import { compressImage } from '@pixuli/core/utils';
+import { showInfo } from '@/ui/feedback/toast';
+import {
+  DEFAULT_COMPRESSION_OPTIONS,
+  type CompressionPreviewMap,
+} from './imageUploadTypes';
+
+interface UseImageUploadCompressionOptions {
+  enableCompression: boolean;
+  compressionOptions?: ImageCompressionOptions;
+  fileDimensions: Record<string, { width: number; height: number }>;
+}
+
+export function useImageUploadCompression({
+  enableCompression,
+  compressionOptions,
+  fileDimensions,
+}: UseImageUploadCompressionOptions) {
+  const [userWantsCompress, setUserWantsCompress] = useState(false);
+  const [compressionPreview, setCompressionPreview] =
+    useState<CompressionPreviewMap>({});
+  const [calculatingCompression, setCalculatingCompression] = useState(false);
+  const [showCompressionConfig, setShowCompressionConfig] = useState(false);
+  const [userCompressionConfig, setUserCompressionConfig] =
+    useState<ImageCompressionOptions>(
+      compressionOptions || DEFAULT_COMPRESSION_OPTIONS,
+    );
+
+  const compressionPreviewRef = useRef(compressionPreview);
+  useEffect(() => {
+    compressionPreviewRef.current = compressionPreview;
+  }, [compressionPreview]);
+
+  const cleanupPreviewUrls = useCallback(() => {
+    Object.values(compressionPreviewRef.current).forEach(preview => {
+      if (preview.originalPreviewUrl) {
+        URL.revokeObjectURL(preview.originalPreviewUrl);
+      }
+      if (preview.compressedPreviewUrl) {
+        URL.revokeObjectURL(preview.compressedPreviewUrl);
+      }
+    });
+  }, []);
+
+  useEffect(() => () => cleanupPreviewUrls(), [cleanupPreviewUrls]);
+
+  const compressFileIfNeeded = useCallback(
+    async (file: File, shouldCompress: boolean): Promise<File> => {
+      if (!shouldCompress || !enableCompression) {
+        return file;
+      }
+      try {
+        const compressionResult = await compressImage(
+          file,
+          userCompressionConfig,
+        );
+        if (compressionResult.compressionRatio > 0) {
+          showInfo(
+            `图片已压缩: ${compressionResult.compressionRatio.toFixed(1)}% (${(compressionResult.originalSize / 1024 / 1024).toFixed(2)}MB → ${(compressionResult.compressedSize / 1024 / 1024).toFixed(2)}MB)`,
+          );
+        }
+        return compressionResult.compressedFile;
+      } catch (error) {
+        console.warn('图片压缩失败，使用原文件:', error);
+        showInfo('图片压缩失败，将使用原文件上传');
+        return file;
+      }
+    },
+    [enableCompression, userCompressionConfig],
+  );
+
+  const calculateCompressionPreview = useCallback(
+    async (files: File[]) => {
+      if (!enableCompression || files.length === 0) {
+        setCompressionPreview({});
+        return;
+      }
+
+      setCalculatingCompression(true);
+      const preview: CompressionPreviewMap = {};
+
+      try {
+        await Promise.all(
+          files.map(async file => {
+            try {
+              const originalPreviewUrl = URL.createObjectURL(file);
+              const result = await compressImage(file, userCompressionConfig);
+              const compressedPreviewUrl = URL.createObjectURL(
+                result.compressedFile,
+              );
+              preview[file.name] = {
+                originalSize: result.originalSize,
+                compressedSize: result.compressedSize,
+                compressionRatio: result.compressionRatio,
+                originalDimensions: result.originalDimensions,
+                compressedDimensions: result.compressedDimensions,
+                originalPreviewUrl,
+                compressedPreviewUrl,
+              };
+            } catch (error) {
+              console.warn(`计算压缩预览失败 ${file.name}:`, error);
+              const dimensions = fileDimensions[file.name] || {
+                width: 0,
+                height: 0,
+              };
+              preview[file.name] = {
+                originalSize: file.size,
+                compressedSize: file.size,
+                compressionRatio: 0,
+                originalDimensions: dimensions,
+                compressedDimensions: dimensions,
+                originalPreviewUrl: URL.createObjectURL(file),
+              };
+            }
+          }),
+        );
+        setCompressionPreview(preview);
+      } catch (error) {
+        console.error('计算压缩预览时出错:', error);
+      } finally {
+        setCalculatingCompression(false);
+      }
+    },
+    [enableCompression, userCompressionConfig, fileDimensions],
+  );
+
+  const handleCompressionToggle = useCallback(
+    (checked: boolean, files: File[]) => {
+      setUserWantsCompress(checked);
+      if (checked && files.length > 0) {
+        void calculateCompressionPreview(files);
+      } else {
+        cleanupPreviewUrls();
+        setCompressionPreview({});
+      }
+    },
+    [calculateCompressionPreview, cleanupPreviewUrls],
+  );
+
+  const handleCompressionConfigChange = useCallback(
+    (config: ImageCompressionOptions, previewFiles: File[]) => {
+      setUserCompressionConfig(config);
+      if (userWantsCompress && previewFiles.length > 0) {
+        void calculateCompressionPreview(previewFiles);
+      }
+    },
+    [userWantsCompress, calculateCompressionPreview],
+  );
+
+  const resetCompressionState = useCallback(() => {
+    cleanupPreviewUrls();
+    setCompressionPreview({});
+    setUserWantsCompress(false);
+    setShowCompressionConfig(false);
+    setUserCompressionConfig(compressionOptions || DEFAULT_COMPRESSION_OPTIONS);
+  }, [cleanupPreviewUrls, compressionOptions]);
+
+  return {
+    userWantsCompress,
+    compressionPreview,
+    calculatingCompression,
+    showCompressionConfig,
+    userCompressionConfig,
+    setShowCompressionConfig,
+    compressFileIfNeeded,
+    handleCompressionToggle,
+    handleCompressionConfigChange,
+    resetCompressionState,
+  };
+}

--- a/app/src/features/library/imageStore.ts
+++ b/app/src/features/library/imageStore.ts
@@ -1,28 +1,39 @@
 import {
   clearGiteeConfig,
-  loadGiteeConfig,
   saveGiteeConfig,
 } from '@/features/settings/config/gitee';
 import {
   clearGitHubConfig,
-  loadGitHubConfig,
   saveGitHubConfig,
 } from '@/features/settings/config/github';
-import {
-  createConfiguredStorageProvider,
-  storagePluginLabel,
-  type StoragePluginId,
-} from '@/storage/createProvider';
-import { isWorkspaceAvailable } from '@/platforms/workspacePlatform';
+import type { StoragePluginId } from '@/storage/createProvider';
 import {
   LogActionType,
   LogStatus,
   useLogStore,
 } from '@/features/operation-log';
 import {
-  getWorkspaceLibraryPort,
-  registerLibraryImageReset,
-} from '@/features/library/workspaceImageBridge';
+  deleteAssetImage,
+  deleteMultipleAssetImages,
+  updateAssetImage,
+} from '@/features/library/assetMutationService';
+import {
+  uploadAssetImage,
+  uploadMultipleAssetImages,
+} from '@/features/library/assetUploadService';
+import {
+  createStorageProvider,
+  resolveInitialProviderSession,
+  resolveActiveRepoConfig,
+} from '@/features/library/assetProviderSession';
+import {
+  isLocalListMode,
+  loadRemoteImageList,
+  refreshLocalImageList,
+  shouldSkipRemoteListLoad,
+  unconfiguredStorageError,
+} from '@/features/library/assetListService';
+import { registerLibraryImageReset } from '@/features/library/workspaceImageBridge';
 import type {
   BatchUploadProgress,
   GiteeConfig,
@@ -31,9 +42,7 @@ import type {
   ImageItem,
   ImageUploadData,
   MultiImageUploadData,
-  UploadProgress,
 } from '@pixuli/core/types';
-import { getUploadFileName } from '@pixuli/core/types';
 import type { StorageProvider } from '@pixuli/core/plugins';
 import { create } from 'zustand';
 
@@ -73,55 +82,17 @@ interface ImageState {
   setBatchUploadProgress: (progress: BatchUploadProgress | null) => void;
 }
 
-function isLocalListMode(): boolean {
-  return getWorkspaceLibraryPort().isLocalActive();
-}
-
-async function refreshLocalIntoImageStore(
-  set: (partial: Partial<ImageState>) => void,
-  options?: { quiet?: boolean },
-): Promise<void> {
-  const workspace = getWorkspaceLibraryPort();
-  const quiet = options?.quiet === true;
-  if (!quiet) {
-    set({ loading: true, error: null });
-  }
-  try {
-    await workspace.refreshLocalImages(quiet ? { quiet: true } : undefined);
-    set({
-      images: workspace.getLocalImages(),
-      loading: false,
-    });
-  } catch (error) {
-    set({
-      loading: false,
-      error: error instanceof Error ? error.message : '加载本地图片失败',
-    });
-  }
-}
-
 export const useImageStore = create<ImageState>((set, get) => {
-  const initialGitHubConfig = loadGitHubConfig();
-  const initialGiteeConfig = loadGiteeConfig();
-
-  const storageType: StoragePluginId | null = initialGiteeConfig
-    ? 'gitee'
-    : initialGitHubConfig
-      ? 'github'
-      : null;
-  const initialConfig = initialGiteeConfig || initialGitHubConfig;
+  const initialSession = resolveInitialProviderSession();
 
   return {
     images: [],
     loading: false,
     error: null,
-    githubConfig: initialGitHubConfig,
-    giteeConfig: initialGiteeConfig,
-    storageProvider:
-      initialConfig && storageType
-        ? createConfiguredStorageProvider(storageType, initialConfig)
-        : null,
-    storageType,
+    githubConfig: initialSession.githubConfig,
+    giteeConfig: initialSession.giteeConfig,
+    storageProvider: initialSession.storageProvider,
+    storageType: initialSession.storageType,
     batchUploadProgress: null,
 
     setGitHubConfig: (config: GitHubConfig) => {
@@ -178,39 +149,34 @@ export const useImageStore = create<ImageState>((set, get) => {
 
     initializeStorage: () => {
       const { githubConfig, giteeConfig, storageType } = get();
-
-      if (storageType === 'gitee' && giteeConfig) {
-        try {
-          const storageProvider = createConfiguredStorageProvider(
-            'gitee',
-            giteeConfig,
-          );
-          set({ storageProvider });
-        } catch (error) {
-          console.error('Failed to initialize gitee storage provider:', error);
-          set({ error: '初始化Gitee存储服务失败' });
-        }
-      } else if (storageType === 'github' && githubConfig) {
-        try {
-          const storageProvider = createConfiguredStorageProvider(
-            'github',
-            githubConfig,
-          );
-          set({ storageProvider });
-        } catch (error) {
-          console.error('Failed to initialize github storage provider:', error);
-          set({ error: '初始化GitHub存储服务失败' });
-        }
+      const config = resolveActiveRepoConfig(
+        storageType,
+        githubConfig,
+        giteeConfig,
+      );
+      if (!storageType || !config) {
+        return;
+      }
+      try {
+        set({ storageProvider: createStorageProvider(storageType, config) });
+      } catch (error) {
+        console.error('Failed to initialize storage provider:', error);
+        set({
+          error:
+            storageType === 'gitee'
+              ? '初始化Gitee存储服务失败'
+              : '初始化GitHub存储服务失败',
+        });
       }
     },
 
     loadImages: async () => {
-      if (isWorkspaceAvailable() && !isLocalListMode()) {
+      if (shouldSkipRemoteListLoad()) {
         return;
       }
 
       if (isLocalListMode()) {
-        await refreshLocalIntoImageStore(set);
+        await refreshLocalImageList(set);
         return;
       }
 
@@ -218,28 +184,14 @@ export const useImageStore = create<ImageState>((set, get) => {
 
       if (!storageProvider) {
         set({
-          error: `${storagePluginLabel(storageType)} 配置未初始化`,
+          error: unconfiguredStorageError(storageType),
         });
         return;
       }
 
       set({ loading: true, error: null });
       try {
-        const images = await storageProvider.listImages();
-
-        const uniqueImages = images.reduce((acc: ImageItem[], current) => {
-          const existingIndex = acc.findIndex(img => img.id === current.id);
-          if (existingIndex === -1) {
-            acc.push(current);
-          } else {
-            const existing = acc[existingIndex];
-            if (new Date(current.updatedAt) > new Date(existing.updatedAt)) {
-              acc[existingIndex] = current;
-            }
-          }
-          return acc;
-        }, []);
-
+        const uniqueImages = await loadRemoteImageList(storageProvider);
         set({ images: uniqueImages, loading: false });
       } catch (error) {
         const errorMsg =
@@ -251,639 +203,62 @@ export const useImageStore = create<ImageState>((set, get) => {
       }
     },
 
-    uploadImage: async (uploadData: ImageUploadData) => {
-      if (isLocalListMode()) {
-        const imported =
-          await getWorkspaceLibraryPort().importLocalImage(uploadData);
-        await refreshLocalIntoImageStore(set, { quiet: true });
-        if (!imported) {
-          return null;
-        }
-        return get().images.find(image => image.id === imported.id) ?? imported;
-      }
+    uploadImage: async (uploadData: ImageUploadData) =>
+      uploadAssetImage(
+        uploadData,
+        () => ({
+          images: get().images,
+          storageProvider: get().storageProvider,
+          storageType: get().storageType,
+        }),
+        set,
+      ),
 
-      const { storageProvider, storageType } = get();
-      if (!storageProvider) {
-        set({
-          error: `${storagePluginLabel(storageType)} 配置未初始化`,
-          loading: false,
-        });
-        return null;
-      }
+    uploadMultipleImages: async (uploadData: MultiImageUploadData) =>
+      uploadMultipleAssetImages(
+        uploadData,
+        () => ({
+          images: get().images,
+          storageProvider: get().storageProvider,
+          storageType: get().storageType,
+        }),
+        set,
+      ),
 
-      set({ loading: true, error: null });
-      const startTime = Date.now();
-      try {
-        const newImage = await storageProvider.uploadImage(uploadData);
-        const duration = Date.now() - startTime;
-        set(state => ({
-          images: state.images.some(img => img.id === newImage.id)
-            ? state.images.map(img => (img.id === newImage.id ? newImage : img))
-            : [...state.images, newImage],
-          loading: false,
-        }));
-        useLogStore.getState().addLog(LogActionType.UPLOAD, LogStatus.SUCCESS, {
-          imageId: newImage.id,
-          imageName: newImage.name,
-          duration,
-          details: {
-            size: newImage.size,
-            type: newImage.type,
-            capture: newImage.captureMetadata,
-          },
-        });
-        return newImage;
-      } catch (error) {
-        const duration = Date.now() - startTime;
-        const errorMsg =
-          error instanceof Error ? error.message : '上传图片失败';
-        set({
-          error: errorMsg,
-          loading: false,
-        });
-        useLogStore.getState().addLog(LogActionType.UPLOAD, LogStatus.FAILED, {
-          imageName: getUploadFileName(uploadData.file, uploadData.name),
-          error: errorMsg,
-          duration,
-        });
-        return null;
-      } finally {
-        set({ loading: false });
-      }
-    },
+    deleteImage: async (imageId: string, fileName: string) =>
+      deleteAssetImage(
+        imageId,
+        fileName,
+        () => ({
+          images: get().images,
+          storageProvider: get().storageProvider,
+          storageType: get().storageType,
+        }),
+        set,
+      ),
 
-    uploadMultipleImages: async (uploadData: MultiImageUploadData) => {
-      const { files, name, description, tags, captureMetadataList } =
-        uploadData;
-
-      if (isLocalListMode()) {
-        const total = files.length;
-        if (total === 0) {
-          return [];
-        }
-
-        let completed = 0;
-        let failed = 0;
-        const startTime = Date.now();
-        const imported: ImageItem[] = [];
-        const items: UploadProgress[] = files.map((_file, index) => ({
-          id: `${Date.now()}-${index}`,
-          progress: 0,
-          status: 'uploading' as const,
-          message: '等待导入...',
-        }));
-
-        // 批量添加不锁壳层：进度走 batchUploadProgress / toast，不置 loading（§5.1）
-        set({
-          error: null,
-          batchUploadProgress: {
-            total,
-            completed: 0,
-            failed: 0,
-            current: files[0]?.name,
-            items,
-          },
-        });
-
-        try {
-          for (let i = 0; i < files.length; i++) {
-            const file = files[i];
-            const itemId = items[i].id;
-            set(state => ({
-              batchUploadProgress: state.batchUploadProgress
-                ? {
-                    ...state.batchUploadProgress,
-                    current: file.name,
-                    items: state.batchUploadProgress.items.map(item =>
-                      item.id === itemId
-                        ? {
-                            ...item,
-                            status: 'uploading',
-                            message: '正在导入...',
-                          }
-                        : item,
-                    ),
-                  }
-                : null,
-            }));
-
-            try {
-              const created = await getWorkspaceLibraryPort().importLocalImage({
-                file,
-                name,
-                description,
-                tags,
-                targetFolder: uploadData.targetFolder,
-                captureMetadata: captureMetadataList?.[i],
-              });
-              if (created) {
-                imported.push(created);
-              }
-              completed++;
-              set(state => ({
-                batchUploadProgress: state.batchUploadProgress
-                  ? {
-                      ...state.batchUploadProgress,
-                      completed,
-                      items: state.batchUploadProgress.items.map(item =>
-                        item.id === itemId
-                          ? {
-                              ...item,
-                              status: 'success',
-                              progress: 100,
-                              message: '导入成功',
-                            }
-                          : item,
-                      ),
-                    }
-                  : null,
-              }));
-            } catch (error) {
-              failed++;
-              const errorMessage =
-                error instanceof Error ? error.message : '导入失败';
-              set(state => ({
-                batchUploadProgress: state.batchUploadProgress
-                  ? {
-                      ...state.batchUploadProgress,
-                      failed,
-                      items: state.batchUploadProgress.items.map(item =>
-                        item.id === itemId
-                          ? {
-                              ...item,
-                              status: 'error',
-                              message: errorMessage,
-                            }
-                          : item,
-                      ),
-                    }
-                  : null,
-              }));
-            }
-          }
-
-          await refreshLocalIntoImageStore(set, { quiet: true });
-          set({ batchUploadProgress: null });
-          useLogStore
-            .getState()
-            .addLog(LogActionType.BATCH_UPLOAD, LogStatus.SUCCESS, {
-              details: { total, completed, failed },
-              duration: Date.now() - startTime,
-            });
-          const importedIds = new Set(imported.map(item => item.id));
-          return get().images.filter(image => importedIds.has(image.id));
-        } catch (error) {
-          const errorMsg =
-            error instanceof Error ? error.message : '批量导入失败';
-          set({
-            error: errorMsg,
-            batchUploadProgress: null,
-          });
-          useLogStore
-            .getState()
-            .addLog(LogActionType.BATCH_UPLOAD, LogStatus.FAILED, {
-              error: errorMsg,
-              details: { total, completed, failed },
-            });
-          return [];
-        }
-      }
-
-      const { storageProvider, storageType } = get();
-      if (!storageProvider) {
-        set({
-          error: `${storagePluginLabel(storageType)} 配置未初始化`,
-          loading: false,
-        });
-        return [];
-      }
-
-      const total = files.length;
-      let completed = 0;
-      let failed = 0;
-      const uploadedImages: ImageItem[] = [];
-
-      try {
-        const items: UploadProgress[] = files.map((_file, index) => ({
-          id: `${Date.now()}-${index}`,
-          progress: 0,
-          status: 'uploading' as const,
-          message: '等待上传...',
-        }));
-
-        set({
-          loading: true,
-          error: null,
-          batchUploadProgress: {
-            total,
-            completed: 0,
-            failed: 0,
-            current: files[0]?.name,
-            items,
-          },
-        });
-
-        for (let i = 0; i < files.length; i++) {
-          const file = files[i];
-          const itemId = items[i].id;
-
-          try {
-            set(state => ({
-              batchUploadProgress: state.batchUploadProgress
-                ? {
-                    ...state.batchUploadProgress,
-                    current: file.name,
-                    items: state.batchUploadProgress.items.map(item =>
-                      item.id === itemId
-                        ? {
-                            ...item,
-                            status: 'uploading',
-                            message: '正在上传...',
-                          }
-                        : item,
-                    ),
-                  }
-                : null,
-            }));
-
-            const fileName = name ? `${name}-${i + 1}-${file.name}` : file.name;
-
-            const singleUploadData: ImageUploadData = {
-              file,
-              name: fileName,
-              description,
-              tags,
-              captureMetadata: captureMetadataList?.[i],
-            };
-
-            const newImage =
-              await storageProvider.uploadImage(singleUploadData);
-            uploadedImages.push(newImage);
-            completed++;
-
-            set(state => ({
-              batchUploadProgress: state.batchUploadProgress
-                ? {
-                    ...state.batchUploadProgress,
-                    completed,
-                    items: state.batchUploadProgress.items.map(item =>
-                      item.id === itemId
-                        ? {
-                            ...item,
-                            status: 'success',
-                            progress: 100,
-                            message: '上传成功',
-                          }
-                        : item,
-                    ),
-                  }
-                : null,
-            }));
-          } catch (error) {
-            failed++;
-            const errorMessage =
-              error instanceof Error ? error.message : '上传失败';
-
-            set(state => ({
-              batchUploadProgress: state.batchUploadProgress
-                ? {
-                    ...state.batchUploadProgress,
-                    failed,
-                    items: state.batchUploadProgress.items.map(item =>
-                      item.id === itemId
-                        ? { ...item, status: 'error', message: errorMessage }
-                        : item,
-                    ),
-                  }
-                : null,
-            }));
-          }
-        }
-
-        const batchStartTime = Date.now();
-        set(state => ({
-          images: [...state.images, ...uploadedImages],
-          loading: false,
-          batchUploadProgress: null,
-        }));
-        useLogStore
-          .getState()
-          .addLog(LogActionType.BATCH_UPLOAD, LogStatus.SUCCESS, {
-            details: {
-              total,
-              completed,
-              failed,
-              images: uploadedImages.map(img => ({
-                id: img.id,
-                name: img.name,
-              })),
-            },
-            duration: Date.now() - batchStartTime,
-          });
-        return uploadedImages;
-      } catch (error) {
-        const errorMsg =
-          error instanceof Error ? error.message : '批量上传失败';
-        set({
-          error: errorMsg,
-          loading: false,
-          batchUploadProgress: null,
-        });
-        useLogStore
-          .getState()
-          .addLog(LogActionType.BATCH_UPLOAD, LogStatus.FAILED, {
-            error: errorMsg,
-            details: { total, completed, failed },
-          });
-        return uploadedImages;
-      } finally {
-        set({ loading: false });
-      }
-    },
-
-    deleteImage: async (imageId: string, fileName: string) => {
-      if (isLocalListMode()) {
-        const image = get().images.find(img => img.id === imageId);
-        const relativePath = image?.localPath ?? fileName;
-        set({ loading: true, error: null });
-        try {
-          await getWorkspaceLibraryPort().softDeleteLocal(relativePath);
-          await refreshLocalIntoImageStore(set);
-        } catch (error) {
-          set({
-            loading: false,
-            error: error instanceof Error ? error.message : '删除图片失败',
-          });
-        }
-        return;
-      }
-
-      const { storageProvider, storageType } = get();
-      if (!storageProvider) {
-        set({
-          error: `${storagePluginLabel(storageType)} 配置未初始化`,
-          loading: false,
-        });
-        return;
-      }
-
-      set({ loading: true, error: null });
-      const startTime = Date.now();
-      try {
-        await storageProvider.deleteImage(fileName);
-        const duration = Date.now() - startTime;
-        set(state => ({
-          images: state.images.filter(img => img.id !== imageId),
-          loading: false,
-        }));
-        useLogStore.getState().addLog(LogActionType.DELETE, LogStatus.SUCCESS, {
-          imageId,
-          imageName: fileName,
-          duration,
-        });
-      } catch (error) {
-        const duration = Date.now() - startTime;
-        const errorMsg =
-          error instanceof Error ? error.message : '删除图片失败';
-        set({
-          error: errorMsg,
-          loading: false,
-        });
-        useLogStore.getState().addLog(LogActionType.DELETE, LogStatus.FAILED, {
-          imageId,
-          imageName: fileName,
-          error: errorMsg,
-          duration,
-        });
-      } finally {
-        set({ loading: false });
-      }
-    },
-
-    deleteMultipleImages: async (imageIds: string[], fileNames: string[]) => {
-      if (imageIds.length === 0) {
-        return;
-      }
-
-      const batchLogDetails = {
+    deleteMultipleImages: async (imageIds: string[], fileNames: string[]) =>
+      deleteMultipleAssetImages(
         imageIds,
-        imageNames: fileNames,
-        count: imageIds.length,
-      };
+        fileNames,
+        () => ({
+          images: get().images,
+          storageProvider: get().storageProvider,
+          storageType: get().storageType,
+        }),
+        set,
+      ),
 
-      if (isLocalListMode()) {
-        const startTime = Date.now();
-        set({ loading: true, error: null });
-        try {
-          const { images } = get();
-          for (const imageId of imageIds) {
-            const image = images.find(img => img.id === imageId);
-            if (image?.localPath) {
-              await getWorkspaceLibraryPort().softDeleteLocal(image.localPath);
-            }
-          }
-          await refreshLocalIntoImageStore(set);
-          useLogStore
-            .getState()
-            .addLog(LogActionType.BATCH_DELETE, LogStatus.SUCCESS, {
-              details: batchLogDetails,
-              duration: Date.now() - startTime,
-            });
-        } catch (error) {
-          const errorMsg =
-            error instanceof Error ? error.message : '批量删除图片失败';
-          set({
-            loading: false,
-            error: errorMsg,
-          });
-          useLogStore
-            .getState()
-            .addLog(LogActionType.BATCH_DELETE, LogStatus.FAILED, {
-              details: batchLogDetails,
-              error: errorMsg,
-            });
-        }
-        return;
-      }
-
-      const { storageProvider, storageType } = get();
-      if (!storageProvider) {
-        set({
-          error: `${storagePluginLabel(storageType)} 配置未初始化`,
-          loading: false,
-        });
-        return;
-      }
-
-      set({ loading: true, error: null });
-      const startTime = Date.now();
-      try {
-        const deletePromises = fileNames.map(fileName =>
-          storageProvider.deleteImage(fileName),
-        );
-        await Promise.all(deletePromises);
-
-        const duration = Date.now() - startTime;
-        set(state => ({
-          images: state.images.filter(img => !imageIds.includes(img.id)),
-          loading: false,
-        }));
-
-        useLogStore
-          .getState()
-          .addLog(LogActionType.BATCH_DELETE, LogStatus.SUCCESS, {
-            details: batchLogDetails,
-            duration,
-          });
-      } catch (error) {
-        const duration = Date.now() - startTime;
-        const errorMsg =
-          error instanceof Error ? error.message : '批量删除图片失败';
-        set({
-          error: errorMsg,
-          loading: false,
-        });
-
-        useLogStore
-          .getState()
-          .addLog(LogActionType.BATCH_DELETE, LogStatus.FAILED, {
-            details: batchLogDetails,
-            error: errorMsg,
-            duration,
-          });
-      } finally {
-        set({ loading: false });
-      }
-    },
-
-    updateImage: async (editData: ImageEditData) => {
-      const { storageProvider, storageType, images } = get();
-      const image = images.find(img => img.id === editData.id);
-      if (!image) {
-        set({ error: '图片不存在', loading: false });
-        return;
-      }
-
-      if (isLocalListMode()) {
-        if (!image.localPath) {
-          set({ error: '本地路径缺失', loading: false });
-          return;
-        }
-        set({ loading: true, error: null });
-        const startTime = Date.now();
-        try {
-          const workspace = getWorkspaceLibraryPort();
-          let relativePath = image.localPath;
-          if (editData.targetFolder !== undefined && relativePath) {
-            const slash = relativePath.lastIndexOf('/');
-            const currentFolder =
-              slash === -1 ? '' : relativePath.slice(0, slash);
-            const nextFolder = editData.targetFolder || 'images';
-            if (nextFolder !== currentFolder) {
-              await workspace.moveLocalFile(relativePath, nextFolder);
-              const fileName = relativePath.slice(slash + 1);
-              relativePath = nextFolder
-                ? `${nextFolder}/${fileName}`
-                : fileName;
-            }
-          }
-          await workspace.updateLocalMetadata(relativePath, {
-            name: editData.name || image.name,
-            description: editData.description ?? image.description,
-            tags: editData.tags ?? image.tags,
-          });
-          await refreshLocalIntoImageStore(set);
-          useLogStore.getState().addLog(LogActionType.EDIT, LogStatus.SUCCESS, {
-            imageId: editData.id,
-            imageName: editData.name || image.name,
-            duration: Date.now() - startTime,
-          });
-        } catch (error) {
-          const errorMsg =
-            error instanceof Error ? error.message : '更新图片失败';
-          set({ error: errorMsg, loading: false });
-          useLogStore.getState().addLog(LogActionType.EDIT, LogStatus.FAILED, {
-            imageId: editData.id,
-            imageName: image.name,
-            error: errorMsg,
-            duration: Date.now() - startTime,
-          });
-        }
-        return;
-      }
-
-      if (!storageProvider) {
-        set({
-          error: `${storagePluginLabel(storageType)} 配置未初始化`,
-          loading: false,
-        });
-        return;
-      }
-
-      if (!storageProvider.updateImageMetadata) {
-        set({ error: '当前存储插件不支持更新元数据', loading: false });
-        return;
-      }
-
-      set({ loading: true, error: null });
-      const startTime = Date.now();
-      try {
-        const metadata: ImageItem = {
-          ...image,
-          name: editData.name || image.name,
-          description: editData.description ?? image.description,
-          tags: editData.tags ?? image.tags,
-          updatedAt: new Date().toISOString(),
-        };
-
-        await storageProvider.updateImageMetadata(metadata.name, metadata);
-
-        const duration = Date.now() - startTime;
-        set(state => ({
-          images: state.images.map(img =>
-            img.id === editData.id ? { ...img, ...metadata } : img,
-          ),
-          loading: false,
-        }));
-        useLogStore.getState().addLog(LogActionType.EDIT, LogStatus.SUCCESS, {
-          imageId: editData.id,
-          imageName: metadata.name,
-          duration,
-          details: {
-            changes: {
-              name:
-                editData.name !== image.name
-                  ? { old: image.name, new: editData.name }
-                  : undefined,
-              description:
-                editData.description !== image.description
-                  ? { old: image.description, new: editData.description }
-                  : undefined,
-              tags:
-                editData.tags !== image.tags
-                  ? { old: image.tags, new: editData.tags }
-                  : undefined,
-            },
-          },
-        });
-      } catch (error) {
-        const duration = Date.now() - startTime;
-        const errorMsg =
-          error instanceof Error ? error.message : '更新图片失败';
-        set({
-          error: errorMsg,
-          loading: false,
-        });
-        useLogStore.getState().addLog(LogActionType.EDIT, LogStatus.FAILED, {
-          imageId: editData.id,
-          imageName: image.name,
-          error: errorMsg,
-          duration,
-        });
-      } finally {
-        set({ loading: false });
-      }
-    },
+    updateImage: async (editData: ImageEditData) =>
+      updateAssetImage(
+        editData,
+        () => ({
+          images: get().images,
+          storageProvider: get().storageProvider,
+          storageType: get().storageType,
+        }),
+        set,
+      ),
 
     addImage: (image: ImageItem) => {
       set(state => ({

--- a/app/src/features/library/useLibraryRoute.ts
+++ b/app/src/features/library/useLibraryRoute.ts
@@ -1,24 +1,18 @@
 import { useSearchContextSafe } from '@/features/library/SearchContext';
-import { LibraryWorkbench } from '@/features/library/LibraryWorkbench';
 import { useImageOperations } from '@/features/library/useImageOperations';
-import { useI18n } from '@/i18n/useI18n';
 import { useImageStore } from '@/features/library/imageStore';
-import { useSourceStore } from '@/features/settings/sourceStore';
-import { useUIStore } from '@/stores/uiStore';
-import { useWorkspaceStore } from '@/features/workspace/workspaceStore';
-import { isWorkspaceAvailable } from '@/platforms/workspacePlatform';
-import { filterImagesByFolder } from '@/features/workspace/folderTree';
 import type { LibrarySearchConfig } from '@/features/library/librarySearchTypes';
-import React, { useEffect, useMemo } from 'react';
+import { useSourceStore } from '@/features/settings/sourceStore';
+import { filterImagesByFolder } from '@/features/workspace/folderTree';
+import { useWorkspaceStore } from '@/features/workspace/workspaceStore';
+import { useI18n } from '@/i18n/useI18n';
+import { isWorkspaceAvailable } from '@/platforms/workspacePlatform';
+import { useUIStore } from '@/stores/uiStore';
+import { useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-interface LibraryPageProps {
-  onOpenConfigModal: () => void;
-}
-
-export const LibraryPage: React.FC<LibraryPageProps> = ({
-  onOpenConfigModal,
-}) => {
+/** `/library` 路由：store 接线、文件夹过滤、搜索适配、工具深链 */
+export function useLibraryRoute() {
   const { t } = useI18n();
   const [searchParams, setSearchParams] = useSearchParams();
   const images = useImageStore(state => state.images);
@@ -74,25 +68,16 @@ export const LibraryPage: React.FC<LibraryPageProps> = ({
     setSearchParams(next, { replace: true });
   }, [searchParams, setActiveMenu, setCurrentUtilityTool, setSearchParams]);
 
-  return (
-    <div className="library-page h-full min-h-0 flex flex-col overflow-hidden">
-      <div className="flex-1 min-h-0 overflow-hidden">
-        <LibraryWorkbench
-          hasConfig={hasConfig}
-          error={error}
-          onClearError={clearError}
-          images={visibleImages}
-          loading={loading}
-          onDeleteImage={handleDeleteImage}
-          onDeleteMultipleImages={handleDeleteMultipleImages}
-          onUpdateImage={handleUpdateImage}
-          onOpenConfigModal={onOpenConfigModal}
-          search={search}
-          t={t}
-        />
-      </div>
-    </div>
-  );
-};
-
-export default LibraryPage;
+  return {
+    t,
+    hasConfig,
+    error,
+    clearError,
+    visibleImages,
+    loading,
+    handleDeleteImage,
+    handleDeleteMultipleImages,
+    handleUpdateImage,
+    search,
+  };
+}

--- a/app/src/features/settings/sidebarSourceTypes.ts
+++ b/app/src/features/settings/sidebarSourceTypes.ts
@@ -1,0 +1,13 @@
+import type { LegacyStorageType } from '@pixuli/core/sources';
+
+/** 侧栏源列表项（`useSourceManagement` → `AppSidebar` / `Sidebar`） */
+export type SidebarSourceItem = {
+  id: string;
+  name: string;
+  type: LegacyStorageType;
+  owner: string;
+  repo: string;
+  path: string;
+  active: boolean;
+  available: boolean;
+};

--- a/app/src/features/settings/useSourceManagement.ts
+++ b/app/src/features/settings/useSourceManagement.ts
@@ -2,6 +2,7 @@ import {
   getRepoConfigFromSource,
   resolveSourceDisplay,
 } from '@pixuli/core/sources';
+import type { SidebarSourceItem } from '@/features/settings/sidebarSourceTypes';
 import { useCallback, useMemo } from 'react';
 import { isStoragePluginRegistered } from '@/storage/registry';
 import { useImageStore } from '@/features/library/imageStore';
@@ -22,7 +23,7 @@ export function useSourceManagement() {
       : sources[0] || null;
   }, [sources, selectedSourceId]);
 
-  const sidebarSources = useMemo(() => {
+  const sidebarSources = useMemo((): SidebarSourceItem[] => {
     return sources.map(source => {
       const repo = getRepoConfigFromSource(source);
       const { legacyType } = resolveSourceDisplay(source.pluginId);

--- a/app/src/features/workspace/workspaceLocalFs.ts
+++ b/app/src/features/workspace/workspaceLocalFs.ts
@@ -1,0 +1,109 @@
+import { DefaultPlatformAdapter } from '@pixuli/core/platform';
+import type { ImageUploadData } from '@pixuli/core/types';
+import { getUploadFileName } from '@pixuli/core/types';
+import { guessMimeType, type LocalVault } from '@pixuli/core/vault';
+import {
+  getWorkspaceSyncEngine,
+  getWorkspaceVault,
+} from '@/features/workspace/workspaceRuntime';
+
+export function sanitizeWorkspaceFileName(name: string): string {
+  return name.replace(/[/\\?%*:|"<>]/g, '_');
+}
+
+export async function resolveImportTargetDir(
+  uploadData: ImageUploadData,
+): Promise<string> {
+  const { useUIStore } = await import('@/stores/uiStore');
+  const selectedFolderPath = useUIStore.getState().selectedFolderPath;
+  const fromForm = uploadData.targetFolder?.replace(/\/+$/, '');
+  const fromTree =
+    selectedFolderPath && selectedFolderPath !== '__root__'
+      ? selectedFolderPath
+      : '';
+  return fromForm || fromTree || 'images';
+}
+
+export async function importImageToLocalVault(
+  uploadData: ImageUploadData,
+): Promise<string> {
+  const fileName = sanitizeWorkspaceFileName(
+    getUploadFileName(uploadData.file, uploadData.name),
+  );
+  const targetDir = await resolveImportTargetDir(uploadData);
+  const targetPath = `${targetDir.replace(/\/+$/, '')}/${Date.now()}-${fileName}`;
+  const vault = getWorkspaceVault();
+  const mimeType =
+    typeof uploadData.file === 'string'
+      ? guessMimeType(fileName)
+      : uploadData.file.type || guessMimeType(fileName);
+
+  let width = 0;
+  let height = 0;
+  if (mimeType.startsWith('image/')) {
+    try {
+      const platform = new DefaultPlatformAdapter();
+      const dimensions = await platform.getImageDimensions(uploadData.file);
+      width = dimensions.width;
+      height = dimensions.height;
+    } catch {
+      width = 0;
+      height = 0;
+    }
+  }
+
+  await vault.importFile(uploadData.file, targetPath, {
+    name: uploadData.name ?? fileName,
+    tags: uploadData.tags ?? [],
+    description: uploadData.description,
+    mimeType,
+    width,
+    height,
+    syncState: 'local-only',
+    createdAt: uploadData.captureMetadata?.takenAt,
+    captureMetadata: uploadData.captureMetadata,
+  });
+
+  await getWorkspaceSyncEngine().enqueuePush({
+    type: 'upload',
+    relativePath: targetPath,
+  });
+
+  return targetPath;
+}
+
+export async function enqueuePendingPushForFolder(
+  vault: LocalVault,
+  folderPath: string,
+  mode: 'upload' | 'delete',
+): Promise<void> {
+  const entries = await vault.list(
+    mode === 'delete' ? { includeDeleted: true } : undefined,
+  );
+  const sync = getWorkspaceSyncEngine();
+  for (const entry of entries) {
+    const inFolder =
+      entry.relativePath === folderPath ||
+      entry.relativePath.startsWith(`${folderPath}/`);
+    if (!inFolder) {
+      continue;
+    }
+    if (mode === 'delete' && entry.deletedAt) {
+      await sync.enqueuePush({
+        type: 'delete',
+        relativePath: entry.relativePath,
+      });
+    }
+    if (
+      mode === 'upload' &&
+      entry.syncState === 'pending-push' &&
+      (entry.relativePath === folderPath ||
+        entry.relativePath.startsWith(`${folderPath}/`))
+    ) {
+      await sync.enqueuePush({
+        type: 'upload',
+        relativePath: entry.relativePath,
+      });
+    }
+  }
+}

--- a/app/src/features/workspace/workspacePersist.ts
+++ b/app/src/features/workspace/workspacePersist.ts
@@ -1,0 +1,56 @@
+const WORKSPACE_STORAGE_KEY = 'pixuli.workspace.v1';
+const WORKSPACE_MODE_KEY = 'pixuli.workspaceMode.v1';
+
+export type WorkspacePersist = {
+  rootPath: string;
+  workspaceId: string;
+  folderLabel?: string;
+};
+
+export function saveWorkspaceModePref(
+  mode: Exclude<import('@pixuli/core/vault').WorkspaceMode, 'unset'>,
+): void {
+  try {
+    localStorage.setItem(WORKSPACE_MODE_KEY, mode);
+  } catch {
+    // ignore
+  }
+}
+
+export function loadPersistedWorkspace(): WorkspacePersist | null {
+  try {
+    const raw = localStorage.getItem(WORKSPACE_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as WorkspacePersist;
+    if (parsed?.rootPath) {
+      return parsed;
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+export function savePersistedWorkspace(
+  rootPath: string,
+  workspaceId: string,
+  folderLabel?: string,
+): void {
+  try {
+    localStorage.setItem(
+      WORKSPACE_STORAGE_KEY,
+      JSON.stringify({ rootPath, workspaceId, folderLabel }),
+    );
+  } catch {
+    // ignore
+  }
+}
+
+export function clearPersistedWorkspace(): void {
+  try {
+    localStorage.removeItem(WORKSPACE_STORAGE_KEY);
+    localStorage.removeItem(WORKSPACE_MODE_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/app/src/features/workspace/workspaceRuntime.ts
+++ b/app/src/features/workspace/workspaceRuntime.ts
@@ -1,0 +1,122 @@
+import {
+  createConfiguredStorageProvider,
+  type StoragePluginId,
+} from '@/storage/createProvider';
+import { useSourceStore } from '@/features/settings/sourceStore';
+import {
+  createLocalVault,
+  createSyncEngine,
+  providerSupportsSync,
+  storedSourcesToWorkspaceBindings,
+  type LocalVault,
+  type SyncEngine,
+  type SyncEngineBinding,
+  type WorkspaceMode,
+} from '@pixuli/core/vault';
+import {
+  getWorkspaceAdapter,
+  resetWorkspaceAdapter,
+} from '@/platforms/workspacePlatform';
+import { clearLocalPreviewCache } from '@/features/workspace/localImageMapper';
+
+let vaultInstance: LocalVault | null = null;
+let syncEngineInstance: SyncEngine | null = null;
+let readWorkspaceMode: () => WorkspaceMode = () => 'unset';
+
+export function getWorkspaceVaultInstance(): LocalVault | null {
+  return vaultInstance;
+}
+
+export function registerWorkspaceModeReader(reader: () => WorkspaceMode): void {
+  readWorkspaceMode = reader;
+}
+
+function getAdapter() {
+  return getWorkspaceAdapter();
+}
+
+export function getWorkspaceVault(): LocalVault {
+  if (!vaultInstance) {
+    vaultInstance = createLocalVault(getAdapter());
+  }
+  return vaultInstance;
+}
+
+function resolveSyncBindings(): SyncEngineBinding[] {
+  if (vaultInstance && readWorkspaceMode() === 'local') {
+    const config = vaultInstance.getConfig();
+    const bindingDefs =
+      config.bindings.length > 0
+        ? config.bindings
+        : storedSourcesToWorkspaceBindings(useSourceStore.getState().sources);
+
+    const bindings: SyncEngineBinding[] = [];
+    for (const binding of bindingDefs) {
+      try {
+        const provider = createConfiguredStorageProvider(
+          binding.pluginId as StoragePluginId,
+          binding.config as never,
+        );
+        if (providerSupportsSync(provider)) {
+          bindings.push({ bindingId: binding.id, provider });
+        }
+      } catch {
+        // skip invalid binding
+      }
+    }
+    return bindings;
+  }
+
+  const source = resolveSelectedSource();
+  const provider = resolveSelectedProvider();
+  if (!source || !provider || !providerSupportsSync(provider)) {
+    return [];
+  }
+  return [{ bindingId: source.id, provider }];
+}
+
+function resolveSelectedSource() {
+  const { selectedSourceId, sources, getSourceById } =
+    useSourceStore.getState();
+  if (selectedSourceId) {
+    return getSourceById(selectedSourceId) ?? null;
+  }
+  return sources[0] ?? null;
+}
+
+function resolveSelectedProvider() {
+  const source = resolveSelectedSource();
+  if (!source) {
+    return null;
+  }
+  try {
+    return createConfiguredStorageProvider(
+      source.pluginId as StoragePluginId,
+      source.config as never,
+    );
+  } catch {
+    return null;
+  }
+}
+
+export function getWorkspaceSyncEngine(): SyncEngine {
+  if (!syncEngineInstance) {
+    syncEngineInstance = createSyncEngine({
+      vault: getWorkspaceVault(),
+      getBindings: resolveSyncBindings,
+      readFileBytes: relativePath => getAdapter().readFile(relativePath),
+    });
+  }
+  return syncEngineInstance;
+}
+
+export function resetWorkspaceSyncEngineOnly(): void {
+  syncEngineInstance = null;
+}
+
+export function resetWorkspaceRuntime(): void {
+  clearLocalPreviewCache();
+  vaultInstance = null;
+  syncEngineInstance = null;
+  resetWorkspaceAdapter();
+}

--- a/app/src/features/workspace/workspaceStore.ts
+++ b/app/src/features/workspace/workspaceStore.ts
@@ -1,28 +1,13 @@
-import {
-  createConfiguredStorageProvider,
-  type StoragePluginId,
-} from '@/storage/createProvider';
 import { useSourceStore } from '@/features/settings/sourceStore';
-import { DefaultPlatformAdapter } from '@pixuli/core/platform';
 import type { ImageItem, ImageUploadData } from '@pixuli/core/types';
 import {
-  createLocalVault,
-  createSyncEngine,
-  guessMimeType,
-  providerSupportsSync,
   storedSourcesToWorkspaceBindings,
   type LocalVault,
-  type SyncEngine,
-  type SyncEngineBinding,
   type SyncStatusSummary,
   type WorkspaceMode,
 } from '@pixuli/core/vault';
-import { getUploadFileName } from '@pixuli/core/types';
 import { create } from 'zustand';
-import {
-  clearLocalPreviewCache,
-  mapEntriesToImageItems,
-} from '@/features/workspace/localImageMapper';
+import { mapEntriesToImageItems } from '@/features/workspace/localImageMapper';
 import {
   getWorkspaceAdapter,
   isMobileWorkspaceActive,
@@ -45,18 +30,26 @@ import {
   type SyncRunOutcome,
 } from '@/features/workspace/syncOutcome';
 import {
+  enqueuePendingPushForFolder,
+  importImageToLocalVault,
+} from '@/features/workspace/workspaceLocalFs';
+import {
   notifyWorkspaceCleared,
   registerWorkspaceLibraryPort,
 } from '@/features/library/workspaceImageBridge';
-
-const WORKSPACE_STORAGE_KEY = 'pixuli.workspace.v1';
-const WORKSPACE_MODE_KEY = 'pixuli.workspaceMode.v1';
-
-interface WorkspacePersist {
-  rootPath: string;
-  workspaceId: string;
-  folderLabel?: string;
-}
+import {
+  clearPersistedWorkspace,
+  loadPersistedWorkspace,
+  savePersistedWorkspace,
+  saveWorkspaceModePref,
+} from '@/features/workspace/workspacePersist';
+import {
+  getWorkspaceSyncEngine,
+  getWorkspaceVault,
+  registerWorkspaceModeReader,
+  resetWorkspaceRuntime,
+  resetWorkspaceSyncEngineOnly,
+} from '@/features/workspace/workspaceRuntime';
 
 interface WorkspaceState {
   mode: WorkspaceMode;
@@ -102,86 +95,8 @@ interface WorkspaceState {
   clearError: () => void;
 }
 
-let vaultInstance: LocalVault | null = null;
-let syncEngineInstance: SyncEngine | null = null;
-
 function getAdapter() {
   return getWorkspaceAdapter();
-}
-
-function getVault(): LocalVault {
-  if (!vaultInstance) {
-    vaultInstance = createLocalVault(getAdapter());
-  }
-  return vaultInstance;
-}
-
-function getSyncEngine(): SyncEngine {
-  if (!syncEngineInstance) {
-    syncEngineInstance = createSyncEngine({
-      vault: getVault(),
-      getBindings: resolveSyncBindings,
-      readFileBytes: relativePath => getAdapter().readFile(relativePath),
-    });
-  }
-  return syncEngineInstance;
-}
-
-function resetSyncEngineOnly(): void {
-  syncEngineInstance = null;
-}
-
-function resetWorkspaceRuntime(): void {
-  clearLocalPreviewCache();
-  vaultInstance = null;
-  syncEngineInstance = null;
-  resetWorkspaceAdapter();
-}
-
-function saveModePref(mode: Exclude<WorkspaceMode, 'unset'>): void {
-  try {
-    localStorage.setItem(WORKSPACE_MODE_KEY, mode);
-  } catch {
-    // ignore
-  }
-}
-
-function loadPersistedWorkspace(): WorkspacePersist | null {
-  try {
-    const raw = localStorage.getItem(WORKSPACE_STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as WorkspacePersist;
-    if (parsed?.rootPath) {
-      return parsed;
-    }
-  } catch {
-    // ignore
-  }
-  return null;
-}
-
-function savePersistedWorkspace(
-  rootPath: string,
-  workspaceId: string,
-  folderLabel?: string,
-): void {
-  try {
-    localStorage.setItem(
-      WORKSPACE_STORAGE_KEY,
-      JSON.stringify({ rootPath, workspaceId, folderLabel }),
-    );
-  } catch {
-    // ignore
-  }
-}
-
-function clearPersistedWorkspace(): void {
-  try {
-    localStorage.removeItem(WORKSPACE_STORAGE_KEY);
-    localStorage.removeItem(WORKSPACE_MODE_KEY);
-  } catch {
-    // ignore
-  }
 }
 
 async function cleanupFsaWorkspaceRoot(rootPath: string | null): Promise<void> {
@@ -218,10 +133,6 @@ function readFolderLabel(
   return null;
 }
 
-function sanitizeFileName(name: string): string {
-  return name.replace(/[/\\?%*:|"<>]/g, '_');
-}
-
 async function openVaultWithRoot(rootPath: string): Promise<LocalVault> {
   const adapter = getAdapter();
   if ('setRootPath' in adapter && typeof adapter.setRootPath === 'function') {
@@ -230,7 +141,7 @@ async function openVaultWithRoot(rootPath: string): Promise<LocalVault> {
   if (window.workspaceAPI) {
     await window.workspaceAPI.setRoot(rootPath);
   }
-  const vault = getVault();
+  const vault = getWorkspaceVault();
   await vault.open();
   await hydrateAccessPolicy(vault.adapter);
   return vault;
@@ -288,7 +199,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         config.workspaceId,
         folderLabel,
       );
-      saveModePref('local');
+      saveWorkspaceModePref('local');
       set({
         mode: 'local',
         rootPath: persisted.rootPath,
@@ -324,7 +235,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       const config = vault.getConfig();
       const folderLabel =
         persisted.folderLabel ?? readFolderLabel(getAdapter()) ?? undefined;
-      saveModePref('local');
+      saveWorkspaceModePref('local');
       set({
         mode: 'local',
         rootPath: persisted.rootPath,
@@ -352,10 +263,13 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       return;
     }
     const sources = useSourceStore.getState().sources;
-    await getVault().upsertBindings(storedSourcesToWorkspaceBindings(sources), {
-      replace: true,
-    });
-    resetSyncEngineOnly();
+    await getWorkspaceVault().upsertBindings(
+      storedSourcesToWorkspaceBindings(sources),
+      {
+        replace: true,
+      },
+    );
+    resetWorkspaceSyncEngineOnly();
   },
 
   pickWorkspace: async (options?: {
@@ -397,7 +311,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       const vault = await openVaultWithRoot(rootPath);
       const config = vault.getConfig();
       savePersistedWorkspace(rootPath, config.workspaceId, folderLabel);
-      saveModePref('local');
+      saveWorkspaceModePref('local');
 
       if (previousRootPath && previousRootPath !== rootPath) {
         await cleanupFsaWorkspaceRoot(previousRootPath);
@@ -460,7 +374,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       set({ loading: true, error: null });
     }
     try {
-      const vault = getVault();
+      const vault = getWorkspaceVault();
       const entries = await vault.list();
       const provider = resolveSelectedProvider();
       const images = await mapEntriesToImageItems(entries, provider);
@@ -479,7 +393,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       return;
     }
     try {
-      const localFolders = await getVault().listFolders();
+      const localFolders = await getWorkspaceVault().listFolders();
       set({ localFolders });
     } catch (error) {
       set({
@@ -494,7 +408,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
     set({ loading: true, error: null });
     try {
-      await getVault().createFolder(relativeDir);
+      await getWorkspaceVault().createFolder(relativeDir);
       await get().refreshLocalFolders();
       set({ loading: false, syncMessage: '已新建文件夹（仅本机）' });
     } catch (error) {
@@ -511,23 +425,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
     set({ loading: true, error: null });
     try {
-      const moved = await getVault().renameFolder(fromDir, toDir);
-      for (let i = 0; i < moved; i += 1) {
-        // enqueue is per-file; refresh will show pending. Queue metadata/uploads for moved paths via scan of pending-push
-      }
-      const entries = await getVault().list();
-      for (const entry of entries) {
-        if (
-          entry.syncState === 'pending-push' &&
-          (entry.relativePath === toDir ||
-            entry.relativePath.startsWith(`${toDir}/`))
-        ) {
-          await getSyncEngine().enqueuePush({
-            type: 'upload',
-            relativePath: entry.relativePath,
-          });
-        }
-      }
+      const moved = await getWorkspaceVault().renameFolder(fromDir, toDir);
+      void moved;
+      await enqueuePendingPushForFolder(getWorkspaceVault(), toDir, 'upload');
       await get().refreshLocalImages();
       await get().refreshSyncStatus();
       set({ loading: false, syncMessage: '已重命名文件夹（仅本机）' });
@@ -545,20 +445,12 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
     set({ loading: true, error: null });
     try {
-      const count = await getVault().deleteFolder(relativeDir);
-      const deleted = await getVault().list({ includeDeleted: true });
-      for (const entry of deleted) {
-        if (
-          entry.deletedAt &&
-          (entry.relativePath === relativeDir ||
-            entry.relativePath.startsWith(`${relativeDir}/`))
-        ) {
-          await getSyncEngine().enqueuePush({
-            type: 'delete',
-            relativePath: entry.relativePath,
-          });
-        }
-      }
+      const count = await getWorkspaceVault().deleteFolder(relativeDir);
+      await enqueuePendingPushForFolder(
+        getWorkspaceVault(),
+        relativeDir,
+        'delete',
+      );
       await get().refreshLocalImages();
       await get().refreshSyncStatus();
       set({ loading: false, syncMessage: '已删除文件夹（仅本机）' });
@@ -578,8 +470,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
     set({ loading: true, error: null });
     try {
-      const entry = await getVault().moveFile(relativePath, targetDir);
-      await getSyncEngine().enqueuePush({
+      const entry = await getWorkspaceVault().moveFile(relativePath, targetDir);
+      await getWorkspaceSyncEngine().enqueuePush({
         type: 'upload',
         relativePath: entry.relativePath,
       });
@@ -599,7 +491,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       return;
     }
     try {
-      const status = await getSyncEngine().getStatus();
+      const status = await getWorkspaceSyncEngine().getStatus();
       set({ syncStatus: status });
     } catch {
       // ignore status refresh errors
@@ -612,7 +504,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
     set({ loading: true, error: null });
     try {
-      const added = await getVault().scan();
+      const added = await getWorkspaceVault().scan();
       await get().refreshLocalImages();
       await get().refreshSyncStatus();
       set({
@@ -637,54 +529,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     // 添加不锁壳层：不置 loading，列表静默刷新（§5.1）
     set({ error: null });
     try {
-      const fileName = sanitizeFileName(
-        getUploadFileName(uploadData.file, uploadData.name),
-      );
-      const { useUIStore } = await import('@/stores/uiStore');
-      const selectedFolderPath = useUIStore.getState().selectedFolderPath;
-      const fromForm = uploadData.targetFolder?.replace(/\/+$/, '');
-      const fromTree =
-        selectedFolderPath && selectedFolderPath !== '__root__'
-          ? selectedFolderPath
-          : '';
-      const targetDir = fromForm || fromTree || 'images';
-      const targetPath = `${targetDir.replace(/\/+$/, '')}/${Date.now()}-${fileName}`;
-      const vault = getVault();
-      const mimeType =
-        typeof uploadData.file === 'string'
-          ? guessMimeType(fileName)
-          : uploadData.file.type || guessMimeType(fileName);
-      let width = 0;
-      let height = 0;
-      if (mimeType.startsWith('image/')) {
-        try {
-          const platform = new DefaultPlatformAdapter();
-          const dimensions = await platform.getImageDimensions(uploadData.file);
-          width = dimensions.width;
-          height = dimensions.height;
-        } catch {
-          width = 0;
-          height = 0;
-        }
-      }
-
-      await vault.importFile(uploadData.file, targetPath, {
-        name: uploadData.name ?? fileName,
-        tags: uploadData.tags ?? [],
-        description: uploadData.description,
-        mimeType,
-        width,
-        height,
-        syncState: 'local-only',
-        createdAt: uploadData.captureMetadata?.takenAt,
-        captureMetadata: uploadData.captureMetadata,
-      });
-
-      await getSyncEngine().enqueuePush({
-        type: 'upload',
-        relativePath: targetPath,
-      });
-
+      const targetPath = await importImageToLocalVault(uploadData);
       await get().refreshLocalImages({ quiet: true });
       await get().refreshSyncStatus();
       set({ syncMessage: '已保存到本地工作区' });
@@ -705,8 +550,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
     set({ loading: true, error: null });
     try {
-      await getVault().updateMetadata(relativePath, patch);
-      await getSyncEngine().enqueuePush({
+      await getWorkspaceVault().updateMetadata(relativePath, patch);
+      await getWorkspaceSyncEngine().enqueuePush({
         type: 'metadata',
         relativePath,
       });
@@ -750,7 +595,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
 
     if (direction === 'push') {
-      const entries = await getVault().list({ includeDeleted: true });
+      const entries = await getWorkspaceVault().list({ includeDeleted: true });
       const hasPushable =
         entries.some(entry => !entry.deletedAt) ||
         entries.some(
@@ -758,7 +603,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
             entry.deletedAt &&
             (entry.remotePath || entry.syncState === 'pending-push'),
         );
-      const status = await getSyncEngine().getStatus();
+      const status = await getWorkspaceSyncEngine().getStatus();
       if (!hasPushable && status.pendingPush === 0) {
         const outcome: SyncRunOutcome = {
           kind: 'info',
@@ -778,7 +623,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     });
 
     try {
-      const result = await getSyncEngine().run({ direction });
+      const result = await getWorkspaceSyncEngine().run({ direction });
       await get().refreshLocalImages();
       await get().refreshSyncStatus();
 
@@ -828,8 +673,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
     set({ loading: true, error: null });
     try {
-      await getVault().softDelete(relativePath);
-      await getSyncEngine().enqueuePush({
+      await getWorkspaceVault().softDelete(relativePath);
+      await getWorkspaceSyncEngine().enqueuePush({
         type: 'delete',
         relativePath,
       });
@@ -847,6 +692,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   clearError: () => set({ error: null, syncOutcome: null }),
 }));
 
+registerWorkspaceModeReader(() => useWorkspaceStore.getState().mode);
+
 registerWorkspaceLibraryPort({
   isLocalActive: () => useWorkspaceStore.getState().isLocalActive(),
   refreshLocalImages: options =>
@@ -861,60 +708,3 @@ registerWorkspaceLibraryPort({
   updateLocalMetadata: (relativePath, patch) =>
     useWorkspaceStore.getState().updateLocalMetadata(relativePath, patch),
 });
-
-function resolveSyncBindings(): SyncEngineBinding[] {
-  if (vaultInstance && useWorkspaceStore.getState().mode === 'local') {
-    const config = vaultInstance.getConfig();
-    const bindingDefs =
-      config.bindings.length > 0
-        ? config.bindings
-        : storedSourcesToWorkspaceBindings(useSourceStore.getState().sources);
-
-    const bindings: SyncEngineBinding[] = [];
-    for (const binding of bindingDefs) {
-      try {
-        const provider = createConfiguredStorageProvider(
-          binding.pluginId as StoragePluginId,
-          binding.config as never,
-        );
-        if (providerSupportsSync(provider)) {
-          bindings.push({ bindingId: binding.id, provider });
-        }
-      } catch {
-        // skip invalid binding
-      }
-    }
-    return bindings;
-  }
-
-  const source = resolveSelectedSource();
-  const provider = resolveSelectedProvider();
-  if (!source || !provider || !providerSupportsSync(provider)) {
-    return [];
-  }
-  return [{ bindingId: source.id, provider }];
-}
-
-function resolveSelectedSource() {
-  const { selectedSourceId, sources, getSourceById } =
-    useSourceStore.getState();
-  if (selectedSourceId) {
-    return getSourceById(selectedSourceId) ?? null;
-  }
-  return sources[0] ?? null;
-}
-
-function resolveSelectedProvider() {
-  const source = resolveSelectedSource();
-  if (!source) {
-    return null;
-  }
-  try {
-    return createConfiguredStorageProvider(
-      source.pluginId as StoragePluginId,
-      source.config as never,
-    );
-  } catch {
-    return null;
-  }
-}

--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -1,4 +1,9 @@
 /** App shell hooks only — feature hooks live under `@/features/*`. */
+export { useAppOrchestration } from './useAppOrchestration';
+export type {
+  AppMainLayoutProps,
+  AppRoutesOrchestrationProps,
+} from './useAppOrchestration';
 export { useAppInitialization } from './useAppInitialization';
 export { useCapacitorBackButton } from './useCapacitorBackButton';
 export { useKeyboardCategories } from './useKeyboardCategories';

--- a/app/src/hooks/useAppOrchestration.ts
+++ b/app/src/hooks/useAppOrchestration.ts
@@ -1,0 +1,174 @@
+import { useImageStore } from '@/features/library/imageStore';
+import { useConfigManagement } from '@/features/settings/useConfigManagement';
+import type { SidebarSourceItem } from '@/features/settings/sidebarSourceTypes';
+import { useSelectedSourceSync } from '@/features/settings/useSelectedSourceSync';
+import { useSourceManagement } from '@/features/settings/useSourceManagement';
+import { useSourceStore } from '@/features/settings/sourceStore';
+import { useWorkspaceBindingSync } from '@/features/workspace/useWorkspaceBindingSync';
+import { useWorkspaceStore } from '@/features/workspace/workspaceStore';
+import {
+  useAppInitialization,
+  useCapacitorBackButton,
+  useKeyboardShortcuts,
+} from '@/hooks';
+import { useI18n } from '@/i18n/useI18n';
+import { isWorkspaceAvailable } from '@/platforms/workspacePlatform';
+import { useUIStore } from '@/stores/uiStore';
+import { useCallback, useEffect, useMemo } from 'react';
+
+type RepoConfigForm = {
+  owner: string;
+  repo: string;
+  branch: string;
+  token: string;
+  path: string;
+  name?: string;
+};
+
+export type AppMainLayoutProps = {
+  sidebarSources: SidebarSourceItem[];
+  selectedSourceId: string | null;
+  onSourceSelect: (sourceId: string) => void;
+  onSourceEdit: (sourceId: string) => void;
+  onSourceDelete: (sourceId: string) => void;
+  hasConfig: boolean;
+  onAddSource: () => void;
+  onSaveConfig: (config: RepoConfigForm) => void;
+  onClearConfig: () => void;
+};
+
+export type AppRoutesOrchestrationProps = {
+  onOpenConfigModal: () => void;
+  isFullscreenMode: boolean;
+  setIsFullscreenMode: (isFullscreen: boolean) => void;
+};
+
+/** App 壳层编排：workspace init、源/配置、快捷键与同步 */
+export function useAppOrchestration(): {
+  mainLayoutProps: AppMainLayoutProps;
+  routesProps: AppRoutesOrchestrationProps;
+} {
+  const { t } = useI18n();
+  const { loadImages } = useImageStore();
+  const initializeWorkspace = useWorkspaceStore(state => state.initialize);
+  const localActive = useWorkspaceStore(state => state.isLocalActive());
+  const { sources, selectedSourceId } = useSourceStore();
+
+  useEffect(() => {
+    if (!isWorkspaceAvailable()) {
+      return;
+    }
+    void initializeWorkspace().then(() => {
+      if (useWorkspaceStore.getState().isLocalActive()) {
+        void loadImages();
+      }
+    });
+  }, [initializeWorkspace, loadImages]);
+
+  const {
+    showConfigModal,
+    editingSourceId,
+    showSettingsModal,
+    isFullscreenMode,
+    setIsFullscreenMode,
+    openConfigModal,
+    closeConfigModal,
+    openKeyboardHelp,
+    closeSettingsModal,
+    openSettingsModalForAddSource,
+    openConfigModalForEdit,
+    openOperationLog,
+  } = useUIStore();
+
+  const sourceManagement = useSourceManagement();
+  const {
+    selectedSource,
+    sidebarSources,
+    handleDeleteSource,
+    handleSourceSelect,
+  } = sourceManagement;
+
+  const { handleSaveConfig, handleClearConfig } = useConfigManagement();
+  const hasConfig = isWorkspaceAvailable() ? localActive : sources.length > 0;
+
+  const handleLoadImages = useCallback(async () => {
+    try {
+      await loadImages();
+    } catch (error) {
+      console.error('Failed to load images:', error);
+    }
+  }, [loadImages]);
+
+  const handleSaveConfigWithId = useMemo(
+    () => (config: RepoConfigForm) => {
+      handleSaveConfig(config, editingSourceId);
+      closeConfigModal();
+    },
+    [handleSaveConfig, editingSourceId, closeConfigModal],
+  );
+
+  const handleClearConfigWithId = useMemo(
+    () => () => {
+      handleClearConfig(editingSourceId);
+      closeConfigModal();
+    },
+    [handleClearConfig, editingSourceId, closeConfigModal],
+  );
+
+  const handleEditSourceWithId = useMemo(
+    () => (sourceId: string) => {
+      openConfigModalForEdit(sourceId);
+    },
+    [openConfigModalForEdit],
+  );
+
+  const handleDeleteSourceWithT = useMemo(
+    () => (sourceId: string) => {
+      handleDeleteSource(sourceId, t);
+    },
+    [handleDeleteSource, t],
+  );
+
+  useSelectedSourceSync(selectedSource ?? null, () => {
+    if (isWorkspaceAvailable()) {
+      return;
+    }
+    if (sources.length > 0 && selectedSource) {
+      void handleLoadImages();
+    }
+  });
+
+  useWorkspaceBindingSync();
+  useAppInitialization(hasConfig, handleLoadImages);
+  useCapacitorBackButton();
+  useKeyboardShortcuts(
+    t,
+    showConfigModal,
+    showSettingsModal,
+    closeConfigModal,
+    closeSettingsModal,
+    openKeyboardHelp,
+    openOperationLog,
+    handleLoadImages,
+    openConfigModal,
+  );
+
+  return {
+    mainLayoutProps: {
+      sidebarSources,
+      selectedSourceId,
+      onSourceSelect: handleSourceSelect,
+      onSourceEdit: handleEditSourceWithId,
+      onSourceDelete: handleDeleteSourceWithT,
+      hasConfig,
+      onAddSource: openSettingsModalForAddSource,
+      onSaveConfig: handleSaveConfigWithId,
+      onClearConfig: handleClearConfigWithId,
+    },
+    routesProps: {
+      onOpenConfigModal: openConfigModal,
+      isFullscreenMode,
+      setIsFullscreenMode,
+    },
+  };
+}

--- a/app/src/hooks/useRouteSync.ts
+++ b/app/src/hooks/useRouteSync.ts
@@ -1,8 +1,8 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-import { getMenuKeyByPath } from '../router/config';
-import { ROUTES } from '../router/routes';
-import { useUIStore } from '../stores/uiStore';
+import { getMenuKeyByPath } from '@/router/config';
+import { ROUTES } from '@/router/routes';
+import { useUIStore } from '@/stores/uiStore';
 
 /**
  * 路由同步 Hook

--- a/app/src/layouts/AppMain.tsx
+++ b/app/src/layouts/AppMain.tsx
@@ -4,9 +4,9 @@
 
 import { Menu } from 'lucide-react';
 import React from 'react';
-import { useMobileViewport } from '../hooks/useMobileViewport';
-import { useI18n } from '../i18n/useI18n';
-import { useUIStore } from '../stores/uiStore';
+import { useMobileViewport } from '@/hooks/useMobileViewport';
+import { useI18n } from '@/i18n/useI18n';
+import { useUIStore } from '@/stores/uiStore';
 import './AppMain.css';
 
 interface AppMainProps {

--- a/app/src/layouts/AppSidebar.tsx
+++ b/app/src/layouts/AppSidebar.tsx
@@ -5,15 +5,16 @@ import {
 } from '@pixuli/core/sources';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useMobileViewport } from '../hooks/useMobileViewport';
-import { ROUTES } from '../router/routes';
+import type { SidebarSourceItem } from '@/features/settings/sidebarSourceTypes';
+import { useMobileViewport } from '@/hooks/useMobileViewport';
+import { ROUTES } from '@/router/routes';
 import { useSourceStore } from '@/features/settings/sourceStore';
-import { useUIStore } from '../stores/uiStore';
+import { useUIStore } from '@/stores/uiStore';
 import { useWorkspaceStore } from '@/features/workspace/workspaceStore';
-import { isWorkspaceAvailable } from '../platforms/workspacePlatform';
+import { isWorkspaceAvailable } from '@/platforms/workspacePlatform';
 
 interface SidebarProps {
-  sidebarSources: any[];
+  sidebarSources: SidebarSourceItem[];
   selectedSourceId: string | null;
   onSourceSelect: (sourceId: string) => void;
   onSourceEdit: (sourceId: string) => void;

--- a/app/src/layouts/MainLayout.tsx
+++ b/app/src/layouts/MainLayout.tsx
@@ -3,6 +3,7 @@
  * 包含侧边栏、主内容区域和所有弹窗组件
  */
 
+import type { AppMainLayoutProps } from '@/hooks/useAppOrchestration';
 import { FullScreenLoading, Toaster } from '@/ui';
 import type { VersionInfo } from '@/features/settings/version-info';
 import { resolveSourceDisplay } from '@pixuli/core/sources';
@@ -36,19 +37,8 @@ import { WorkspaceWelcomeScreen } from './WorkspaceWelcomeScreen';
 // 声明构建时注入的全局变量
 declare const __VERSION_INFO__: VersionInfo;
 
-interface MainLayoutProps {
+interface MainLayoutProps extends AppMainLayoutProps {
   children: React.ReactNode;
-  // Source 相关 props
-  sidebarSources: any[];
-  selectedSourceId: string | null;
-  onSourceSelect: (sourceId: string) => void;
-  onSourceEdit: (sourceId: string) => void;
-  onSourceDelete: (sourceId: string) => void;
-  hasConfig: boolean;
-  onAddSource: () => void;
-  // 配置相关 props（用于弹窗）
-  onSaveConfig: (config: any) => void;
-  onClearConfig: () => void;
 }
 
 export const MainLayout: React.FC<MainLayoutProps> = ({

--- a/app/src/router/routes.tsx
+++ b/app/src/router/routes.tsx
@@ -3,7 +3,9 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import { WorkspaceRouteRedirect } from './WorkspaceRouteRedirect';
 
 const LibraryPage = lazy(() =>
-  import('../pages/library').then(module => ({ default: module.LibraryPage })),
+  import('@/features/library/LibraryPage').then(module => ({
+    default: module.LibraryPage,
+  })),
 );
 
 export const ROUTES = {

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -36,7 +36,6 @@
     "src/**/__tests__/**/*",
     "src/test/**/*",
     "**/*.test.*",
-    "**/__tests__/**",
-    "src/pages/HomePage/**"
+    "**/__tests__/**"
   ]
 }


### PR DESCRIPTION
## Summary

- **S10**：将 `imageStore` / `workspaceStore` 中的列表、上传、变更、provider 会话、本地 FS 与持久化逻辑拆到独立服务模块（`asset*Service`、`workspaceLocalFs`、`workspacePersist`、`workspaceRuntime`）；`ImageUpload` 抽取 `useImageUploadCapture` / `useImageUploadCompression` hooks
- **S11**：`App.tsx` 编排迁入 `useAppOrchestration`，`LibraryPage` 路由接线迁入 `useLibraryRoute`；布局层统一 `@/` 导入并收紧类型
- **pages 清理**：删除 `pages/`，`LibraryPage` 迁入 `features/library`

## 主要文件

| 区域 | 新增/变更 |
|------|-----------|
| library | `assetListService` · `assetUploadService` · `assetMutationService` · `assetProviderSession` · `useLibraryRoute` · `LibraryPage` |
| workspace | `workspaceLocalFs` · `workspacePersist` · `workspaceRuntime` |
| 壳层 | `useAppOrchestration` · `sidebarSourceTypes` |
| 上传 UI | `useImageUploadCapture` · `useImageUploadCompression` |

## Test plan

- [x] `pnpm test`（61 files / 559 tests 全绿）
- [ ] Web：`pnpm dev:web`，验证资源库列表加载、单张/批量上传、删除、编辑元数据
- [ ] 本地工作区：导入图片、文件夹重命名/删除后同步队列正常
- [ ] 上传浮层：压缩预览、裁剪、取消后状态重置


Made with [Cursor](https://cursor.com)