### PR TITLE
fix(app): 资源库 UI 修复与工作区/编辑弹窗调整

### DIFF
--- a/app/src/features/inspector/AssetInspector.tsx
+++ b/app/src/features/inspector/AssetInspector.tsx
@@ -45,6 +45,7 @@ import { useUIStore } from '@/stores/uiStore';
 import type { ImageEditData, ImageItem } from '@pixuli/core/types';
 import { formatFileSize } from '@pixuli/core/utils';
 import { getAssetKind } from '@/features/library/utils/assetKind';
+import { UTILITY_TOOLS_ENABLED } from '@/features/tools/utilityToolsConfig';
 import {
   INSPECTOR_WIDTH_MAX,
   INSPECTOR_WIDTH_MIN,
@@ -326,28 +327,30 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
     grid.push({
       id: 'compress',
       label: t('image.inspector.actionCompress'),
-      title:
-        kind === 'image'
+      title: !UTILITY_TOOLS_ENABLED
+        ? t('image.inspector.toolDisabled')
+        : kind === 'image'
           ? t('image.inspector.sendCompress')
           : t('image.inspector.toolImageOnly'),
       icon: SlidersHorizontal,
-      disabled: kind !== 'image' || !onSendCompress,
+      disabled: !UTILITY_TOOLS_ENABLED || kind !== 'image' || !onSendCompress,
       onClick: () => {
-        if (kind !== 'image') return;
+        if (!UTILITY_TOOLS_ENABLED || kind !== 'image') return;
         onSendCompress?.();
       },
     });
     grid.push({
       id: 'convert',
       label: t('image.inspector.actionConvert'),
-      title:
-        kind === 'image'
+      title: !UTILITY_TOOLS_ENABLED
+        ? t('image.inspector.toolDisabled')
+        : kind === 'image'
           ? t('image.inspector.sendConvert')
           : t('image.inspector.toolImageOnly'),
       icon: Wand2,
-      disabled: kind !== 'image' || !onSendConvert,
+      disabled: !UTILITY_TOOLS_ENABLED || kind !== 'image' || !onSendConvert,
       onClick: () => {
-        if (kind !== 'image') return;
+        if (!UTILITY_TOOLS_ENABLED || kind !== 'image') return;
         onSendConvert?.();
       },
     });
@@ -398,12 +401,18 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
     const imageCount = selectedImages.filter(
       item => getAssetKind(item) === 'image',
     ).length;
-    const compressTitle =
-      imageCount === 0
+    const compressTitle = !UTILITY_TOOLS_ENABLED
+      ? t('image.inspector.toolDisabled')
+      : imageCount === 0
         ? t('image.inspector.toolImageOnly')
         : imageCount < selectedImages.length
           ? `${t('image.inspector.sendCompress')} (${imageCount}/${selectedImages.length})`
           : t('image.inspector.sendCompress');
+    const convertTitle = !UTILITY_TOOLS_ENABLED
+      ? t('image.inspector.toolDisabled')
+      : imageCount === 0
+        ? t('image.inspector.toolImageOnly')
+        : t('image.inspector.sendConvert');
     const grid: CompactAction[] = [
       {
         id: 'sync',
@@ -418,19 +427,22 @@ export const AssetInspector: React.FC<AssetInspectorProps> = ({
         label: t('image.inspector.actionCompress'),
         title: compressTitle,
         icon: SlidersHorizontal,
-        disabled: imageCount === 0 || !onSendCompress,
-        onClick: () => onSendCompress?.(),
+        disabled: !UTILITY_TOOLS_ENABLED || imageCount === 0 || !onSendCompress,
+        onClick: () => {
+          if (!UTILITY_TOOLS_ENABLED) return;
+          onSendCompress?.();
+        },
       },
       {
         id: 'convert',
         label: t('image.inspector.actionConvert'),
-        title:
-          imageCount === 0
-            ? t('image.inspector.toolImageOnly')
-            : t('image.inspector.sendConvert'),
+        title: convertTitle,
         icon: Wand2,
-        disabled: imageCount === 0 || !onSendConvert,
-        onClick: () => onSendConvert?.(),
+        disabled: !UTILITY_TOOLS_ENABLED || imageCount === 0 || !onSendConvert,
+        onClick: () => {
+          if (!UTILITY_TOOLS_ENABLED) return;
+          onSendConvert?.();
+        },
       },
     ];
     return {

--- a/app/src/features/inspector/ImageEditModal.tsx
+++ b/app/src/features/inspector/ImageEditModal.tsx
@@ -8,12 +8,6 @@ import {
 } from '@/ui/feedback/toast';
 import './ImageEditModal.css';
 
-function folderFromPath(path?: string): string {
-  if (!path) return 'images';
-  const slash = path.lastIndexOf('/');
-  return slash === -1 ? 'images' : path.slice(0, slash) || 'images';
-}
-
 interface ImageEditModalProps {
   image: ImageItem;
   isOpen: boolean;
@@ -45,7 +39,6 @@ const ImageEditModal: React.FC<ImageEditModalProps> = ({
     name: image.name,
     description: image.description || '',
     tags: image.tags || [],
-    targetFolder: folderFromPath(image.localPath),
   });
   const [imageDimensions, setImageDimensions] = useState<{
     width: number;
@@ -127,7 +120,6 @@ const ImageEditModal: React.FC<ImageEditModalProps> = ({
         name: image.name,
         description: image.description || '',
         tags: image.tags || [],
-        targetFolder: folderFromPath(image.localPath),
       });
       // 清空标签输入框
       if (tagInputRef.current) {
@@ -202,27 +194,6 @@ const ImageEditModal: React.FC<ImageEditModalProps> = ({
               value={formData.name || ''}
               onChange={e => handleInputChange('name', e.target.value)}
               placeholder={translate('image.edit.namePlaceholder')}
-              className="image-edit-form-input"
-            />
-          </div>
-
-          <div className="image-edit-form-group">
-            <label className="image-edit-form-label">
-              {translate('image.edit.folder')}{' '}
-              <span className="image-edit-form-optional">
-                {translate('image.edit.optional')}
-              </span>
-            </label>
-            <input
-              type="text"
-              value={formData.targetFolder ?? folderFromPath(image.localPath)}
-              onChange={e =>
-                setFormData(prev => ({
-                  ...prev,
-                  targetFolder: e.target.value,
-                }))
-              }
-              placeholder="images"
               className="image-edit-form-input"
             />
           </div>

--- a/app/src/features/library/AssetLibraryBatchBar.tsx
+++ b/app/src/features/library/AssetLibraryBatchBar.tsx
@@ -1,5 +1,6 @@
 import { RefreshCw, Trash2, Wand2 } from 'lucide-react';
 import React from 'react';
+import { UTILITY_TOOLS_ENABLED } from '@/features/tools/utilityToolsConfig';
 
 export interface AssetLibraryBatchBarProps {
   selectedCount: number;
@@ -62,10 +63,16 @@ export const AssetLibraryBatchBar: React.FC<AssetLibraryBatchBarProps> = ({
     <button
       type="button"
       className="asset-library-chrome-btn"
-      disabled={!allImagesSelected || !onSendCompress}
-      title={allImagesSelected ? undefined : t('image.inspector.toolImageOnly')}
+      disabled={!UTILITY_TOOLS_ENABLED || !allImagesSelected || !onSendCompress}
+      title={
+        !UTILITY_TOOLS_ENABLED
+          ? t('image.inspector.toolDisabled')
+          : allImagesSelected
+            ? undefined
+            : t('image.inspector.toolImageOnly')
+      }
       onClick={() => {
-        if (!allImagesSelected) return;
+        if (!UTILITY_TOOLS_ENABLED || !allImagesSelected) return;
         onSendCompress?.();
       }}
     >
@@ -74,10 +81,16 @@ export const AssetLibraryBatchBar: React.FC<AssetLibraryBatchBarProps> = ({
     <button
       type="button"
       className="asset-library-chrome-btn"
-      disabled={!allImagesSelected || !onSendConvert}
-      title={allImagesSelected ? undefined : t('image.inspector.toolImageOnly')}
+      disabled={!UTILITY_TOOLS_ENABLED || !allImagesSelected || !onSendConvert}
+      title={
+        !UTILITY_TOOLS_ENABLED
+          ? t('image.inspector.toolDisabled')
+          : allImagesSelected
+            ? undefined
+            : t('image.inspector.toolImageOnly')
+      }
       onClick={() => {
-        if (!allImagesSelected) return;
+        if (!UTILITY_TOOLS_ENABLED || !allImagesSelected) return;
         onSendConvert?.();
       }}
     >

--- a/app/src/features/tools/index.ts
+++ b/app/src/features/tools/index.ts
@@ -1,6 +1,7 @@
 export { CompressToolPanel } from './compress';
 export { ConvertToolPanel } from './convert';
 export { UtilityToolOverlay } from './UtilityToolOverlay';
+export { UTILITY_TOOLS_ENABLED } from './utilityToolsConfig';
 export {
   WebImageProcessorService,
   webImageProcessorService,

--- a/app/src/features/tools/utilityToolsConfig.ts
+++ b/app/src/features/tools/utilityToolsConfig.ts
@@ -1,0 +1,2 @@
+/** 压缩/转换工具暂不可用（侧栏入口与检查器「功能」按钮同步） */
+export const UTILITY_TOOLS_ENABLED = false;

--- a/app/src/features/workspace/WorkspaceFolderTree.tsx
+++ b/app/src/features/workspace/WorkspaceFolderTree.tsx
@@ -8,7 +8,7 @@ import {
   Trash2,
   X,
 } from 'lucide-react';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useI18n } from '@/i18n/useI18n';
 import {
   EXPLORER_WIDTH_MAX,
@@ -18,6 +18,7 @@ import {
 import { useImageStore } from '@/features/library/imageStore';
 import { useUIStore } from '@/stores/uiStore';
 import { useWorkspaceStore } from '@/features/workspace/workspaceStore';
+import { formatWorkspaceTitle } from '@/features/workspace/workspacePathDisplay';
 import {
   buildWorkspaceFolderTree,
   folderNodeLabel,
@@ -32,30 +33,6 @@ export function resolveNewFolderParent(selectedOrMenuPath: string): string {
     return '';
   }
   return path.replace(/\/+$/, '');
-}
-
-/** 资源管理器展示的本机位置：真实路径优先，虚拟存储用可读说明 */
-export function formatWorkspaceLocation(
-  rootPath: string | null,
-  displayName: string | null,
-  t: (key: string) => string,
-): string | null {
-  if (!rootPath) {
-    return null;
-  }
-  if (rootPath.startsWith('mobile://')) {
-    return t('workspace.mobileStorage');
-  }
-  if (rootPath.startsWith('opfs://')) {
-    return t('workspace.webStorage');
-  }
-  if (rootPath.startsWith('fsa://')) {
-    const name = displayName?.trim();
-    return name
-      ? `${t('workspace.fsaStorage')} · ${name}`
-      : t('workspace.fsaStorage');
-  }
-  return rootPath;
 }
 
 interface TreeRowProps {
@@ -153,6 +130,10 @@ export const WorkspaceFolderTree: React.FC<{ overlay?: boolean }> = ({
   const images = useImageStore(state => state.images);
   const displayName = useWorkspaceStore(state => state.displayName);
   const rootPath = useWorkspaceStore(state => state.rootPath);
+  const rootDisplayPath = useWorkspaceStore(state => state.rootDisplayPath);
+  const refreshRootDisplayPath = useWorkspaceStore(
+    state => state.refreshRootDisplayPath,
+  );
   const localFolders = useWorkspaceStore(state => state.localFolders);
   const createLocalFolder = useWorkspaceStore(state => state.createLocalFolder);
   const renameLocalFolder = useWorkspaceStore(state => state.renameLocalFolder);
@@ -283,7 +264,18 @@ export const WorkspaceFolderTree: React.FC<{ overlay?: boolean }> = ({
     }
   };
 
-  const workspaceLocation = formatWorkspaceLocation(rootPath, displayName, t);
+  const workspaceTitle = formatWorkspaceTitle(
+    rootPath,
+    displayName,
+    rootDisplayPath,
+    t,
+  );
+
+  useEffect(() => {
+    if (rootPath?.startsWith('fsa://') && !rootDisplayPath) {
+      void refreshRootDisplayPath();
+    }
+  }, [rootPath, rootDisplayPath, refreshRootDisplayPath]);
 
   return (
     <aside
@@ -293,20 +285,12 @@ export const WorkspaceFolderTree: React.FC<{ overlay?: boolean }> = ({
     >
       <div className="workspace-explorer-header">
         <div className="workspace-explorer-header-text">
-          <h2 className="workspace-explorer-title">
-            {displayName || t('workspace.unnamed')}
+          <h2 className="workspace-explorer-title" title={workspaceTitle}>
+            {workspaceTitle}
           </h2>
           <p className="workspace-explorer-subtitle">
             {t('workspace.explorer')}
           </p>
-          {workspaceLocation ? (
-            <p className="workspace-explorer-path" title={workspaceLocation}>
-              <span className="workspace-explorer-path-label">
-                {t('workspace.localPath')}
-              </span>
-              {workspaceLocation}
-            </p>
-          ) : null}
         </div>
         {overlay ? (
           <div className="workspace-explorer-header-actions">

--- a/app/src/features/workspace/WorkspaceManagePanel.tsx
+++ b/app/src/features/workspace/WorkspaceManagePanel.tsx
@@ -12,6 +12,7 @@ import { useImageStore } from '@/features/library/imageStore';
 import { useSourceStore } from '@/features/settings/sourceStore';
 import { useUIStore } from '@/stores/uiStore';
 import { useWorkspaceStore } from '@/features/workspace/workspaceStore';
+import { formatWorkspaceTitle } from '@/features/workspace/workspacePathDisplay';
 import { formatSyncOutcome } from './syncOutcome';
 
 function formatSyncTime(
@@ -33,6 +34,7 @@ export const WorkspaceManagePanel: React.FC = () => {
   const {
     displayName,
     rootPath,
+    rootDisplayPath,
     pushing,
     syncing,
     syncStatus,
@@ -171,35 +173,17 @@ export const WorkspaceManagePanel: React.FC = () => {
           {t('settings.workspaceCurrentTitle')}
         </h3>
         <div className="mt-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
-          <p className="text-sm font-medium text-gray-900">
-            {displayName || t('workspace.unnamed')}
-          </p>
-          {rootPath?.startsWith('mobile://') && (
-            <p className="mt-1 text-xs text-gray-500">
-              {t('workspace.mobileStorage')}
-            </p>
-          )}
-          {rootPath?.startsWith('fsa://') && (
-            <p className="mt-1 text-xs text-gray-500">
-              {t('workspace.fsaStorage')}
-            </p>
-          )}
-          {rootPath?.startsWith('opfs://') && (
-            <p className="mt-1 text-xs text-gray-500">
-              {t('workspace.webStorage')}
-            </p>
-          )}
-          {rootPath &&
-            !rootPath.startsWith('opfs://') &&
-            !rootPath.startsWith('fsa://') &&
-            !rootPath.startsWith('mobile://') && (
-              <p
-                className="mt-1 truncate text-xs text-gray-500"
-                title={rootPath}
-              >
-                {rootPath}
-              </p>
+          <p
+            className="truncate text-sm font-medium text-gray-900"
+            title={formatWorkspaceTitle(
+              rootPath,
+              displayName,
+              rootDisplayPath,
+              t,
             )}
+          >
+            {formatWorkspaceTitle(rootPath, displayName, rootDisplayPath, t)}
+          </p>
           <div className="mt-3 flex flex-wrap gap-2">
             <span className="inline-flex items-center rounded-full border border-gray-200 bg-white px-2 py-0.5 text-xs text-gray-700">
               {t('workspace.lastSync')}:{' '}

--- a/app/src/features/workspace/__tests__/resolveNewFolderParent.test.ts
+++ b/app/src/features/workspace/__tests__/resolveNewFolderParent.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  formatWorkspaceLocation,
-  resolveNewFolderParent,
-} from '../WorkspaceFolderTree';
+import { resolveNewFolderParent } from '../WorkspaceFolderTree';
 
 describe('resolveNewFolderParent', () => {
   it('maps root / empty to workspace top-level', () => {
@@ -15,27 +12,5 @@ describe('resolveNewFolderParent', () => {
     expect(resolveNewFolderParent('111')).toBe('111');
     expect(resolveNewFolderParent('images')).toBe('images');
     expect(resolveNewFolderParent('images/trip/')).toBe('images/trip');
-  });
-});
-
-describe('formatWorkspaceLocation', () => {
-  const t = (key: string) => key;
-
-  it('returns absolute filesystem paths as-is', () => {
-    expect(formatWorkspaceLocation('/Users/me/Pictures/111', '111', t)).toBe(
-      '/Users/me/Pictures/111',
-    );
-  });
-
-  it('labels virtual storage backends', () => {
-    expect(formatWorkspaceLocation('opfs://abc', null, t)).toBe(
-      'workspace.webStorage',
-    );
-    expect(formatWorkspaceLocation('fsa://abc', '相册', t)).toBe(
-      'workspace.fsaStorage · 相册',
-    );
-    expect(formatWorkspaceLocation('mobile://abc', null, t)).toBe(
-      'workspace.mobileStorage',
-    );
   });
 });

--- a/app/src/features/workspace/__tests__/workspacePathDisplay.test.ts
+++ b/app/src/features/workspace/__tests__/workspacePathDisplay.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatWorkspacePathHint,
+  formatWorkspaceTitle,
+  isVirtualWorkspaceRoot,
+} from '../workspacePathDisplay';
+
+describe('isVirtualWorkspaceRoot', () => {
+  it('detects virtual workspace schemes', () => {
+    expect(isVirtualWorkspaceRoot('fsa://abc')).toBe(true);
+    expect(isVirtualWorkspaceRoot('opfs://abc')).toBe(true);
+    expect(isVirtualWorkspaceRoot('mobile://abc')).toBe(true);
+    expect(isVirtualWorkspaceRoot('/Users/me/Pictures')).toBe(false);
+  });
+});
+
+describe('formatWorkspacePathHint', () => {
+  const t = (key: string) => key;
+
+  it('returns absolute filesystem paths as-is', () => {
+    expect(formatWorkspacePathHint('/Users/me/Pictures/111', null, t)).toBe(
+      '/Users/me/Pictures/111',
+    );
+  });
+
+  it('uses resolved absolute path for FSA workspaces', () => {
+    expect(
+      formatWorkspacePathHint('fsa://abc', '/Users/me/Pictures/222', t),
+    ).toBe('/Users/me/Pictures/222');
+  });
+
+  it('returns null for FSA when absolute path is unavailable', () => {
+    expect(formatWorkspacePathHint('fsa://abc', null, t)).toBeNull();
+  });
+
+  it('labels other virtual storage backends', () => {
+    expect(formatWorkspacePathHint('opfs://abc', null, t)).toBe(
+      'workspace.webStorage',
+    );
+    expect(formatWorkspacePathHint('mobile://abc', null, t)).toBe(
+      'workspace.mobileStorage',
+    );
+  });
+});
+
+describe('formatWorkspaceTitle', () => {
+  const t = (key: string) => key;
+
+  it('combines workspace name and absolute path', () => {
+    expect(
+      formatWorkspaceTitle(
+        '/Users/me/Pictures/111',
+        '111',
+        '/Users/me/Pictures/111',
+        t,
+      ),
+    ).toBe('111（/Users/me/Pictures/111）');
+    expect(
+      formatWorkspaceTitle('fsa://abc', '222', '/Users/me/Pictures/222', t),
+    ).toBe('222（/Users/me/Pictures/222）');
+  });
+
+  it('omits parentheses when FSA path cannot be resolved', () => {
+    expect(formatWorkspaceTitle('fsa://abc', '222', null, t)).toBe('222');
+  });
+
+  it('falls back to unnamed when no path', () => {
+    expect(formatWorkspaceTitle(null, null, null, t)).toBe('workspace.unnamed');
+  });
+});

--- a/app/src/features/workspace/workspacePathDisplay.ts
+++ b/app/src/features/workspace/workspacePathDisplay.ts
@@ -1,0 +1,76 @@
+import {
+  parseFsaRootPath,
+  resolveFsaAbsolutePath,
+} from '@/platforms/web/fsaWorkspaceFs';
+
+export function isVirtualWorkspaceRoot(rootPath: string): boolean {
+  return (
+    rootPath.startsWith('opfs://') ||
+    rootPath.startsWith('fsa://') ||
+    rootPath.startsWith('mobile://')
+  );
+}
+
+/** 解析工作区在本机的展示路径（绝对路径优先；FSA 仅在运行时/API 允许时解析） */
+export async function resolveWorkspaceRootDisplayPath(
+  rootPath: string | null,
+  persistedAbsolutePath?: string | null,
+): Promise<string | null> {
+  if (!rootPath) {
+    return null;
+  }
+
+  if (!isVirtualWorkspaceRoot(rootPath)) {
+    return rootPath;
+  }
+
+  if (rootPath.startsWith('fsa://')) {
+    const cached = persistedAbsolutePath?.trim();
+    if (cached) {
+      return cached;
+    }
+    const workspaceId = parseFsaRootPath(rootPath);
+    if (!workspaceId) {
+      return null;
+    }
+    return resolveFsaAbsolutePath(workspaceId);
+  }
+
+  return null;
+}
+
+/** 资源管理器路径说明（不含工作区名称，用于标题括号内） */
+export function formatWorkspacePathHint(
+  rootPath: string | null,
+  rootDisplayPath: string | null | undefined,
+  t: (key: string) => string,
+): string | null {
+  if (!rootPath) {
+    return null;
+  }
+  if (rootPath.startsWith('mobile://')) {
+    return t('workspace.mobileStorage');
+  }
+  if (rootPath.startsWith('opfs://')) {
+    return t('workspace.webStorage');
+  }
+  if (rootPath.startsWith('fsa://')) {
+    return rootDisplayPath?.trim() || null;
+  }
+  return rootPath;
+}
+
+/** 资源管理器标题：工作区名称（路径） */
+export function formatWorkspaceTitle(
+  rootPath: string | null,
+  displayName: string | null,
+  rootDisplayPath: string | null | undefined,
+  t: (key: string) => string,
+): string {
+  const name = displayName?.trim() || t('workspace.unnamed');
+  const pathHint = formatWorkspacePathHint(rootPath, rootDisplayPath, t);
+  if (!pathHint) {
+    return name;
+  }
+  return `${name}（${pathHint}）`;
+}

--- a/app/src/features/workspace/workspacePersist.ts
+++ b/app/src/features/workspace/workspacePersist.ts
@@ -5,6 +5,8 @@ export type WorkspacePersist = {
   rootPath: string;
   workspaceId: string;
   folderLabel?: string;
+  /** FSA 工作区解析到的本机绝对路径（若运行时曾成功获取） */
+  absolutePath?: string;
 };
 
 export function saveWorkspaceModePref(
@@ -35,11 +37,18 @@ export function savePersistedWorkspace(
   rootPath: string,
   workspaceId: string,
   folderLabel?: string,
+  absolutePath?: string,
 ): void {
   try {
+    const existing = loadPersistedWorkspace();
     localStorage.setItem(
       WORKSPACE_STORAGE_KEY,
-      JSON.stringify({ rootPath, workspaceId, folderLabel }),
+      JSON.stringify({
+        rootPath,
+        workspaceId,
+        folderLabel,
+        absolutePath: absolutePath ?? existing?.absolutePath,
+      }),
     );
   } catch {
     // ignore

--- a/app/src/features/workspace/workspaceRuntime.ts
+++ b/app/src/features/workspace/workspaceRuntime.ts
@@ -84,7 +84,7 @@ function resolveSelectedSource() {
   return sources[0] ?? null;
 }
 
-function resolveSelectedProvider() {
+export function resolveSelectedProvider() {
   const source = resolveSelectedSource();
   if (!source) {
     return null;

--- a/app/src/features/workspace/workspaceStore.ts
+++ b/app/src/features/workspace/workspaceStore.ts
@@ -43,18 +43,22 @@ import {
   savePersistedWorkspace,
   saveWorkspaceModePref,
 } from '@/features/workspace/workspacePersist';
+import { resolveWorkspaceRootDisplayPath } from '@/features/workspace/workspacePathDisplay';
 import {
   getWorkspaceSyncEngine,
   getWorkspaceVault,
   registerWorkspaceModeReader,
   resetWorkspaceRuntime,
   resetWorkspaceSyncEngineOnly,
+  resolveSelectedProvider,
 } from '@/features/workspace/workspaceRuntime';
 
 interface WorkspaceState {
   mode: WorkspaceMode;
   rootPath: string | null;
   displayName: string | null;
+  /** 本机绝对路径或虚拟存储说明（FSA 在可解析时为绝对路径） */
+  rootDisplayPath: string | null;
   localImages: ImageItem[];
   loading: boolean;
   pushing: boolean;
@@ -75,6 +79,7 @@ interface WorkspaceState {
   syncBindingsFromSources: () => Promise<void>;
   /** quiet：添加/写入时静默刷新，避免锁住资源库壳层（§5.1） */
   refreshLocalImages: (options?: { quiet?: boolean }) => Promise<void>;
+  refreshRootDisplayPath: () => Promise<void>;
   refreshSyncStatus: () => Promise<void>;
   scanWorkspace: () => Promise<void>;
   importLocalImage: (uploadData: ImageUploadData) => Promise<ImageItem | null>;
@@ -147,10 +152,36 @@ async function openVaultWithRoot(rootPath: string): Promise<LocalVault> {
   return vault;
 }
 
+async function refreshAndPersistRootDisplayPath(
+  rootPath: string | null,
+  apply: (rootDisplayPath: string | null) => void,
+): Promise<void> {
+  const persisted = loadPersistedWorkspace();
+  const resolved = await resolveWorkspaceRootDisplayPath(
+    rootPath,
+    persisted?.absolutePath,
+  );
+  apply(resolved);
+  if (
+    resolved &&
+    rootPath?.startsWith('fsa://') &&
+    persisted?.rootPath === rootPath &&
+    resolved !== persisted.absolutePath
+  ) {
+    savePersistedWorkspace(
+      persisted.rootPath,
+      persisted.workspaceId,
+      persisted.folderLabel,
+      resolved,
+    );
+  }
+}
+
 export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   mode: 'unset',
   rootPath: null,
   displayName: null,
+  rootDisplayPath: null,
   localImages: [],
   localFolders: [],
   loading: false,
@@ -206,6 +237,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         displayName: folderLabel ?? config.displayName,
         loading: false,
       });
+      await refreshAndPersistRootDisplayPath(
+        persisted.rootPath,
+        rootDisplayPath => set({ rootDisplayPath }),
+      );
       await get().syncBindingsFromSources();
       await get().refreshLocalImages();
       await get().refreshSyncStatus();
@@ -244,6 +279,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         syncMessage: null,
         syncOutcome: null,
       });
+      await refreshAndPersistRootDisplayPath(
+        persisted.rootPath,
+        rootDisplayPath => set({ rootDisplayPath }),
+      );
       await get().syncBindingsFromSources();
       await get().refreshLocalImages();
       await get().refreshSyncStatus();
@@ -325,6 +364,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         syncMessage: null,
         syncOutcome: null,
       });
+      await refreshAndPersistRootDisplayPath(rootPath, rootDisplayPath =>
+        set({ rootDisplayPath }),
+      );
       await get().syncBindingsFromSources();
       await get().refreshLocalImages();
       await get().refreshSyncStatus();
@@ -351,6 +393,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       mode: 'unset',
       rootPath: null,
       displayName: null,
+      rootDisplayPath: null,
       localImages: [],
       localFolders: [],
       loading: false,
@@ -362,6 +405,12 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       syncOutcome: null,
     });
     notifyWorkspaceCleared();
+  },
+
+  refreshRootDisplayPath: async () => {
+    await refreshAndPersistRootDisplayPath(get().rootPath, rootDisplayPath =>
+      set({ rootDisplayPath }),
+    );
   },
 
   refreshLocalImages: async options => {

--- a/app/src/layouts/AppSidebar.tsx
+++ b/app/src/layouts/AppSidebar.tsx
@@ -11,6 +11,7 @@ import { ROUTES } from '@/router/routes';
 import { useSourceStore } from '@/features/settings/sourceStore';
 import { useUIStore } from '@/stores/uiStore';
 import { useWorkspaceStore } from '@/features/workspace/workspaceStore';
+import { UTILITY_TOOLS_ENABLED } from '@/features/tools/utilityToolsConfig';
 import { isWorkspaceAvailable } from '@/platforms/workspacePlatform';
 
 interface SidebarProps {
@@ -156,7 +157,7 @@ export const AppSidebar: React.FC<SidebarProps> = ({
           syncBusy={syncBusy}
           syncDisabled={syncBusy}
           syncRemoteLabel={syncRemoteLabel}
-          hideUtilityTools
+          hideUtilityTools={!UTILITY_TOOLS_ENABLED}
           hideHelpFooter
           showWorkspaceNav={isWorkspaceAvailable()}
           hideSources

--- a/app/src/platforms/web/fsaWorkspaceFs.ts
+++ b/app/src/platforms/web/fsaWorkspaceFs.ts
@@ -217,6 +217,50 @@ export async function fsaListFiles(
   return results.sort();
 }
 
+function deriveDirectoryFromFilePath(
+  filePath: string,
+  fileName: string,
+): string | null {
+  const normalized = filePath.replace(/\\/g, '/');
+  const suffix = `/${fileName}`;
+  if (normalized.endsWith(suffix)) {
+    return normalized.slice(0, -suffix.length);
+  }
+  const lastSlash = normalized.lastIndexOf('/');
+  if (lastSlash > 0) {
+    return normalized.slice(0, lastSlash);
+  }
+  return null;
+}
+
+/** 尝试从 FSA 目录内文件推断本机绝对路径（浏览器通常不可用；Electron 等环境可能有效） */
+export async function resolveFsaAbsolutePath(
+  workspaceId: string,
+): Promise<string | null> {
+  const handle = await loadFsaDirectoryHandle(workspaceId);
+  if (!handle) {
+    return null;
+  }
+
+  try {
+    for await (const [name, entry] of handle.entries()) {
+      if (entry.kind !== 'file') {
+        continue;
+      }
+      const file = await (entry as FileSystemFileHandle).getFile();
+      const filePath = (file as File & { path?: string }).path;
+      if (typeof filePath === 'string' && filePath.trim().length > 0) {
+        return deriveDirectoryFromFilePath(filePath, name);
+      }
+      break;
+    }
+  } catch {
+    // ignore probe errors
+  }
+
+  return null;
+}
+
 export async function pickFsaDirectory(): Promise<FileSystemDirectoryHandle | null> {
   if (!isFileSystemAccessSupported()) {
     return null;


### PR DESCRIPTION
## Summary

- 修复本地工作区同步报错：`resolveSelectedProvider is not defined`（导出并接入 `workspaceStore`）
- 资源管理器标题改为「工作区名称（路径）」；FSA 工作区尝试解析本机绝对路径并持久化
- 压缩/转换工具统一经 `UTILITY_TOOLS_ENABLED` 暂时禁用（侧栏、检查器、批量栏）
- 图片编辑弹窗移除「文件夹」字段，保存时仅更新名称/描述/标签

## Test plan

- [x] `pnpm test`（565 tests）
- [ ] Web：连接 FSA 工作区后同步不再报错；标题显示名称（路径）
- [ ] 检查器压缩/转换按钮呈禁用态，提示「暂不可用」
- [ ] 编辑图片弹窗无文件夹输入，保存元数据正常


Made with [Cursor](https://cursor.com)