### PR TITLE
refactor(app): S13–S15 端口契约、壳层 Modal 注册表与测试 fixture

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -44,7 +44,7 @@ pnpm build:android    # 已签名 release APK；debug 用 pnpm build:android:deb
 
 | 路径               | 说明                                               |
 | ------------------ | -------------------------------------------------- |
-| `src/`             | 应用源码（features、layouts、pages）               |
+| `src/`             | 应用源码（features、layouts、router）              |
 | `src/platforms/`   | 平台检测、各端适配器、Web 浏览器壳层               |
 | `electron/`        | Desktop 主进程 / preload                           |
 | `android/`         | Capacitor Android 工程                             |

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,5 +1,6 @@
 import './App.css';
 import '@/features/access/registerPublishPort';
+import '@/features/tools/registerUtilityToolPort';
 import { SearchProvider } from '@/features/library/SearchContext';
 import { useAppOrchestration } from '@/hooks/useAppOrchestration';
 import { MainLayout } from '@/layouts/MainLayout';

--- a/app/src/README.md
+++ b/app/src/README.md
@@ -11,17 +11,17 @@ L2  ui/                      薄 primitives / brand（@/ui）
 L3  layouts/ + platforms/ + boot/ + router/   壳层与路由
 ```
 
-| 路径                     | 职责                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------- |
-| `features/library`       | 资源库 SSOT：`LibraryPage`、`useLibraryRoute`、`LibraryWorkbench`、`imageStore` |
-| `features/tools`         | 增强工具：`imageProcessor`、压缩/转换 Panel、`UtilityToolOverlay`               |
-| `features/settings`      | 设置、源管理 hooks、配置 Modal、`sourceStore`                                   |
-| `features/workspace`     | 本地工作区、folderTree、`workspaceStore`                                        |
-| `features/operation-log` | 操作日志 UI + store + service（域内聚）                                         |
-| `stores/`                | **跨 feature** 壳层全局 Zustand                                                 |
-| `router/`                | `/library` 主路由、`LibraryPage` lazy 加载、legacy redirect                     |
-| `i18n/`                  | 文案 SSOT；壳层标语见 `brand.json` + `brandCopy.ts`                             |
-| `ui/`                    | 禁止放复合业务 UI                                                               |
+| 路径                     | 职责                                                                             |
+| ------------------------ | -------------------------------------------------------------------------------- |
+| `features/library`       | 资源库 SSOT：`LibraryRoute`、`useLibraryRoute`、`LibraryWorkbench`、`imageStore` |
+| `features/tools`         | 增强工具：`imageProcessor`、压缩/转换 Panel、`UtilityToolOverlay`                |
+| `features/settings`      | 设置、源管理 hooks、配置 Modal、`sourceStore`                                    |
+| `features/workspace`     | 本地工作区、folderTree、`workspaceStore`                                         |
+| `features/operation-log` | 操作日志 UI + store + service（域内聚）                                          |
+| `stores/`                | **跨 feature** 壳层全局 Zustand                                                  |
+| `router/`                | `/library` 主路由、`LibraryRoute` lazy 加载、legacy redirect                     |
+| `i18n/`                  | 文案 SSOT；壳层标语见 `brand.json` + `brandCopy.ts`                              |
+| `ui/`                    | 禁止放复合业务 UI                                                                |
 
 ## 路由
 
@@ -43,6 +43,8 @@ L3  layouts/ + platforms/ + boot/ + router/   壳层与路由
 跨 feature 互调经端口契约，避免直接 import 对方 store：
 
 - `workspaceImageBridge`（`library` ↔ `workspace`）
+- `sourceSelectionPort`（`settings` ↔ `library` 源选中与仓库配置）
+- `utilityToolPort`（`library` / `inspector` / 侧栏 → `tools` overlay）
 - `publishContract`（`library` / `inspector` ↔ `access` 只读发布状态）
 
 ## 导入约定
@@ -51,6 +53,8 @@ L3  layouts/ + platforms/ + boot/ + router/   壳层与路由
 - 薄 UI：`@/ui`
 - 壳层 hooks：`@/hooks`（仅 init、路由同步、键盘、面板）
 - 无域归属的纯函数：`@/utils`（当前仅 `clipboard`）
+- 面板宽度常量：`constants/panelWidth.ts`（壳层 `usePanelResize`）
+- 全局 ambient 类型：`types/*.d.ts`（FSA / SW / workspace API 等，无 barrel）
 
 ## 文案
 
@@ -62,4 +66,5 @@ L3  layouts/ + platforms/ + boot/ + router/   壳层与路由
 
 在仓库根目录：`pnpm test` · `pnpm dev:web` · `pnpm build:web`
 
-更细的 UI 边界见 [ui/README.md](./ui/README.md)。
+更细的 UI 边界见 [ui/README.md](./ui/README.md)；壳层 hooks 见
+[hooks/README.md](./hooks/README.md)。

--- a/app/src/features/library/LibraryRoute.tsx
+++ b/app/src/features/library/LibraryRoute.tsx
@@ -2,11 +2,12 @@ import { LibraryWorkbench } from '@/features/library/LibraryWorkbench';
 import { useLibraryRoute } from '@/features/library/useLibraryRoute';
 import React from 'react';
 
-interface LibraryPageProps {
+interface LibraryRouteProps {
   onOpenConfigModal: () => void;
 }
 
-export const LibraryPage: React.FC<LibraryPageProps> = ({
+/** `/library` 路由视图：接线 `useLibraryRoute` 与 `LibraryWorkbench` */
+export const LibraryRoute: React.FC<LibraryRouteProps> = ({
   onOpenConfigModal,
 }) => {
   const {
@@ -43,4 +44,4 @@ export const LibraryPage: React.FC<LibraryPageProps> = ({
   );
 };
 
-export default LibraryPage;
+export default LibraryRoute;

--- a/app/src/features/library/LibraryWorkbench.tsx
+++ b/app/src/features/library/LibraryWorkbench.tsx
@@ -25,6 +25,7 @@ import {
   useNativeShareImage,
 } from '@/features/library/useNativeImageActions';
 import { useImageStore } from '@/features/library/imageStore';
+import { openUtilityTool } from '@/features/tools/utilityToolPort';
 import { useUIStore } from '@/stores/uiStore';
 import { useWorkspaceStore } from '@/features/workspace/workspaceStore';
 import './LibraryWorkbench.css';
@@ -97,11 +98,6 @@ export const LibraryWorkbench: React.FC<LibraryWorkbenchProps> = ({
   const setWorkspaceExplorerOpen = useUIStore(
     state => state.setWorkspaceExplorerOpen,
   );
-  const setCurrentUtilityTool = useUIStore(
-    state => state.setCurrentUtilityTool,
-  );
-  const setCurrentView = useUIStore(state => state.setCurrentView);
-  const setActiveMenu = useUIStore(state => state.setActiveMenu);
   const currentUtilityTool = useUIStore(state => state.currentUtilityTool);
 
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
@@ -249,22 +245,13 @@ export const LibraryWorkbench: React.FC<LibraryWorkbenchProps> = ({
     setReviewIndex(0);
   }, []);
 
-  const openUtilityTool = useCallback(
-    (tool: 'compress' | 'convert') => {
-      setCurrentUtilityTool(tool);
-      setCurrentView('library');
-      setActiveMenu(tool);
-    },
-    [setActiveMenu, setCurrentUtilityTool, setCurrentView],
-  );
-
   const handleSendCompress = useCallback(() => {
     openUtilityTool('compress');
-  }, [openUtilityTool]);
+  }, []);
 
   const handleSendConvert = useCallback(() => {
     openUtilityTool('convert');
-  }, [openUtilityTool]);
+  }, []);
 
   useEffect(() => {
     if (!workspaceExplorerOpen) return;

--- a/app/src/features/library/imageStore.ts
+++ b/app/src/features/library/imageStore.ts
@@ -34,6 +34,7 @@ import {
   unconfiguredStorageError,
 } from '@/features/library/assetListService';
 import { registerLibraryImageReset } from '@/features/library/workspaceImageBridge';
+import { registerSourceSelectionPort } from '@/features/library/sourceSelectionPort';
 import type {
   BatchUploadProgress,
   GiteeConfig,
@@ -294,4 +295,23 @@ export const useImageStore = create<ImageState>((set, get) => {
 
 registerLibraryImageReset(() => {
   useImageStore.setState({ images: [], loading: false, error: null });
+});
+
+registerSourceSelectionPort({
+  getStorageType: () => useImageStore.getState().storageType,
+  getGitHubConfig: () => useImageStore.getState().githubConfig,
+  getGiteeConfig: () => useImageStore.getState().giteeConfig,
+  getStorageProvider: () => useImageStore.getState().storageProvider,
+  setStorageType: type => useImageStore.setState({ storageType: type }),
+  setGitHubConfig: config => useImageStore.getState().setGitHubConfig(config),
+  setGiteeConfig: config => useImageStore.getState().setGiteeConfig(config),
+  clearGitHubConfig: () => useImageStore.getState().clearGitHubConfig(),
+  clearGiteeConfig: () => useImageStore.getState().clearGiteeConfig(),
+  loadImages: () => useImageStore.getState().loadImages(),
+  initializeStorageIfNeeded: () => {
+    const { storageProvider, initializeStorage } = useImageStore.getState();
+    if (!storageProvider) {
+      initializeStorage();
+    }
+  },
 });

--- a/app/src/features/library/sourceSelectionPort.ts
+++ b/app/src/features/library/sourceSelectionPort.ts
@@ -1,0 +1,42 @@
+import type { GiteeConfig, GitHubConfig } from '@pixuli/core/types';
+import type { StorageProvider } from '@pixuli/core/plugins';
+import type { StoragePluginId } from '@/storage/createProvider';
+
+/** settings ↔ library：源选中与仓库配置同步（避免 settings 直接依赖 imageStore） */
+export interface SourceSelectionPort {
+  getStorageType(): StoragePluginId | null;
+  getGitHubConfig(): GitHubConfig | null;
+  getGiteeConfig(): GiteeConfig | null;
+  getStorageProvider(): StorageProvider | null;
+  setStorageType(type: StoragePluginId): void;
+  setGitHubConfig(config: GitHubConfig): void;
+  setGiteeConfig(config: GiteeConfig): void;
+  clearGitHubConfig(): void;
+  clearGiteeConfig(): void;
+  loadImages(): Promise<void>;
+  initializeStorageIfNeeded(): void;
+}
+
+const inactivePort: SourceSelectionPort = {
+  getStorageType: () => null,
+  getGitHubConfig: () => null,
+  getGiteeConfig: () => null,
+  getStorageProvider: () => null,
+  setStorageType: () => undefined,
+  setGitHubConfig: () => undefined,
+  setGiteeConfig: () => undefined,
+  clearGitHubConfig: () => undefined,
+  clearGiteeConfig: () => undefined,
+  loadImages: async () => undefined,
+  initializeStorageIfNeeded: () => undefined,
+};
+
+let sourceSelectionPort: SourceSelectionPort | null = null;
+
+export function registerSourceSelectionPort(port: SourceSelectionPort): void {
+  sourceSelectionPort = port;
+}
+
+export function getSourceSelectionPort(): SourceSelectionPort {
+  return sourceSelectionPort ?? inactivePort;
+}

--- a/app/src/features/library/useLibraryRoute.ts
+++ b/app/src/features/library/useLibraryRoute.ts
@@ -7,6 +7,7 @@ import { filterImagesByFolder } from '@/features/workspace/folderTree';
 import { useWorkspaceStore } from '@/features/workspace/workspaceStore';
 import { useI18n } from '@/i18n/useI18n';
 import { isWorkspaceAvailable } from '@/platforms/workspacePlatform';
+import { openUtilityTool } from '@/features/tools/utilityToolPort';
 import { useUIStore } from '@/stores/uiStore';
 import { useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -22,10 +23,6 @@ export function useLibraryRoute() {
   const { sources } = useSourceStore();
   const localActive = useWorkspaceStore(state => state.isLocalActive());
   const selectedFolderPath = useUIStore(state => state.selectedFolderPath);
-  const setCurrentUtilityTool = useUIStore(
-    state => state.setCurrentUtilityTool,
-  );
-  const setActiveMenu = useUIStore(state => state.setActiveMenu);
   const { handleDeleteImage, handleDeleteMultipleImages, handleUpdateImage } =
     useImageOperations();
   const searchContext = useSearchContextSafe();
@@ -61,12 +58,11 @@ export function useLibraryRoute() {
     if (tool !== 'compress' && tool !== 'convert') {
       return;
     }
-    setCurrentUtilityTool(tool);
-    setActiveMenu(tool);
+    openUtilityTool(tool);
     const next = new URLSearchParams(searchParams);
     next.delete('tool');
     setSearchParams(next, { replace: true });
-  }, [searchParams, setActiveMenu, setCurrentUtilityTool, setSearchParams]);
+  }, [searchParams, setSearchParams]);
 
   return {
     t,

--- a/app/src/features/library/useSourceSelection.ts
+++ b/app/src/features/library/useSourceSelection.ts
@@ -1,0 +1,51 @@
+import type { GiteeConfig, GitHubConfig } from '@pixuli/core/types';
+import type { StoragePluginId } from '@/storage/createProvider';
+import { useCallback } from 'react';
+import { useImageStore } from '@/features/library/imageStore';
+import { getSourceSelectionPort } from '@/features/library/sourceSelectionPort';
+
+/** settings 侧 reactive 读口：内部仍订阅 imageStore，对外不暴露 store */
+export function useSourceSelection() {
+  const storageType = useImageStore(state => state.storageType);
+  const githubConfig = useImageStore(state => state.githubConfig);
+  const giteeConfig = useImageStore(state => state.giteeConfig);
+  const loading = useImageStore(state => state.loading);
+
+  const setGitHubConfig = useCallback(
+    (config: GitHubConfig) => getSourceSelectionPort().setGitHubConfig(config),
+    [],
+  );
+  const setGiteeConfig = useCallback(
+    (config: GiteeConfig) => getSourceSelectionPort().setGiteeConfig(config),
+    [],
+  );
+  const clearGitHubConfig = useCallback(
+    () => getSourceSelectionPort().clearGitHubConfig(),
+    [],
+  );
+  const clearGiteeConfig = useCallback(
+    () => getSourceSelectionPort().clearGiteeConfig(),
+    [],
+  );
+  const loadImages = useCallback(
+    () => getSourceSelectionPort().loadImages(),
+    [],
+  );
+  const setStorageType = useCallback(
+    (type: StoragePluginId) => getSourceSelectionPort().setStorageType(type),
+    [],
+  );
+
+  return {
+    storageType,
+    githubConfig,
+    giteeConfig,
+    loading,
+    setGitHubConfig,
+    setGiteeConfig,
+    clearGitHubConfig,
+    clearGiteeConfig,
+    loadImages,
+    setStorageType,
+  };
+}

--- a/app/src/features/settings/SettingsSyncPanel.tsx
+++ b/app/src/features/settings/SettingsSyncPanel.tsx
@@ -1,4 +1,4 @@
-import type { SidebarSource } from '@/layouts/sidebar';
+import type { SidebarSource } from '@/features/settings/sidebarSourceTypes';
 import { Edit, Github, Plus, Trash2 } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 import { SourceTypePicker } from '@/features/source-type/SourceTypePicker';

--- a/app/src/features/settings/__tests__/modalTestFixtures.ts
+++ b/app/src/features/settings/__tests__/modalTestFixtures.ts
@@ -1,0 +1,88 @@
+import { vi } from 'vitest';
+
+/** 配置 Modal 测试共用文案 */
+export const commonConfigModalMessages: Record<string, string> = {
+  'storage.configuration': '配置',
+  'common.cancel': '取消',
+  'messages.configSaved': '配置已成功保存！',
+  'messages.configCleared': '配置已成功清除！',
+  'messages.configExported': '配置已成功导出！',
+  'messages.configImported': '配置已成功导入！',
+  'messages.saveFailed': '保存配置失败',
+  'messages.clearFailed': '清除配置失败',
+  'messages.exportFailed': '导出配置失败',
+  'messages.importFailed': '导入配置失败',
+  'messages.invalidFormat': '配置文件格式不正确',
+  'messages.noConfigToExport': '没有可导出的配置',
+};
+
+export const githubConfigModalTranslations: Record<string, string> = {
+  ...commonConfigModalMessages,
+  'github.config.title': 'GitHub 仓库配置',
+  'github.config.username': 'GitHub 用户名',
+  'github.config.repository': '仓库名称',
+  'github.config.branch': '分支名称',
+  'github.config.path': '图片存储路径',
+  'github.config.token': 'GitHub Token',
+  'github.config.import': '↑ 导入',
+  'github.config.export': '导出',
+  'github.config.clearConfig': '清除配置',
+  'github.config.saveConfig': '保存配置',
+  'github.config.usernamePlaceholder': '您的 GitHub 用户名或组织名',
+  'github.config.repositoryPlaceholder': '用于存储图片的仓库名称',
+  'github.config.branchPlaceholder': '通常为 main 或 master',
+  'github.config.pathPlaceholder': '仓库中存储图片的文件夹路径',
+  'github.config.tokenPlaceholder': 'ghp_xxxxxxxxxxxxxxxxxxxx',
+  'github.config.tokenDescription': '需要 repo 权限的 Personal Access Token',
+  'github.help.title': '配置帮助',
+  'messages.configSaved': 'GitHub 配置已成功保存！',
+  'messages.configCleared': 'GitHub 配置已成功清除！',
+  'messages.configExported': 'GitHub 配置已成功导出！',
+  'messages.configImported': 'GitHub 配置已成功导入！',
+};
+
+export const giteeConfigModalTranslations: Record<string, string> = {
+  ...commonConfigModalMessages,
+  'gitee.config.title': 'Gitee 配置',
+  'gitee.config.username': '用户名/组织名',
+  'gitee.config.repository': '仓库名',
+  'gitee.config.branch': '分支',
+  'gitee.config.path': '路径',
+  'gitee.config.token': '个人访问令牌',
+  'gitee.config.import': '导入',
+  'gitee.config.export': '导出',
+  'gitee.config.clearConfig': '清除配置',
+  'gitee.config.saveConfig': '保存配置',
+  'gitee.config.close': '关闭',
+  'gitee.config.required': '*',
+  'gitee.config.usernamePlaceholder': '请输入 Gitee 用户名或组织名',
+  'gitee.config.repositoryPlaceholder': '请输入仓库名',
+  'gitee.config.branchPlaceholder': 'master',
+  'gitee.config.pathPlaceholder': 'images',
+  'gitee.config.tokenPlaceholder': '请输入 Gitee 个人访问令牌',
+  'gitee.config.tokenDescription': 'Token 用于访问 Gitee API，请妥善保管。',
+  'gitee.help.title': '帮助信息',
+  'messages.configSaved': 'Gitee 配置已成功保存！',
+  'messages.configCleared': 'Gitee 配置已成功清除！',
+  'messages.configExported': 'Gitee 配置已成功导出！',
+  'messages.configImported': 'Gitee 配置已成功导入！',
+  'messages.unknownError': '未知错误',
+  'messages.fileFormatError': '文件格式错误',
+};
+
+export function makeModalTranslate(translations: Record<string, string>) {
+  return (key: string) => translations[key] || key;
+}
+
+export function createConfigModalDefaultProps() {
+  return {
+    isOpen: true,
+    onClose: vi.fn(),
+    onSaveConfig: vi.fn(),
+    onClearConfig: vi.fn(),
+  };
+}
+
+export function resetModalBodyOverflow() {
+  document.body.style.overflow = '';
+}

--- a/app/src/features/settings/gitee-config/GiteeConfigModal.test.tsx
+++ b/app/src/features/settings/gitee-config/GiteeConfigModal.test.tsx
@@ -3,54 +3,25 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import GiteeConfigModal from './GiteeConfigModal';
 import type { GiteeConfig } from '@pixuli/core/types';
+import {
+  createConfigModalDefaultProps,
+  resetModalBodyOverflow,
+} from '../__tests__/modalTestFixtures';
 
-// Mock toast utilities
 vi.mock('@/ui/feedback/toast', () => ({
   showSuccess: vi.fn(),
   showError: vi.fn(),
 }));
 
-// Mock defaultTranslate
-vi.mock('@/i18n/locales', () => ({
-  defaultTranslate: (key: string) => {
-    const translations: Record<string, string> = {
-      'gitee.config.title': 'Gitee 配置',
-      'gitee.config.username': '用户名/组织名',
-      'gitee.config.repository': '仓库名',
-      'gitee.config.branch': '分支',
-      'gitee.config.path': '路径',
-      'gitee.config.token': '个人访问令牌',
-      'gitee.config.import': '导入',
-      'gitee.config.export': '导出',
-      'gitee.config.clearConfig': '清除配置',
-      'gitee.config.saveConfig': '保存配置',
-      'gitee.config.close': '关闭',
-      'gitee.config.required': '*',
-      'gitee.config.usernamePlaceholder': '请输入 Gitee 用户名或组织名',
-      'gitee.config.repositoryPlaceholder': '请输入仓库名',
-      'gitee.config.branchPlaceholder': 'master',
-      'gitee.config.pathPlaceholder': 'images',
-      'gitee.config.tokenPlaceholder': '请输入 Gitee 个人访问令牌',
-      'gitee.config.tokenDescription': 'Token 用于访问 Gitee API，请妥善保管。',
-      'gitee.help.title': '帮助信息',
-      'storage.configuration': '配置',
-      'common.cancel': '取消',
-      'messages.configSaved': 'Gitee 配置已成功保存！',
-      'messages.configCleared': 'Gitee 配置已成功清除！',
-      'messages.configExported': 'Gitee 配置已成功导出！',
-      'messages.configImported': 'Gitee 配置已成功导入！',
-      'messages.saveFailed': '保存配置失败',
-      'messages.clearFailed': '清除配置失败',
-      'messages.exportFailed': '导出配置失败',
-      'messages.importFailed': '导入配置失败',
-      'messages.invalidFormat': '配置文件格式不正确',
-      'messages.noConfigToExport': '没有可导出的配置',
-      'messages.unknownError': '未知错误',
-      'messages.fileFormatError': '文件格式错误',
-    };
-    return translations[key] || key;
-  },
-}));
+vi.mock('@/i18n/locales', async importOriginal => {
+  const { giteeConfigModalTranslations, makeModalTranslate } = await import(
+    '../__tests__/modalTestFixtures'
+  );
+  return {
+    ...((await importOriginal()) as object),
+    defaultTranslate: makeModalTranslate(giteeConfigModalTranslations),
+  };
+});
 
 describe('GiteeConfigModal', () => {
   const mockGiteeConfig: GiteeConfig = {
@@ -61,23 +32,15 @@ describe('GiteeConfigModal', () => {
     path: 'images',
   };
 
-  const defaultProps = {
-    isOpen: true,
-    onClose: vi.fn(),
-    onSaveConfig: vi.fn(),
-    onClearConfig: vi.fn(),
-  };
+  const defaultProps = createConfigModalDefaultProps();
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // 重置 document.body.style
-    document.body.style.overflow = '';
+    resetModalBodyOverflow();
   });
 
   afterEach(() => {
-    // 清理事件监听器
-    document.removeEventListener('keydown', vi.fn());
-    document.body.style.overflow = '';
+    resetModalBodyOverflow();
   });
 
   describe('渲染', () => {

--- a/app/src/features/settings/github-config/GitHubConfigModal.test.tsx
+++ b/app/src/features/settings/github-config/GitHubConfigModal.test.tsx
@@ -3,6 +3,10 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import GitHubConfigModal from './GitHubConfigModal';
 import type { GitHubConfig } from '@pixuli/core/types';
+import {
+  createConfigModalDefaultProps,
+  resetModalBodyOverflow,
+} from '../__tests__/modalTestFixtures';
 
 // Mock toast utilities
 vi.mock('@/ui/feedback/toast', () => ({
@@ -10,44 +14,15 @@ vi.mock('@/ui/feedback/toast', () => ({
   showError: vi.fn(),
 }));
 
-// Mock defaultTranslate
-vi.mock('@/i18n/locales', () => ({
-  defaultTranslate: (key: string) => {
-    const translations: Record<string, string> = {
-      'github.config.title': 'GitHub 仓库配置',
-      'github.config.username': 'GitHub 用户名',
-      'github.config.repository': '仓库名称',
-      'github.config.branch': '分支名称',
-      'github.config.path': '图片存储路径',
-      'github.config.token': 'GitHub Token',
-      'github.config.import': '↑ 导入',
-      'github.config.export': '导出',
-      'github.config.clearConfig': '清除配置',
-      'github.config.saveConfig': '保存配置',
-      'github.config.usernamePlaceholder': '您的 GitHub 用户名或组织名',
-      'github.config.repositoryPlaceholder': '用于存储图片的仓库名称',
-      'github.config.branchPlaceholder': '通常为 main 或 master',
-      'github.config.pathPlaceholder': '仓库中存储图片的文件夹路径',
-      'github.config.tokenPlaceholder': 'ghp_xxxxxxxxxxxxxxxxxxxx',
-      'github.config.tokenDescription':
-        '需要 repo 权限的 Personal Access Token',
-      'github.help.title': '配置帮助',
-      'storage.configuration': '配置',
-      'common.cancel': '取消',
-      'messages.configSaved': 'GitHub 配置已成功保存！',
-      'messages.configCleared': 'GitHub 配置已成功清除！',
-      'messages.configExported': 'GitHub 配置已成功导出！',
-      'messages.configImported': 'GitHub 配置已成功导入！',
-      'messages.saveFailed': '保存配置失败',
-      'messages.clearFailed': '清除配置失败',
-      'messages.exportFailed': '导出配置失败',
-      'messages.importFailed': '导入配置失败',
-      'messages.invalidFormat': '配置文件格式不正确',
-      'messages.noConfigToExport': '没有可导出的配置',
-    };
-    return translations[key] || key;
-  },
-}));
+vi.mock('@/i18n/locales', async importOriginal => {
+  const { githubConfigModalTranslations, makeModalTranslate } = await import(
+    '../__tests__/modalTestFixtures'
+  );
+  return {
+    ...((await importOriginal()) as object),
+    defaultTranslate: makeModalTranslate(githubConfigModalTranslations),
+  };
+});
 
 describe('GitHubConfigModal', () => {
   const mockGitHubConfig: GitHubConfig = {
@@ -58,23 +33,15 @@ describe('GitHubConfigModal', () => {
     path: 'images',
   };
 
-  const defaultProps = {
-    isOpen: true,
-    onClose: vi.fn(),
-    onSaveConfig: vi.fn(),
-    onClearConfig: vi.fn(),
-  };
+  const defaultProps = createConfigModalDefaultProps();
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // 重置 document.body.style
-    document.body.style.overflow = '';
+    resetModalBodyOverflow();
   });
 
   afterEach(() => {
-    // 清理事件监听器
-    document.removeEventListener('keydown', vi.fn());
-    document.body.style.overflow = '';
+    resetModalBodyOverflow();
   });
 
   describe('渲染', () => {

--- a/app/src/features/settings/sidebar/SidebarSourceSection.tsx
+++ b/app/src/features/settings/sidebar/SidebarSourceSection.tsx
@@ -1,7 +1,7 @@
 import { Github, Plus } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import { SidebarSourceContextMenu } from '@/layouts/sidebar/SidebarSourceContextMenu';
-import type { SidebarSource } from '@/layouts/sidebar/types';
+import type { SidebarSource } from '@/features/settings/sidebarSourceTypes';
 
 export interface SidebarSourceSectionProps {
   sources: SidebarSource[];

--- a/app/src/features/settings/sidebarSourceTypes.ts
+++ b/app/src/features/settings/sidebarSourceTypes.ts
@@ -11,3 +11,6 @@ export type SidebarSourceItem = {
   active: boolean;
   available: boolean;
 };
+
+/** 与 `SidebarSourceItem` 同型；layouts 侧栏 props 沿用此别名 */
+export type SidebarSource = SidebarSourceItem;

--- a/app/src/features/settings/syncSourceRepoToImageStore.ts
+++ b/app/src/features/settings/syncSourceRepoToImageStore.ts
@@ -4,30 +4,31 @@ import {
   type StoredSourceEntry,
 } from '@pixuli/core/sources';
 import type { GiteeConfig, GitHubConfig } from '@pixuli/core/types';
-import { useImageStore } from '@/features/library/imageStore';
+import { getSourceSelectionPort } from '@/features/library/sourceSelectionPort';
 
 export type RepoConfigFields = Pick<
   GitHubConfig,
   'owner' | 'repo' | 'branch' | 'token' | 'path'
 >;
 
-/** 将仓库连接字段写入 imageStore（GitHub/Gitee 双轨 legacy 配置） */
+/** 将仓库连接字段写入资源库（GitHub/Gitee 双轨 legacy 配置） */
 export function syncRepoConfigToImageStore(
   pluginId: string,
   repoConfig: RepoConfigFields,
 ): void {
   const legacyType = pluginIdToLegacyType(pluginId);
-  const { setGitHubConfig, setGiteeConfig } = useImageStore.getState();
+  const port = getSourceSelectionPort();
   if (legacyType === 'github') {
-    setGitHubConfig(repoConfig as GitHubConfig);
+    port.setGitHubConfig(repoConfig as GitHubConfig);
   } else {
-    setGiteeConfig(repoConfig as GiteeConfig);
+    port.setGiteeConfig(repoConfig as GiteeConfig);
   }
 }
 
 /** 选中/编辑源时同步 storageType 与仓库配置 */
 export function syncSourceEntryToImageStore(source: StoredSourceEntry): void {
   const legacyType = pluginIdToLegacyType(source.pluginId);
-  useImageStore.setState({ storageType: legacyType });
+  const port = getSourceSelectionPort();
+  port.setStorageType(legacyType);
   syncRepoConfigToImageStore(source.pluginId, getRepoConfigFromSource(source));
 }

--- a/app/src/features/settings/useConfigManagement.ts
+++ b/app/src/features/settings/useConfigManagement.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useImageStore } from '@/features/library/imageStore';
+import { useSourceSelection } from '@/features/library/useSourceSelection';
 import { useSourceStore } from '@/features/settings/sourceStore';
 import { useUIStore } from '@/stores/uiStore';
 
@@ -14,7 +14,7 @@ export function useConfigManagement() {
     clearGitHubConfig,
     clearGiteeConfig,
     loadImages,
-  } = useImageStore();
+  } = useSourceSelection();
   const { addSource, updateSource, removeSource, setSelectedSourceId } =
     useSourceStore();
 
@@ -73,7 +73,7 @@ export function useConfigManagement() {
       }
 
       setTimeout(() => {
-        loadImages();
+        void loadImages();
       }, 100);
     },
     [

--- a/app/src/features/settings/useSelectedSourceSync.ts
+++ b/app/src/features/settings/useSelectedSourceSync.ts
@@ -3,17 +3,18 @@ import {
   type StoredSourceEntry,
 } from '@pixuli/core/sources';
 import { useEffect, useRef } from 'react';
-import { useImageStore } from '@/features/library/imageStore';
+import { getSourceSelectionPort } from '@/features/library/sourceSelectionPort';
+import { useSourceSelection } from '@/features/library/useSourceSelection';
 import { useUIStore } from '@/stores/uiStore';
 
 /**
- * 同步选中源到 store 的配置
+ * 同步选中源到资源库配置
  */
 export function useSelectedSourceSync(
   selectedSource: StoredSourceEntry | null,
   onConfigSynced?: () => void,
 ) {
-  const { setGitHubConfig, setGiteeConfig } = useImageStore();
+  const { setGitHubConfig, setGiteeConfig } = useSourceSelection();
   const lastSyncedSourceIdRef = useRef<string | null>(null);
   const isInitialMountRef = useRef(true);
 
@@ -33,12 +34,13 @@ export function useSelectedSourceSync(
       }
 
       const sourceConfig = getRepoConfigFromSource(selectedSource);
+      const port = getSourceSelectionPort();
       if (selectedSource.pluginId === 'github') {
         setGitHubConfig(sourceConfig);
-        useImageStore.setState({ storageType: 'github' });
+        port.setStorageType('github');
       } else {
         setGiteeConfig(sourceConfig);
-        useImageStore.setState({ storageType: 'gitee' });
+        port.setStorageType('gitee');
       }
 
       lastSyncedSourceIdRef.current = selectedSource.id;
@@ -46,11 +48,7 @@ export function useSelectedSourceSync(
 
       if (onConfigSynced) {
         setTimeout(() => {
-          const { storageProvider, initializeStorage } =
-            useImageStore.getState();
-          if (!storageProvider) {
-            initializeStorage();
-          }
+          port.initializeStorageIfNeeded();
           onConfigSynced();
         }, 100);
       }

--- a/app/src/features/settings/useSourceManagement.ts
+++ b/app/src/features/settings/useSourceManagement.ts
@@ -5,7 +5,7 @@ import {
 import type { SidebarSourceItem } from '@/features/settings/sidebarSourceTypes';
 import { useCallback, useMemo } from 'react';
 import { isStoragePluginRegistered } from '@/storage/registry';
-import { useImageStore } from '@/features/library/imageStore';
+import { useSourceSelection } from '@/features/library/useSourceSelection';
 import { useSourceStore } from '@/features/settings/sourceStore';
 import { syncSourceEntryToImageStore } from '@/features/settings/syncSourceRepoToImageStore';
 
@@ -13,7 +13,7 @@ import { syncSourceEntryToImageStore } from '@/features/settings/syncSourceRepoT
  * 源管理相关的 hooks
  */
 export function useSourceManagement() {
-  const { loadImages } = useImageStore();
+  const { loadImages } = useSourceSelection();
   const { sources, selectedSourceId, setSelectedSourceId, removeSource } =
     useSourceStore();
 
@@ -75,7 +75,7 @@ export function useSourceManagement() {
       }
       setSelectedSourceId(id);
       syncSourceEntryToImageStore(source);
-      loadImages();
+      void loadImages();
     },
     [sources, setSelectedSourceId, loadImages],
   );

--- a/app/src/features/tools/registerUtilityToolPort.ts
+++ b/app/src/features/tools/registerUtilityToolPort.ts
@@ -1,0 +1,13 @@
+import { useUIStore } from '@/stores/uiStore';
+import { registerUtilityToolPort } from '@/features/tools/utilityToolPort';
+
+registerUtilityToolPort({
+  openUtilityTool(tool) {
+    useUIStore.getState().setCurrentUtilityTool(tool);
+    useUIStore.getState().setCurrentView('library');
+    useUIStore.getState().setActiveMenu(tool);
+  },
+  getCurrentTool() {
+    return useUIStore.getState().currentUtilityTool;
+  },
+});

--- a/app/src/features/tools/utilityToolPort.ts
+++ b/app/src/features/tools/utilityToolPort.ts
@@ -1,0 +1,30 @@
+export type UtilityToolId = 'compress' | 'convert';
+
+/** inspector / library / 侧栏 → tools overlay：打开增强工具（避免跨域直接写 uiStore） */
+export interface UtilityToolPort {
+  openUtilityTool(tool: UtilityToolId): void;
+  getCurrentTool(): UtilityToolId | null;
+}
+
+const inactivePort: UtilityToolPort = {
+  openUtilityTool: () => undefined,
+  getCurrentTool: () => null,
+};
+
+let utilityToolPort: UtilityToolPort | null = null;
+
+export function registerUtilityToolPort(port: UtilityToolPort): void {
+  utilityToolPort = port;
+}
+
+export function getUtilityToolPort(): UtilityToolPort {
+  return utilityToolPort ?? inactivePort;
+}
+
+export function openUtilityTool(tool: UtilityToolId): void {
+  getUtilityToolPort().openUtilityTool(tool);
+}
+
+export function getCurrentUtilityTool(): UtilityToolId | null {
+  return getUtilityToolPort().getCurrentTool();
+}

--- a/app/src/hooks/README.md
+++ b/app/src/hooks/README.md
@@ -1,0 +1,21 @@
+# 壳层 Hooks（`app/src/hooks`）
+
+编排级 hooks：应用 init、路由同步、键盘快捷键、面板尺寸等。**不含**业务域逻辑（域逻辑在
+`features/`）。
+
+## 键盘快捷键分工
+
+| 层            | 路径                             | 职责                                                   |
+| ------------- | -------------------------------- | ------------------------------------------------------ |
+| **引擎 SSOT** | `ui/utils/keyboardShortcuts.ts`  | `KeyboardShortcutManager`、`keyboardManager` 注册/分发 |
+| **壳层编排**  | `hooks/keyboardShortcuts.ts`     | `createKeyboardShortcuts(t)`，CustomEvent 映射         |
+| **壳层注册**  | `hooks/useKeyboardShortcuts.ts`  | 启动时将快捷键挂到 `keyboardManager`                   |
+| **设置展示**  | `hooks/useKeyboardCategories.ts` | 设置页快捷键分类数据                                   |
+| **组件级**    | `ui/hooks/useKeyboard.ts`        | `useKeyboard` / `useEscapeKey` primitive               |
+| **域内**      | 如 `AssetLibrary.tsx`            | 必要时 `keyboardManager.registerBatch`                 |
+
+**约定**：新增全局快捷键优先走 `hooks/useKeyboardShortcuts` +
+`keyboardShortcuts.ts`；Modal 内 Esc 用
+`useEscapeKey`；feature 内局部快捷键在域内注册并注明冲突。
+
+文案 SSOT：`i18n/locales/*/keyboard.json`。

--- a/app/src/layouts/AppSidebar.tsx
+++ b/app/src/layouts/AppSidebar.tsx
@@ -9,10 +9,11 @@ import type { SidebarSourceItem } from '@/features/settings/sidebarSourceTypes';
 import { useMobileViewport } from '@/hooks/useMobileViewport';
 import { ROUTES } from '@/router/routes';
 import { useSourceStore } from '@/features/settings/sourceStore';
-import { useUIStore } from '@/stores/uiStore';
-import { useWorkspaceStore } from '@/features/workspace/workspaceStore';
+import { openUtilityTool } from '@/features/tools/utilityToolPort';
 import { UTILITY_TOOLS_ENABLED } from '@/features/tools/utilityToolsConfig';
 import { isWorkspaceAvailable } from '@/platforms/workspacePlatform';
+import { useUIStore } from '@/stores/uiStore';
+import { useWorkspaceStore } from '@/features/workspace/workspaceStore';
 
 interface SidebarProps {
   sidebarSources: SidebarSourceItem[];
@@ -105,9 +106,7 @@ export const AppSidebar: React.FC<SidebarProps> = ({
       setActiveMenu('workspace');
       navigate(ROUTES.WORKSPACE);
     } else if (menuItem.type === 'utility') {
-      setCurrentUtilityTool(menuItem.tool);
-      setCurrentView('library');
-      setActiveMenu(menuItem.tool);
+      openUtilityTool(menuItem.tool);
       navigate(ROUTES.LIBRARY);
     }
     closeDrawerIfMobile();

--- a/app/src/layouts/MainLayout.tsx
+++ b/app/src/layouts/MainLayout.tsx
@@ -4,37 +4,19 @@
  */
 
 import type { AppMainLayoutProps } from '@/hooks/useAppOrchestration';
-import { FullScreenLoading, Toaster } from '@/ui';
 import type { VersionInfo } from '@/features/settings/version-info';
-import { resolveSourceDisplay } from '@pixuli/core/sources';
-import type { GiteeConfig, GitHubConfig } from '@pixuli/core/types';
-import React, { useMemo } from 'react';
-import {
-  GiteeConfigModal,
-  GitHubConfigModal,
-  SettingsModal,
-} from '@/features/settings';
-import { PublishDrawer } from '@/features/access/PublishDrawer';
-import { SyncDirectionModal, WorkspaceModal } from '@/features/workspace';
+import React from 'react';
 import { useRouteSync } from '@/hooks/useRouteSync';
 import { useI18n } from '@/i18n/useI18n';
-import { useImageStore } from '@/features/library/imageStore';
-import { useSourceStore } from '@/features/settings/sourceStore';
-import { useUIStore } from '@/stores/uiStore';
+import { useSourceSelection } from '@/features/library/useSourceSelection';
 import { useWorkspaceStore } from '@/features/workspace/workspaceStore';
 import { isWorkspaceAvailable } from '@/platforms/workspacePlatform';
-import { exportJsonFile } from '@/features/settings/exportJsonFile';
-import { getPlatform, WebBrowserChrome } from '@/platforms';
-import {
-  configFieldsKey,
-  resolveModalRepoConfig,
-} from '@/features/settings/resolveModalRepoConfig';
+import { MainLayoutModals } from './MainLayoutModals';
 import { AppMain } from './AppMain';
 import { AppSidebar } from './AppSidebar';
 import { WorkspaceShell } from './WorkspaceShell';
 import { WorkspaceWelcomeScreen } from './WorkspaceWelcomeScreen';
 
-// 声明构建时注入的全局变量
 declare const __VERSION_INFO__: VersionInfo;
 
 interface MainLayoutProps extends AppMainLayoutProps {
@@ -54,7 +36,7 @@ export const MainLayout: React.FC<MainLayoutProps> = ({
   onClearConfig,
 }) => {
   const { t } = useI18n();
-  const { loading, storageType, githubConfig, giteeConfig } = useImageStore();
+  const { loading } = useSourceSelection();
   const workspaceMode = useWorkspaceStore(state => state.mode);
   const workspaceLoading = useWorkspaceStore(state => state.loading);
   const needsWorkspaceSetup = useWorkspaceStore(
@@ -63,120 +45,16 @@ export const MainLayout: React.FC<MainLayoutProps> = ({
   const localActive = isWorkspaceAvailable() && workspaceMode === 'local';
   const workspacePlatform = isWorkspaceAvailable();
   const showGlobalLoading = localActive ? workspaceLoading : loading;
-  const sources = useSourceStore(state => state.sources);
-  const platform = getPlatform();
 
   useRouteSync();
 
-  const {
-    showConfigModal,
-    showSettingsModal,
-    showWorkspaceModal,
-    editingSourceId,
-    editingSourcePluginId,
-    editingSourceRepoConfig,
-    closeConfigModal,
-    closeSettingsModal,
-    closeWorkspaceModal,
-  } = useUIStore();
-
-  const editingSource = useMemo(
-    () =>
-      editingSourceId
-        ? (sources.find(s => s.id === editingSourceId) ?? null)
-        : null,
-    [sources, editingSourceId],
-  );
-
-  const configModalStorageType =
-    editingSourceId && editingSourcePluginId
-      ? resolveSourceDisplay(editingSourcePluginId).legacyType
-      : editingSource
-        ? resolveSourceDisplay(editingSource.pluginId).legacyType
-        : storageType;
-
-  const modalResolveOptions = {
-    editingSourceId,
-    editingSourcePluginId,
-    editingSourceRepoConfig,
-    editingSource,
-    fallbackGithub: githubConfig,
-    fallbackGitee: giteeConfig,
-  };
-
-  const modalGitHubConfig = resolveModalRepoConfig(
-    'github',
-    modalResolveOptions,
-  ) as GitHubConfig | null;
-
-  const modalGiteeConfig = resolveModalRepoConfig(
-    'gitee',
-    modalResolveOptions,
-  ) as GiteeConfig | null;
-
-  const modalGitHubConfigKey = configFieldsKey(modalGitHubConfig);
-  const modalGiteeConfigKey = configFieldsKey(modalGiteeConfig);
-
   const modals = (
-    <>
-      <GitHubConfigModal
-        key={
-          editingSourceId
-            ? `github-edit-${editingSourceId}-${modalGitHubConfigKey}`
-            : `github-new-${storageType ?? 'none'}`
-        }
-        isOpen={showConfigModal && configModalStorageType !== 'gitee'}
-        onClose={closeConfigModal}
-        githubConfig={modalGitHubConfig}
-        onSaveConfig={onSaveConfig}
-        onClearConfig={onClearConfig}
-        platform={platform}
-        exportJsonFile={exportJsonFile}
-        t={t}
-      />
-
-      <GiteeConfigModal
-        key={
-          editingSourceId
-            ? `gitee-edit-${editingSourceId}-${modalGiteeConfigKey}`
-            : `gitee-new-${storageType ?? 'none'}`
-        }
-        isOpen={showConfigModal && configModalStorageType === 'gitee'}
-        onClose={closeConfigModal}
-        giteeConfig={modalGiteeConfig}
-        onSaveConfig={onSaveConfig}
-        onClearConfig={onClearConfig}
-        platform={platform}
-        exportJsonFile={exportJsonFile}
-        t={t}
-      />
-
-      <SettingsModal
-        isOpen={showSettingsModal}
-        onClose={closeSettingsModal}
-        t={t}
-        versionInfo={__VERSION_INFO__}
-      />
-
-      <PublishDrawer />
-
-      <WorkspaceModal
-        isOpen={showWorkspaceModal}
-        onClose={closeWorkspaceModal}
-        t={t}
-      />
-
-      <SyncDirectionModal />
-
-      <Toaster />
-
-      <FullScreenLoading
-        visible={showGlobalLoading}
-        text={showGlobalLoading ? t('app.loadingResources') : undefined}
-      />
-
-      <WebBrowserChrome />
-    </>
+    <MainLayoutModals
+      showGlobalLoading={showGlobalLoading}
+      onSaveConfig={onSaveConfig}
+      onClearConfig={onClearConfig}
+      versionInfo={__VERSION_INFO__}
+    />
   );
 
   if (workspacePlatform && needsWorkspaceSetup() && !workspaceLoading) {

--- a/app/src/layouts/MainLayoutModals.tsx
+++ b/app/src/layouts/MainLayoutModals.tsx
@@ -1,0 +1,197 @@
+import type { VersionInfo } from '@/features/settings/version-info';
+import { resolveSourceDisplay } from '@pixuli/core/sources';
+import type { GiteeConfig, GitHubConfig } from '@pixuli/core/types';
+import React, { Suspense, lazy, useMemo } from 'react';
+import { FullScreenLoading, Toaster } from '@/ui';
+import { useI18n } from '@/i18n/useI18n';
+import { useSourceStore } from '@/features/settings/sourceStore';
+import { useUIStore } from '@/stores/uiStore';
+import { getPlatform, WebBrowserChrome } from '@/platforms';
+import { exportJsonFile } from '@/features/settings/exportJsonFile';
+import {
+  configFieldsKey,
+  resolveModalRepoConfig,
+} from '@/features/settings/resolveModalRepoConfig';
+import { useSourceSelection } from '@/features/library/useSourceSelection';
+
+const GitHubConfigModal = lazy(() =>
+  import('@/features/settings/github-config/GitHubConfigModal').then(m => ({
+    default: m.default,
+  })),
+);
+const GiteeConfigModal = lazy(() =>
+  import('@/features/settings/gitee-config/GiteeConfigModal').then(m => ({
+    default: m.default,
+  })),
+);
+const SettingsModal = lazy(() =>
+  import('@/features/settings/SettingsModal').then(m => ({
+    default: m.SettingsModal,
+  })),
+);
+const PublishDrawer = lazy(() =>
+  import('@/features/access/PublishDrawer').then(m => ({
+    default: m.PublishDrawer,
+  })),
+);
+const WorkspaceModal = lazy(() =>
+  import('@/features/workspace/WorkspaceModal').then(m => ({
+    default: m.WorkspaceModal,
+  })),
+);
+const SyncDirectionModal = lazy(() =>
+  import('@/features/workspace/SyncDirectionModal').then(m => ({
+    default: m.SyncDirectionModal,
+  })),
+);
+
+interface MainLayoutModalsProps {
+  showGlobalLoading: boolean;
+  onSaveConfig: AppMainLayoutModalsConfigProps['onSaveConfig'];
+  onClearConfig: AppMainLayoutModalsConfigProps['onClearConfig'];
+  versionInfo: VersionInfo;
+}
+
+interface AppMainLayoutModalsConfigProps {
+  onSaveConfig: (
+    config: {
+      owner: string;
+      repo: string;
+      branch: string;
+      token: string;
+      path: string;
+      name?: string;
+    },
+    editingSourceId: string | null,
+  ) => void;
+  onClearConfig: (editingSourceId: string | null) => void;
+}
+
+const ModalFallback = () => null;
+
+export const MainLayoutModals: React.FC<MainLayoutModalsProps> = ({
+  showGlobalLoading,
+  onSaveConfig,
+  onClearConfig,
+  versionInfo,
+}) => {
+  const { t } = useI18n();
+  const { storageType, githubConfig, giteeConfig } = useSourceSelection();
+  const sources = useSourceStore(state => state.sources);
+  const platform = getPlatform();
+
+  const {
+    showConfigModal,
+    showSettingsModal,
+    showWorkspaceModal,
+    editingSourceId,
+    editingSourcePluginId,
+    editingSourceRepoConfig,
+    closeConfigModal,
+    closeSettingsModal,
+    closeWorkspaceModal,
+  } = useUIStore();
+
+  const editingSource = useMemo(
+    () =>
+      editingSourceId
+        ? (sources.find(s => s.id === editingSourceId) ?? null)
+        : null,
+    [sources, editingSourceId],
+  );
+
+  const configModalStorageType =
+    editingSourceId && editingSourcePluginId
+      ? resolveSourceDisplay(editingSourcePluginId).legacyType
+      : editingSource
+        ? resolveSourceDisplay(editingSource.pluginId).legacyType
+        : storageType;
+
+  const modalResolveOptions = {
+    editingSourceId,
+    editingSourcePluginId,
+    editingSourceRepoConfig,
+    editingSource,
+    fallbackGithub: githubConfig,
+    fallbackGitee: giteeConfig,
+  };
+
+  const modalGitHubConfig = resolveModalRepoConfig(
+    'github',
+    modalResolveOptions,
+  ) as GitHubConfig | null;
+
+  const modalGiteeConfig = resolveModalRepoConfig(
+    'gitee',
+    modalResolveOptions,
+  ) as GiteeConfig | null;
+
+  const modalGitHubConfigKey = configFieldsKey(modalGitHubConfig);
+  const modalGiteeConfigKey = configFieldsKey(modalGiteeConfig);
+
+  return (
+    <>
+      <Suspense fallback={<ModalFallback />}>
+        <GitHubConfigModal
+          key={
+            editingSourceId
+              ? `github-edit-${editingSourceId}-${modalGitHubConfigKey}`
+              : `github-new-${storageType ?? 'none'}`
+          }
+          isOpen={showConfigModal && configModalStorageType !== 'gitee'}
+          onClose={closeConfigModal}
+          githubConfig={modalGitHubConfig}
+          onSaveConfig={onSaveConfig}
+          onClearConfig={onClearConfig}
+          platform={platform}
+          exportJsonFile={exportJsonFile}
+          t={t}
+        />
+
+        <GiteeConfigModal
+          key={
+            editingSourceId
+              ? `gitee-edit-${editingSourceId}-${modalGiteeConfigKey}`
+              : `gitee-new-${storageType ?? 'none'}`
+          }
+          isOpen={showConfigModal && configModalStorageType === 'gitee'}
+          onClose={closeConfigModal}
+          giteeConfig={modalGiteeConfig}
+          onSaveConfig={onSaveConfig}
+          onClearConfig={onClearConfig}
+          platform={platform}
+          exportJsonFile={exportJsonFile}
+          t={t}
+        />
+
+        <SettingsModal
+          isOpen={showSettingsModal}
+          onClose={closeSettingsModal}
+          t={t}
+          versionInfo={versionInfo}
+        />
+
+        <PublishDrawer />
+
+        <WorkspaceModal
+          isOpen={showWorkspaceModal}
+          onClose={closeWorkspaceModal}
+          t={t}
+        />
+
+        <SyncDirectionModal />
+      </Suspense>
+
+      <Toaster />
+
+      <FullScreenLoading
+        visible={showGlobalLoading}
+        text={showGlobalLoading ? t('app.loadingResources') : undefined}
+      />
+
+      <WebBrowserChrome />
+    </>
+  );
+};
+
+export type { AppMainLayoutModalsConfigProps };

--- a/app/src/layouts/sidebar/types.ts
+++ b/app/src/layouts/sidebar/types.ts
@@ -1,4 +1,5 @@
 import type React from 'react';
+import type { SidebarSource } from '@/features/settings/sidebarSourceTypes';
 
 export type SidebarView = 'library' | 'explore' | 'tags' | 'favorites';
 
@@ -9,17 +10,6 @@ export type SidebarMenuItem =
   | { type: 'library' }
   | { type: 'workspace' }
   | { type: 'utility'; tool: SidebarUtilityTool };
-
-export interface SidebarSource {
-  id: string;
-  name: string;
-  type: 'github' | 'gitee';
-  owner: string;
-  repo: string;
-  path: string;
-  active?: boolean;
-  available?: boolean;
-}
 
 export interface SidebarProps {
   onMenuClick?: (menuItem: SidebarMenuItem) => void;

--- a/app/src/router/routes.tsx
+++ b/app/src/router/routes.tsx
@@ -2,9 +2,9 @@ import React, { Suspense, lazy } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { WorkspaceRouteRedirect } from './WorkspaceRouteRedirect';
 
-const LibraryPage = lazy(() =>
-  import('@/features/library/LibraryPage').then(module => ({
-    default: module.LibraryPage,
+const LibraryRoute = lazy(() =>
+  import('@/features/library/LibraryRoute').then(module => ({
+    default: module.LibraryRoute,
   })),
 );
 
@@ -36,7 +36,7 @@ const RouteSuspense = ({ children }: { children: React.ReactNode }) => (
 export const AppRoutes: React.FC<AppRoutesProps> = ({ onOpenConfigModal }) => {
   const libraryElement = (
     <RouteSuspense>
-      <LibraryPage onOpenConfigModal={onOpenConfigModal} />
+      <LibraryRoute onOpenConfigModal={onOpenConfigModal} />
     </RouteSuspense>
   );
 


### PR DESCRIPTION
## Summary

- **S13 契约层**：新增 `sourceSelectionPort` / `useSourceSelection`（settings ↔ library 源配置同步）、`utilityToolPort`（library/侧栏 → tools overlay）；`SidebarSource` 类型 SSOT 归位 `sidebarSourceTypes`
- **S14 壳层**：`MainLayoutModals` lazy 注册 6 个 Modal/Drawer，`MainLayout` 瘦身；`LibraryPage` → `LibraryRoute`；更新 `app/README.md` / `src/README.md`，新增 `hooks/README.md`
- **S15 质量债**：抽取 `modalTestFixtures` 供 GitHub/Gitee ConfigModal 测试复用；文档补充 `constants/`、`types/` 放置说明

## Test plan

- [x] `pnpm test`（565/565）
- [ ] 手动：切换 GitHub/Gitee 源、保存配置后资源库正常加载
- [ ] 手动：侧栏/检查器打开压缩/转换 overlay
- [ ] 手动：配置 Modal、设置 Modal、工作区 Modal 正常 lazy 打开


Made with [Cursor](https://cursor.com)