### PR TITLE
fix(sync): preserve display name after sync round-trip

### DIFF
--- a/packages/core/src/vault/__tests__/syncApply.test.ts
+++ b/packages/core/src/vault/__tests__/syncApply.test.ts
@@ -5,6 +5,7 @@ import {
   applySyncPull,
   buildSyncPushItems,
   resolveLocalPathForPull,
+  resolvePullDisplayName,
   resolveRemotePathForPush,
 } from '../syncApply';
 import { isSyncExcludedPath } from '../syncPath';
@@ -260,5 +261,115 @@ describe('syncApply (configRoot 1:1)', () => {
       true,
     );
     expect(await adapter.exists('111/Omnivuli.png')).toBe(true);
+  });
+
+  it('resolvePullDisplayName keeps local display name when remote only has basename', () => {
+    const remotePath = 'images/1788164287239-photo.jpg';
+    expect(
+      resolvePullDisplayName(
+        { name: '1788164287239-photo.jpg' },
+        { name: 'Vacation Photo' } as never,
+        remotePath,
+      ),
+    ).toBe('Vacation Photo');
+  });
+
+  it('resolvePullDisplayName prefers remote manifest display name', () => {
+    const remotePath = 'images/1788164287239-photo.jpg';
+    expect(
+      resolvePullDisplayName(
+        { name: 'Vacation Photo' },
+        { name: 'Old Name' } as never,
+        remotePath,
+      ),
+    ).toBe('Vacation Photo');
+  });
+
+  it('pull preserves local display name when remote metadata falls back to basename', async () => {
+    const adapter = new MemoryWorkspaceAdapter('desktop');
+    await adapter.pickRoot();
+    const vault = createLocalVault(adapter);
+    await vault.open();
+
+    await vault.importFile(
+      new Uint8Array([1, 2, 3]),
+      'images/1788164287239-photo.jpg',
+      {
+        name: 'Vacation Photo',
+        syncState: 'synced',
+        remotePath: 'images/1788164287239-photo.jpg',
+        bindingId: 'binding-1',
+        updatedAt: '2026-08-20T10:00:00.000Z',
+      },
+    );
+
+    const fetchFn = vi.fn();
+    const result = await applySyncPull(
+      vault,
+      'binding-1',
+      {
+        items: [
+          {
+            remotePath: 'images/1788164287239-photo.jpg',
+            action: 'update',
+            metadata: {
+              name: '1788164287239-photo.jpg',
+              updatedAt: '2026-08-20T02:00:00.000Z',
+            },
+          },
+        ],
+      },
+      createMockProvider(),
+      { fetchFn },
+    );
+
+    expect(result.pulled).toBe(0);
+    expect(fetchFn).not.toHaveBeenCalled();
+    const entry = await vault.getByPath('images/1788164287239-photo.jpg');
+    expect(entry?.name).toBe('Vacation Photo');
+  });
+
+  it('pull merges remote display name without re-downloading file bytes', async () => {
+    const adapter = new MemoryWorkspaceAdapter('desktop');
+    await adapter.pickRoot();
+    const vault = createLocalVault(adapter);
+    await vault.open();
+
+    await vault.importFile(
+      new Uint8Array([1, 2, 3]),
+      'images/1788164287239-photo.jpg',
+      {
+        name: '1788164287239-photo.jpg',
+        syncState: 'synced',
+        remotePath: 'images/1788164287239-photo.jpg',
+        bindingId: 'binding-1',
+        updatedAt: '2026-08-20T10:00:00.000Z',
+      },
+    );
+
+    const fetchFn = vi.fn();
+    const result = await applySyncPull(
+      vault,
+      'binding-1',
+      {
+        items: [
+          {
+            remotePath: 'images/1788164287239-photo.jpg',
+            action: 'update',
+            metadata: {
+              name: 'Vacation Photo',
+              updatedAt: '2026-08-20T08:00:00.000Z',
+            },
+          },
+        ],
+      },
+      createMockProvider(),
+      { fetchFn },
+    );
+
+    expect(result.pulled).toBe(1);
+    expect(fetchFn).not.toHaveBeenCalled();
+    const entry = await vault.getByPath('images/1788164287239-photo.jpg');
+    expect(entry?.name).toBe('Vacation Photo');
   });
 });

--- a/packages/core/src/vault/localVault.ts
+++ b/packages/core/src/vault/localVault.ts
@@ -189,12 +189,25 @@ export function createLocalVault(adapter: WorkspaceAdapter): LocalVault {
       );
     },
 
-    async updateMetadata(relativePath, patch) {
+    async updateMetadata(relativePath, patch, options) {
       const entry = index.find(item => item.relativePath === relativePath);
       if (!entry || entry.deletedAt) {
         throw new Error(`Image not found: ${relativePath}`);
       }
+      const metadataChanged =
+        (patch.name !== undefined && patch.name !== entry.name) ||
+        (patch.description !== undefined &&
+          patch.description !== entry.description) ||
+        (patch.tags !== undefined &&
+          JSON.stringify(patch.tags) !== JSON.stringify(entry.tags));
       Object.assign(entry, patch, { updatedAt: nowIso() });
+      if (
+        metadataChanged &&
+        entry.syncState === 'synced' &&
+        !options?.skipPendingPush
+      ) {
+        entry.syncState = 'pending-push';
+      }
       await persistIndex();
       return { ...entry };
     },

--- a/packages/core/src/vault/syncApply.ts
+++ b/packages/core/src/vault/syncApply.ts
@@ -84,10 +84,52 @@ async function findExistingForPullItem(
   );
 }
 
+/** 远端 manifest 未单独存展示名时，listImages 会回退为 basename（含 timestamp 前缀） */
+export function resolvePullDisplayName(
+  meta: Partial<ImageItem>,
+  existing: LocalImageIndexEntry | null | undefined,
+  remotePath: string,
+): string {
+  const remoteBase = basename(remotePath);
+  if (meta.name && meta.name !== remoteBase) {
+    return meta.name;
+  }
+  if (existing?.name && existing.name !== remoteBase) {
+    return existing.name;
+  }
+  return meta.name ?? existing?.name ?? remoteBase;
+}
+
+function metadataPatchFromPull(
+  existing: LocalImageIndexEntry,
+  meta: Partial<ImageItem>,
+  remotePath: string,
+): Partial<LocalImageIndexEntry> | null {
+  const patch: Partial<LocalImageIndexEntry> = {};
+  const name = resolvePullDisplayName(meta, existing, remotePath);
+  if (name !== existing.name) {
+    patch.name = name;
+  }
+  if (
+    meta.description !== undefined &&
+    meta.description !== existing.description
+  ) {
+    patch.description = meta.description;
+  }
+  if (
+    meta.tags !== undefined &&
+    JSON.stringify(meta.tags) !== JSON.stringify(existing.tags)
+  ) {
+    patch.tags = meta.tags;
+  }
+  return Object.keys(patch).length > 0 ? patch : null;
+}
+
 function isRemoteUpToDate(
   existing: LocalImageIndexEntry,
   remotePath: string,
   remoteUpdatedAt: string,
+  meta: Partial<ImageItem>,
 ): boolean {
   if (existing.syncState !== 'synced') {
     return false;
@@ -95,6 +137,22 @@ function isRemoteUpToDate(
   if (
     existing.remotePath !== remotePath &&
     existing.relativePath !== resolveLocalPathForPull(remotePath)
+  ) {
+    return false;
+  }
+  const resolvedName = resolvePullDisplayName(meta, existing, remotePath);
+  if (resolvedName !== existing.name) {
+    return false;
+  }
+  if (
+    meta.description !== undefined &&
+    meta.description !== existing.description
+  ) {
+    return false;
+  }
+  if (
+    meta.tags !== undefined &&
+    JSON.stringify(meta.tags) !== JSON.stringify(existing.tags)
   ) {
     return false;
   }
@@ -135,11 +193,29 @@ export async function applySyncPull(
       continue;
     }
 
+    const meta = pickImageMetadata(item.metadata);
+
     if (
       existing &&
       !existing.deletedAt &&
-      isRemoteUpToDate(existing, item.remotePath, remoteUpdatedAt)
+      isRemoteUpToDate(existing, item.remotePath, remoteUpdatedAt, meta)
     ) {
+      continue;
+    }
+
+    if (
+      existing &&
+      !existing.deletedAt &&
+      existing.syncState === 'synced' &&
+      existing.updatedAt >= remoteUpdatedAt
+    ) {
+      const patch = metadataPatchFromPull(existing, meta, item.remotePath);
+      if (patch) {
+        await vault.updateMetadata(existing.relativePath, patch, {
+          skipPendingPush: true,
+        });
+        pulled += 1;
+      }
       continue;
     }
 
@@ -150,14 +226,13 @@ export async function applySyncPull(
       fetchFn,
     );
 
-    const meta = pickImageMetadata(item.metadata);
     const previousPath = existing?.relativePath;
 
     await vault.adapter.writeFile(canonicalPath, bytes);
     await vault.importFile(canonicalPath, canonicalPath, {
       ...meta,
       id: existing?.id,
-      name: meta.name ?? basename(item.remotePath),
+      name: resolvePullDisplayName(meta, existing, item.remotePath),
       mimeType: meta.type,
       syncState: 'synced',
       remotePath: item.remotePath,

--- a/packages/core/src/vault/types.ts
+++ b/packages/core/src/vault/types.ts
@@ -83,6 +83,7 @@ export interface LocalVault {
   updateMetadata(
     relativePath: string,
     patch: Partial<Pick<LocalImageIndexEntry, 'name' | 'tags' | 'description'>>,
+    options?: { skipPendingPush?: boolean },
   ): Promise<LocalImageIndexEntry>;
   softDelete(relativePath: string): Promise<void>;
   /** 从索引移除并删除磁盘文件（同步路径归并等内部用途） */


### PR DESCRIPTION
## Summary

- 修复同步 round-trip 后展示名被 timestamp 文件名（如 `1788164287239-photo.jpg`）覆盖的问题
- 新增 `resolvePullDisplayName`：远端 manifest 无独立展示名时保留本地已编辑的 `name`
- pull 时若文件内容已是最新，仅合并元数据（展示名/标签/描述），无需重新下载
- 用户本地编辑元数据时标记 `pending-push`，确保展示名写入远端 manifest

## Test plan

- [x] `pnpm test packages/core/src/vault/__tests__/`
- [ ] 本地编辑图片展示名 → push → pull，界面仍显示用户设置的名称
- [ ] 另一设备 pull 后展示名与远端 manifest 一致


Made with [Cursor](https://cursor.com)